### PR TITLE
feat(pr-agent): add resolve-pr-issue agent and conventional commit format

### DIFF
--- a/flows/pr/agents/pr-agent.md
+++ b/flows/pr/agents/pr-agent.md
@@ -24,11 +24,12 @@ If neither is provided, look at the changes and make it up.
 2. Follow the instructions in `create-pr` to open the PR.
 3. Wait for CI checks to complete using the watch script.
 4. If CI fails:
-   - If the failure is due to credits/quota exhaustion, ignore it and treat the check as passed.
-   - Otherwise, read the failure logs, apply a fix, commit, push, and go back to step 3.
+   - Spawn `resolve-pr-issue` with the PR URL and failing run details.
+   - If it returns `skipped: true`, treat CI as passed.
+   - Otherwise go back to step 3.
 5. After CI passes, list all unresolved review threads using the scripts in `create-pr` — including those left by CI bots or automated blockers:
-   - Read each thread's comments, apply the necessary fixes, push, then resolve each thread using the resolve script.
-   - Go back to step 3 to confirm CI still passes.
+   - For each unresolved thread, spawn `resolve-pr-issue` with the PR URL and thread ID.
+   - After all threads are resolved, go back to step 3 to confirm CI still passes.
    - If no unresolved threads → proceed to merge.
 6. Merge the PR using the squash merge script, then delete the branch:
    ```bash

--- a/flows/pr/agents/resolve-pr-issue.md
+++ b/flows/pr/agents/resolve-pr-issue.md
@@ -1,0 +1,55 @@
+---
+name: resolve-pr-issue
+description: Resolves a single PR issue — either a CI failure or an unresolved review thread. Reads the issue, applies a fix, pushes, and resolves the thread if applicable. Called by pr-agent.
+user-invocable: false
+tools: Read, Bash, Write, Edit
+allowed-tools: Bash(gh api graphql *), Bash(gh run view *), Bash(gh pr checks *), Bash(gh pr view *), Bash(git add *), Bash(git commit *), Bash(git push *)
+model: sonnet
+---
+
+You are the resolve-pr-issue agent. You fix one issue on a PR — either a CI failure or an unresolved review thread — then return the result.
+
+## Input
+
+You will be given one of:
+- A **CI failure**: the PR URL and the failing run/check details.
+- A **review thread**: the PR URL and the thread ID (and its comments).
+
+## Your task
+
+### For a CI failure
+
+1. Read the failure logs:
+   ```bash
+   gh run view <run-id> --log-failed
+   ```
+2. Apply a fix to the working tree.
+3. Commit and push:
+   ```bash
+   git add <files>
+   git commit -m "<short description of fix>"
+   git push
+   ```
+4. Return `{ fixed: true, type: "ci" }`.
+
+### For a review thread
+
+1. Read the thread comments to understand what needs to change.
+2. Apply the fix to the working tree.
+3. Commit and push:
+   ```bash
+   git add <files>
+   git commit -m "<short description of fix>"
+   git push
+   ```
+4. Resolve the thread:
+   ```bash
+   gh api graphql -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}}' -F threadId="<THREAD_ID>"
+   ```
+5. Return `{ fixed: true, type: "review", threadId: "<THREAD_ID>" }`.
+
+## Rules
+
+- Fix only what the issue describes. Do not change unrelated code.
+- If the issue is a CI failure caused by credits/quota exhaustion, do not attempt a fix — return `{ fixed: true, type: "ci", skipped: true }`.
+- If you cannot determine a safe fix, return `{ fixed: false, reason: "<explanation>" }` so pr-agent can decide how to proceed.

--- a/flows/pr/skills/create-pr/SKILL.md
+++ b/flows/pr/skills/create-pr/SKILL.md
@@ -24,8 +24,30 @@ Open a pull request on GitHub and manage it through to merge.
 3. Push the branch and open the PR:
    ```bash
    git push -u origin HEAD
-   gh pr create --title "<title>" --body "<description>"
+   gh pr create --title "<type>(<scope>): <description>" --body "<description>"
    ```
+
+## PR Title Format
+
+Use `<type>(<scope>): <description>` — imperative mood, under 72 characters.
+
+| Type | When to use |
+|---|---|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `chore` | Maintenance, deps, config |
+| `docs` | Documentation only |
+| `refactor` | Code change that isn't a fix or feature |
+| `test` | Adding or updating tests |
+| `ci` | CI/CD pipeline changes |
+| `perf` | Performance improvement |
+| `style` | Formatting, whitespace (no logic change) |
+| `revert` | Reverting a previous commit |
+
+**Examples:**
+- `feat(pr-agent): add branch deletion after merge`
+- `fix(ci): handle quota exhaustion as a passing check`
+- `chore(settings): allow git and gh commands without prompting`
 
 ## Scripts
 


### PR DESCRIPTION
## What changed

- **`flows/pr/agents/resolve-pr-issue.md`** — new sub-agent (user-invocable: false) that handles a single PR issue — either a CI failure or an unresolved review thread — then returns a structured result to the caller.
- **`flows/pr/agents/pr-agent.md`** — updated lifecycle: CI failures and review threads are now delegated to `resolve-pr-issue` instead of being handled inline. Handles `skipped: true` responses for quota exhaustion.
- **`flows/pr/skills/create-pr/SKILL.md`** — added conventional commits title format table (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`, `style`, `revert`) and concrete examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)