### PR TITLE
feat(planning): add planning-agent with staged architecture design workflow

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,8 +17,7 @@
       "Bash(git check-ignore *)",
       "Bash(git stash *)",
       "Bash(git pull *)",
-      "Bash(git remote *)",
-      "Bash(gh repo *)"
+      "Bash(git remote *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,8 @@
       "Bash(git check-ignore *)",
       "Bash(git stash *)",
       "Bash(git pull *)",
-      "Bash(git remote *)"
+      "Bash(git remote *)",
+      "Bash(gh repo *)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Skills Factory
 
+TODO update this to have all the top level agents and skills for the orchestrators 
+
 You are the orchestrator of this skills factory. Your job is to route work to the correct agent or skill. Always prefer an agent or skill over doing the work yourself.
 
 ## Agents
@@ -10,6 +12,7 @@ You are the orchestrator of this skills factory. Your job is to route work to th
 | `debugger-agent` | Triggers an integration flow, waits for it, fetches logs, and produces a code fix. Does not open PRs. |
 | `documentation-agent` | Explores a codebase and writes a structured system document to `/tmp/
 | `pr-agent` | Opens a PR, watches CI, resolves review threads, squash-merges, deletes the branch, and returns to main. Use after a fix is applied. |
+| `planning-agent` | Works with the user at a high level to design architecture before implementation. Produces a staged plan (Mermaid → I/O contracts → acceptance criteria → pseudocode) in `docs/plans/`. Can invoke `documentation-agent` to research existing systems. |
 
 ## Skills
 

--- a/agents/planning/agents/planning-agent.md
+++ b/agents/planning/agents/planning-agent.md
@@ -1,0 +1,46 @@
+---
+name: planning-agent
+user-invocable: false
+description: High-level planning agent. Works with the user to design architecture for a new feature or system before any code is written. Produces a plan in docs/plans/ using staged gates: Mermaid diagram, black-box I/O contracts, acceptance criteria, and optional pseudocode.
+tools: Read, Grep, Glob, Bash, Write, Edit, Agent
+model: sonnet
+---
+
+You are the planning-agent. Your job is to work with the user at a high level to produce an architecture plan before implementation begins. You do not write code, fix bugs, or open PRs. You only plan.
+
+Focus only on the system being built and the parts it directly touches. If something is loosely related or owned by another team/service, note the boundary and move on — do not deep-dive into it.
+
+## docs/ directory structure
+
+| Path | Purpose |
+|---|---|
+| `docs/plans/` | Plans for current and upcoming work — output goes here |
+| `docs/docs/` | Authoritative system documentation — use as reference, do not modify |
+
+## Your task
+
+1. Understand what the user wants to build. Ask clarifying questions until the scope is clear enough to diagram.
+2. If the system touches existing code you don't understand, invoke the `documentation-agent` to research it. Use its output as context — do not re-explore what it already documented.
+3. Create a new plan file in `docs/plans/<feature-name>.md` using `templates/plan-template.md` as the scaffold.
+4. Walk the user through each stage in order. Do not advance to the next stage without explicit user approval.
+
+## Stages
+
+| Stage | What to produce | Gate |
+|---|---|---|
+| 1 | Mermaid diagram — nodes, boundaries, labeled data flows | User approval required |
+| 2 | Black-box I/O contracts — input/output types, validation rules, success/failure paths | User approval required |
+| 3 | Acceptance criteria — test flows with inputs and pass/fail rules | User approval required |
+| 4 | Pseudocode for critical flows (optional) | User approval required if included; mark skipped with reason if not |
+
+## Scope rule
+
+Only model what this system owns. When a boundary points to an external system or loosely related service, reference it by name and note it as out-of-scope — do not diagram its internals.
+
+## Using the documentation-agent
+
+Invoke the `documentation-agent` when you need to understand an existing system that the planned feature will interact with. Pass it the system or topic name. Use the docs it returns as your source of truth for that system's contracts.
+
+## Output
+
+A completed `docs/plans/<feature-name>.md` with all approved stages filled in and the stage gate tracker updated. Set status to `approved` after all stages pass.

--- a/agents/planning/templates/plan-template.md
+++ b/agents/planning/templates/plan-template.md
@@ -1,0 +1,167 @@
+# Plan Title
+
+## Plan Metadata
+
+- Plan type: `plan` | `sub-plan`
+- Parent plan: `required for sub-plan; otherwise N/A`
+- Depends on:  `N/A`
+  - `plan-link`
+  - `plan-link`
+- Status: `draft` | `approved` | `documentation`
+
+Status semantics:
+- `draft`: Plan is being created or updated and is not final.
+- `approved`: Plan is approved but not yet applied in code.
+- `documentation`: Code currently exists and matches the plan contract.
+
+
+Update rule:
+- When an existing plan is edited, set status to `draft` until re-approved.
+
+## System Intent
+
+- What is being built:
+- Primary consumer(s):
+- Boundary (black-box scope only):
+
+## Stage Gate Tracker
+
+- [ ] Stage 1 Mermaid approved
+- [ ] Stage 2 I/O contracts approved
+- [ ] Stage 3 pseudocode/technical details approved or skipped
+
+## 1. Mermaid Diagram
+
+Reference: `.agent/skills/create-mermaid-diagram/SKILL.md`
+
+```mermaid
+flowchart TD
+  In[Input Contract] -->|Typed payload| Box[System Boundary]
+  Box -->|Typed response/event| Out[Output Contract]
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## 2. Black-Box Inputs and Outputs
+
+Keep this short. Define types in JSON-style blocks and capture each flow with path-level rows.
+- Flow naming rule: each flow uses this format:
+  - ``### Flow: `<flowname>` ``
+  - ``- Test files: <path/to/test_file.ext>, ...`` (or `N/A` when no automated test is required)
+  - ``- Core files: <path/to/core_file.ext>, ...``
+- `N/A` means explicit no-test-required waiver for that flow (not a missing mapping).
+
+### Global Types
+
+Define shared types used across multiple flows.
+
+```txt
+Identifier {
+  value: string (stable unique identifier)
+}
+
+RequestMetadata {
+  trace_id: string (request trace identifier)
+  requested_at: timestamp (request timestamp)
+}
+
+StandardError {
+  status: number (HTTP status)
+  code: string (stable machine-readable code)
+  message: string (human-readable summary)
+}
+```
+
+### Flow: `createResource`
+- Test files: `tests/test_create_resource.py`
+- Core files: `src/resource_service.py`
+
+#### Type Definitions
+
+```txt
+CreateResourceInput {
+  id: Identifier (required)
+  metadata: RequestMetadata (required)
+}
+
+CreateResourceOutput {
+  result_id: Identifier (identifier for created/updated result)
+  status: string (domain-specific success status)
+}
+```
+
+#### Paths
+
+| path-name | input | output/expected state change | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `createResource.success` | `CreateResourceInput` | `CreateResourceOutput; primary resource is created/updated` | `happy path` | `use real business rule notes here` | `Y` |
+| `createResource.validation-failure` | `CreateResourceInput` | `StandardError status=400 code=invalid-input` | `error` | `no state change on validation failure` | |
+
+### Flow: `transitionResource`
+- Test files: `tests/test_transition_resource.py`
+- Core files: `src/resource_state.py`
+
+#### Type Definitions
+
+```txt
+TransitionResourceInput {
+  source_id: Identifier (required)
+  metadata: RequestMetadata (required)
+}
+
+TransitionResourceOutput {
+  state: string (resulting state label)
+  updated_at: timestamp (state transition timestamp)
+}
+```
+
+#### Paths
+
+| path-name | input | output/expected state change | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `transitionResource.success` | `TransitionResourceInput` | `TransitionResourceOutput; resource transitions to expected state` | `happy path` | `document downstream effects if any` | `Y` |
+| `transitionResource.not-allowed` | `TransitionResourceInput` | `StandardError status=409 code=state-conflict` | `error` | `state transition is rejected` | |
+
+### Flow: `linkChildToParent`
+- Test files: `tests/test_link_child_to_parent.py`
+- Core files: `src/resource_links.py`
+
+#### Type Definitions
+
+```txt
+LinkChildToParentInput {
+  parent_id: Identifier (required)
+  child_id: Identifier (required)
+}
+
+LinkChildToParentOutput {
+  linked: boolean (whether relationship exists after operation)
+}
+```
+
+#### Paths
+
+| path-name | input | output/expected state change | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `linkChildToParent.success` | `LinkChildToParentInput` | `LinkChildToParentOutput linked=true; relationship is stored` | `happy path` | `idempotent behavior can be documented here` | `Y` |
+| `linkChildToParent.already-linked` | `LinkChildToParentInput` | `LinkChildToParentOutput linked=true; no additional state change` | `subpath` | `example idempotent subpath` | |
+| `linkChildToParent.missing-parent` | `LinkChildToParentInput` | `StandardError status=404 code=not-found` | `error` | `parent resource must exist` | |
+
+## 3. Pseudocode / Technical Details for Critical Flows (Optional)
+
+Use this section for implementation-oriented details that are too low-level for System Intent, including:
+- Deployment/build prerequisites (required inputs, generated artifacts, external setup steps).
+- Required secrets/config injection steps and ownership/sign-off checkpoints.
+- Critical execution strategy details needed for successful implementation.
+
+- Flow name::
+```
+pseudocode goes in here
+```
+- Implementation notes:
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## 4. Handoff to Related Plan Reconciliation
+
+After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans.


### PR DESCRIPTION
## Description

Adds a new `planning-agent` to the skills factory. The agent works interactively with users to design architecture before any implementation begins. It uses staged gates to guide the process:

1. **Mermaid diagram** — nodes, boundaries, labeled data flows (user approval required)
2. **Black-box I/O contracts** — input/output types, validation rules, success/failure paths (user approval required)
3. **Acceptance criteria** — test flows with inputs and pass/fail rules (user approval required)
4. **Pseudocode** for critical flows (optional, user approval required if included)

The agent can invoke `documentation-agent` to research existing systems before planning. Plans are written to `docs/plans/<feature-name>.md` using the included `plan-template.md` scaffold.

Changes:
- `agents/planning/agents/planning-agent.md` — new agent definition
- `agents/planning/templates/plan-template.md` — plan scaffold template
- `CLAUDE.md` — registered `planning-agent` in the agents table