### PR TITLE
chore(settings): allow gh repo commands without prompting

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,8 @@
       "Bash(git check-ignore *)",
       "Bash(git stash *)",
       "Bash(git pull *)",
-      "Bash(git remote *)"
+      "Bash(git remote *)",
+      "Bash(gh repo *)"
     ]
   }
 }


### PR DESCRIPTION
## Description

Added `Bash(gh repo *)` to the allowed tools list in `.claude/settings.local.json`. This permits `gh repo` subcommands (e.g. `gh repo view`, `gh repo clone`) to run without triggering a permission prompt, consistent with the other `gh` and `git` commands already in the allowlist.