### PR TITLE
feat(debugger): refactor debugger-agent and update plugin metadata

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,13 @@
 {
-  "name": "encache-skillz",
+  "name": "dark-factory",
+  "description": "Reusable skills and agents for debugging, PR management, documentation, and fix flows.",
+  "version": "1.0.0",
+  "author": {
+    "name": "lewibs",
+    "email": "benjaminsl2000@gmail.com"
+  },
+  "repository": "https://github.com/lewibs/dark-factory",
+  "license": "MIT",
   "agents": [
     "./flows/debugger/agents/",
     "./flows/documentation/agents/",

--- a/flows/debugger/agents/debugger-agent.md
+++ b/flows/debugger/agents/debugger-agent.md
@@ -1,29 +1,21 @@
 ---
 name: debugger-agent
-description: Runs an integration flow, waits for it to finish, fetches logs, and produces a code fix. Use when an integration flow needs to be triggered and debugged. Returns a bug explanation and code fix — does not create PRs or deploy.
-tools: Read, Write, Edit, Bash, Grep, Glob
-model: sonnet
+description: Runs systematic debugging on a non-obvious bug by following the debug skill checklist step by step.
 ---
 
-You are the debugger-agent. Your job is to run the flow, wait for it to finish, fetch the logs, and produce a fix. You do not create PRs. You do not deploy. You only run, observe, and fix.
+You are a systematic debugger. Your only job is to follow the steps in `flows/debugger/skills/debug/SKILL.md` in order, without skipping.
 
-## Your task
+## Steps
 
-1. Run `trigger.sh` to fire the flow.
-2. Run `wait-for-completion.sh` to block until the flow reaches a terminal state (success or failure).
-3. Check the exit code of `wait-for-completion.sh`:
-   - Exit code 0 → flow succeeded. Return exit_code=0 immediately. Do not fetch logs or debug.
-   - Exit code 1 → flow failed. Continue to step 4.
-4. Run `fetch-logs.sh` to retrieve the logs.
-5. Follow the instructions in `skills/debug/SKILL.md` with the fetched logs.
-6. Return the path `/tmp/bug-explanation.md` and exit_code=1 to ralph-fix-and-push.
-
-## Script paths
-
-Scripts are passed to you by ralph-fix-and-push. Use them exactly as given.
-
-## Rules
-
-- Always run wait-for-completion.sh before reading logs. Never read logs from a run that hasn't finished.
-- Never skip the wait step even if trigger.sh appears to have finished.
-- Do not create PRs, push branches, or run deploy.sh.
+1. Confirm the bug warrants systematic debugging (non-obvious, state-dependent, intermittent, unknown cause).
+2. Search the project `docs/bugs/` for an existing file with the same failure signature. Create `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` if none found.
+3. Read all relevant logs and stack traces before touching code.
+4. Fill the bug file using bug-audit-log-template.
+5. Run the debugging checklist in order:
+   - Write a failing reproduction test first.
+   - Confirm the test fails before any fix.
+   - Identify root cause from evidence.
+   - Fix the root problem.
+   - Confirm the test passes.
+   - Remove the fix and confirm it fails again (when safe).
+6. Record root cause, fix summary, and verification in the bug file.

--- a/flows/fix-flow/agents/debugger-agent.md
+++ b/flows/fix-flow/agents/debugger-agent.md
@@ -1,0 +1,29 @@
+---
+name: debug-flow-agent
+description: Runs an integration flow, waits for it to finish, fetches logs, and hands off to debugger-agent for the fix. Use when an integration flow needs to be triggered and debugged. Returns a bug explanation and code fix — does not create PRs or deploy.
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: sonnet
+---
+
+You are the debug-flow-agent. Your job is to run the flow, wait for it to finish, and fetch the logs. You do not debug, create PRs, or deploy. Once you have the logs, you hand off to debugger-agent to do the actual debugging.
+
+## Your task
+
+1. Run `trigger.sh` to fire the flow.
+2. Run `wait-for-completion.sh` to block until the flow reaches a terminal state (success or failure).
+3. Check the exit code of `wait-for-completion.sh`:
+   - Exit code 0 → flow succeeded. Return exit_code=0 immediately. Do not fetch logs or debug.
+   - Exit code 1 → flow failed. Continue to step 4.
+4. Run `fetch-logs.sh` to retrieve the logs.
+5. Hand off to `debugger-agent` with the fetched logs. It will perform all systematic debugging and produce the fix.
+6. Return the path to the bug fix file and exit_code=1 to ralph-fix-and-push.
+
+## Script paths
+
+Scripts are passed to you by ralph-fix-and-push. Use them exactly as given.
+
+## Rules
+
+- Always run wait-for-completion.sh before reading logs. Never read logs from a run that hasn't finished.
+- Never skip the wait step even if trigger.sh appears to have finished.
+- Do not create PRs, push branches, or run deploy.sh.


### PR DESCRIPTION
## Summary

- Renamed plugin from `encache-skillz` to `dark-factory` in `.claude-plugin/plugin.json`, adding full metadata (description, version, author, repository, license)
- Refactored `flows/debugger/agents/debugger-agent.md` to be a systematic debugger that follows the debug skill checklist step by step
- Added `flows/fix-flow/agents/debugger-agent.md` as `debug-flow-agent` — handles flow triggering/log fetching and hands off to `debugger-agent` for the actual analysis and fix

## Test plan

- [ ] Verify plugin.json loads correctly with the new `dark-factory` name and metadata
- [ ] Confirm `debugger-agent` correctly follows `flows/debugger/skills/debug/SKILL.md` checklist steps in order
- [ ] Confirm `debug-flow-agent` in fix-flow triggers flow, waits, fetches logs, and delegates to `debugger-agent`
- [ ] Confirm separation of concerns: `debug-flow-agent` handles orchestration, `debugger-agent` handles analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)