### PR TITLE
feat(documentation): add detect-drift and update-documentation agents, generalize detect-drift skill

### DIFF
--- a/agents/documentation/agents/detect-drift-agent.md
+++ b/agents/documentation/agents/detect-drift-agent.md
@@ -1,0 +1,35 @@
+---
+name: detect-drift-agent
+user-invocable: false
+description: Audits parity between docs/docs/ system documentation and actual code. Detects stale references, undocumented flows, and broken claims. Fixes straightforward drift in place and reports findings.
+tools: Read, Grep, Glob, Bash, Write, Edit
+model: sonnet
+---
+
+# detect-drift-agent
+
+Audits `docs/docs/` against the actual codebase and fixes drift.
+
+## Required argument
+
+None required. Runs against all files in `docs/docs/` by default. Optionally accept a specific doc file path to scope the audit.
+
+```
+/detect-drift-agent [doc-file-path]
+```
+
+## Your task
+
+1. Run the detect-drift skill at `agents/documentation/skills/detect-drift/SKILL.md`.
+   - Target: `docs/docs/` (system documentation, not plans)
+   - If a specific doc file was provided as an argument, scope the audit to that file only.
+
+2. After the skill produces its findings report:
+   - Fix any `extra` or `different` items that are straightforward (broken file paths, stale references, renamed files).
+   - For `missing` items (implemented behavior not documented), add a brief section to the relevant doc or create a new doc in `docs/docs/`.
+   - For `wrong` items, note them in the report and ask the developer how to proceed.
+
+3. Return:
+   - A summary of findings (counts per severity bucket).
+   - Paths to every doc file updated or created.
+   - Any unresolved items that need developer input.

--- a/agents/documentation/agents/investigation-agent.md
+++ b/agents/documentation/agents/investigation-agent.md
@@ -1,12 +1,12 @@
 ---
-name: documentation-agent
+name: investigation-agent
 user-invocable: false
 description: General-purpose investigation agent. Given a system or topic, explores the codebase, validates or creates authoritative docs, and returns the paths to what was written.
 tools: Read, Grep, Glob, Bash, Write, Edit
 model: sonnet
 ---
 
-You are the documentation-agent. Your job is to investigate a system and produce accurate documentation. You do not fix code, run flows, or open PRs. You only read, document, and return file paths.
+You are the investigation-agent. Your job is to investigate a system and produce accurate documentation. You do not fix code, run flows, or open PRs. You only read, document, and return file paths.
 
 ## docs/ directory structure
 

--- a/agents/documentation/agents/update-documentation-agent.md
+++ b/agents/documentation/agents/update-documentation-agent.md
@@ -1,0 +1,80 @@
+---
+name: update-documentation-agent
+user-invocable: false
+description: Updates docs/ based on an implemented plan. Given a plan path, identifies affected flows and docs, then deletes stale content, updates modified sections, and adds new information.
+tools: Read, Grep, Glob, Bash, Write, Edit
+model: sonnet
+---
+
+# update-documentation-agent
+
+Updates project documentation after a plan has been implemented. Runs three phases in strict sequence.
+
+## Required argument
+
+The plan path is required. If not provided, stop and ask the developer before doing anything else.
+
+```
+/update-documentation-agent <plan-path>
+```
+
+## docs/ directory structure
+
+| Path | Purpose |
+|---|---|
+| `docs/plans/` | Working plans — source of truth for what was implemented |
+| `docs/bugs/` | Audit logs of previously fixed bugs |
+| `docs/docs/` | Authoritative system documentation — what you update |
+
+## Phase 1 — Identify Flows
+
+Read the plan at `<plan-path>`. Extract every flow, service, or component that was created or modified.
+
+Build a checklist of flows in `tmp/update-docs-flows.md`:
+
+```markdown
+# Flows Checklist
+
+- [ ] <flow-or-component-name> — created/modified
+- [ ] ...
+```
+
+Do not proceed to Phase 2 until this file exists.
+
+## Phase 2 — Identify Affected Docs
+
+Search `docs/docs/` for documents that reference any of the flows from Phase 1. Use Grep and Glob to scan file contents.
+
+Append an affected-docs checklist to `tmp/update-docs-flows.md`:
+
+```markdown
+# Affected Docs Checklist
+
+- [ ] docs/docs/<file>.md — touches <flow-name>
+- [ ] ...
+```
+
+If a flow has no existing doc, note it as `NEW — no existing doc`:
+
+```markdown
+- [ ] NEW — <flow-name> has no existing doc
+```
+
+Do not proceed to Phase 3 until every flow has been assessed.
+
+## Phase 3 — Update Docs
+
+Process each item from the Phase 2 checklist:
+
+**For existing docs:** Edit the file to reflect the plan's changes:
+- Delete sections about removed behavior
+- Update sections about modified behavior
+- Add new sections for new behavior
+
+**For new flows with no existing doc:** If the plan contains enough detail to document the flow, create `docs/docs/<flow-name>.md` using the documentation skill at `skills/documentation/SKILL.md`. If the plan is unrelated to any existing system, copy the plan content into `docs/docs/<plan-name>.md` as a new standalone document.
+
+Mark each checklist item in `tmp/update-docs-flows.md` as done (`[x]`) after completing it.
+
+## Completion
+
+Return the paths to every file written or updated.

--- a/agents/documentation/skills/detect-drift/SKILL.md
+++ b/agents/documentation/skills/detect-drift/SKILL.md
@@ -1,79 +1,75 @@
 ---
 name: detect-drift
-description: Audit parity between documentation/plans and actual implementation. Works for both docs/docs/ system documents and docs/plans/ plan files. Use when validating ship readiness, checking whether documented flows/files/tests match implemented code, or verifying that major implemented flows are not missing from docs or plans.
+description: Audit parity between docs/docs/ system documentation and actual implementation. Detects stale references, undocumented flows, and broken behavioral claims. Use when validating whether documented systems match implemented code.
 ---
 
 ## Required
 
-Use this skill whenever drift may exist between documentation (plans or docs) and code.
+Use this skill whenever drift may exist between `docs/docs/` system documentation and code.
 
 1. Determine audit target:
-   - **Plans audit**: targets `docs/plans/*.md` — checks plan flow/file/test references against code.
    - **Docs audit**: targets `docs/docs/*.md` — checks documented system behavior against code.
-   - Both can be run together.
+   - A specific doc file can be targeted instead of the full directory.
 
 2. Build inventory and baseline checklist artifacts.
-   - For plans: read `docs/index.md` (fallback to `docs/plans/index.md` for legacy repos). Enumerate all plan docs in `docs/plans/*.md`. Flag catalog drift (listed-but-missing, unlisted-but-present).
-   - For docs: enumerate all files in `docs/docs/*.md`. Check that each documented system still exists in the codebase.
+   - Enumerate all files in `docs/docs/*.md`. Check that each documented system still exists in the codebase.
    - Generate checklists:
      - `python agents/documentation/skills/detect-drift/scripts/generate_checklists.py`
    - Review:
-     - `docs/plans/checklists/DRIFT-SUMMARY.md`
-     - `docs/plans/checklists/plans/*.md`
-     - `docs/plans/checklists/ui-surfaces/*.md`
-   - Temporary artifact rule: files under `docs/plans/checklists/` are process-only. Delete them after reporting findings.
+     - `tmp/drift-checklists/DRIFT-SUMMARY.md`
+     - `tmp/drift-checklists/docs/*.md`
+   - Temporary artifact rule: files under `tmp/drift-checklists/` are process-only. Delete them after reporting findings.
 
-3. Validate references (docs/plans -> code).
-   - For each plan or doc, inspect:
+3. Validate references (docs -> code).
+   - For each doc, inspect:
      - `### Flow: <file.function>, <test-path|N/A>` headings
      - `Core files` lists
      - Mermaid node file references
    - Confirm referenced files exist.
    - Flag broken paths and stale renamed/deleted references.
 
-4. Validate test mapping for each flow (docs/plans -> tests).
+4. Validate test mapping for each flow (docs -> tests).
    - For every flow row/heading with a concrete test path, confirm the test file exists.
    - Confirm at least one test in that file is relevant to the documented flow.
-   - If a flow is `N/A`, treat as acceptable only when the doc/plan explicitly justifies it.
+   - If a flow is `N/A`, treat as acceptable only when the doc explicitly justifies it.
 
-5. Validate code-to-doc parity with a second agent (code -> docs/plans).
+5. Validate code-to-doc parity with a second agent (code -> docs).
    - Spawn a second agent dedicated to code-first discovery.
-   - Primary agent responsibility: doc/plan-first verification (steps 2-4).
+   - Primary agent responsibility: doc-first verification (steps 2-4).
    - Second agent responsibility:
      - scan changed and adjacent code paths,
-     - identify major implemented flows not represented in any plan or doc,
-     - report missing coverage and suggested owning doc/plan.
+     - identify major implemented flows not represented in any doc,
+     - report missing coverage and suggested owning doc.
    - Merge findings and de-duplicate before final report.
 
-6. Validate docs/plans do not over-claim implementation.
-   - If a plan claims `documentation` status, verify code/test evidence exists.
+6. Validate docs do not over-claim implementation.
    - If a doc claims a system behavior, verify the code matches.
    - Flag behavior documented as implemented when code is absent or materially different.
 
 7. Produce a structured findings report.
    - Severity levels: `Critical`, `Major`, `Minor`, `Nitpick`.
-   - Include exact `path:line` references in plans/docs/tests/code.
+   - Include exact `path:line` references in docs/tests/code.
    - Include matrix buckets:
-     - `extra`: doc/plan entries that have no valid code/test target (stale or deleted)
-     - `missing`: implemented flows/surfaces not represented in any doc or plan
-     - `different`: doc/plan and code both exist but contract or test mapping diverges
-     - `wrong`: ownership or boundary claims attached to the wrong doc/plan
+     - `extra`: doc entries that have no valid code/test target (stale or deleted)
+     - `missing`: implemented flows/surfaces not represented in any doc
+     - `different`: doc and code both exist but contract or test mapping diverges
+     - `wrong`: ownership or boundary claims attached to the wrong doc
 
 8. Resolve or document deferrals.
    - Fix straightforward drift immediately when requested.
-   - For deferred items, add explicit TODOs with owning doc/plan and file targets.
+   - For deferred items, add explicit TODOs with owning doc and file targets.
 
 9. Cleanup generated artifacts.
    - After providing the findings summary, delete generated checklist files:
-     - `rm -rf docs/plans/checklists`
+     - `rm -rf tmp/drift-checklists`
 
 ## Context
 
 This skill is a bidirectional contract audit:
 
-- Plans/Docs -> Code: ensure documented flows/files/tests are real.
-- Code -> Plans/Docs: ensure major implemented flows are documented.
-- Plans -> Checklist Artifacts: create actionable audit lists per plan and per UI surface.
+- Docs -> Code: ensure documented flows/files/tests are real.
+- Code -> Docs: ensure major implemented flows are documented.
+- Docs -> Checklist Artifacts: create actionable audit lists per doc.
 
 The goal is to prevent silent drift between source-of-truth documentation and actual implementation.
 
@@ -82,22 +78,20 @@ The goal is to prevent silent drift between source-of-truth documentation and ac
 - Generator: `agents/documentation/skills/detect-drift/scripts/generate_checklists.py`
 - Templates:
   - `agents/documentation/skills/detect-drift/templates/plan-checklist-template.md`
-  - `agents/documentation/skills/detect-drift/templates/ui-surface-checklist-template.md`
 - Output (temporary):
-  - `docs/plans/checklists/DRIFT-SUMMARY.md`
-  - `docs/plans/checklists/plans/*.md`
-  - `docs/plans/checklists/ui-surfaces/*.md`
+  - `tmp/drift-checklists/DRIFT-SUMMARY.md`
+  - `tmp/drift-checklists/docs/*.md`
 
 ## Troubleshooting
 
-- Doc/plan references deleted files:
+- Doc references deleted files:
   1. Update paths to new locations or mark as intentionally deleted migration history.
   2. Remove temporary refactor tables when migration is complete.
 - Tests exist but do not exercise documented flow:
-  1. Add/adjust tests or narrow doc/plan claims.
+  1. Add/adjust tests or narrow doc claims.
   2. Do not keep broad claims without executable coverage.
 - Code has major undocumented behavior:
-  1. Add flow rows/types to the owning plan or doc.
+  1. Add flow rows/types to the owning doc.
   2. If ownership is unclear, define ownership first, then document.
 - Second agent cannot be used:
   1. Continue with local code-first pass.

--- a/agents/documentation/skills/detect-drift/scripts/generate_checklists.py
+++ b/agents/documentation/skills/detect-drift/scripts/generate_checklists.py
@@ -51,13 +51,23 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--plans-dir",
-        default="docs/plans",
-        help="Relative path to plan docs directory.",
+        default="docs/docs",
+        help="Relative path to docs directory (default: docs/docs).",
     )
     parser.add_argument(
         "--output-dir",
-        default="docs/plans/checklists",
-        help="Relative path where checklist artifacts are written.",
+        default="tmp/drift-checklists",
+        help="Relative path where checklist artifacts are written (default: tmp/drift-checklists).",
+    )
+    parser.add_argument(
+        "--ui-surfaces-dir",
+        default=None,
+        help="Relative path to UI entry surfaces directory to audit (optional).",
+    )
+    parser.add_argument(
+        "--api-surfaces-dir",
+        default=None,
+        help="Relative path to server API directory to audit (optional).",
     )
     return parser.parse_args()
 
@@ -67,6 +77,8 @@ def find_repo_root_from(start: Path) -> Path | None:
         if (candidate / CANONICAL_CATALOG_PATH).is_file():
             return candidate
         if (candidate / LEGACY_CATALOG_PATH).is_file():
+            return candidate
+        if (candidate / "docs" / "docs").is_dir():
             return candidate
     return None
 
@@ -130,16 +142,14 @@ def parse_catalog(catalog_path: Path, plans_dir: Path) -> set[str]:
     return catalog_entries
 
 
-def resolve_catalog_path(repo_root: Path) -> Path:
+def resolve_catalog_path(repo_root: Path) -> Path | None:
     canonical = (repo_root / CANONICAL_CATALOG_PATH).resolve()
     if canonical.is_file():
         return canonical
     legacy = (repo_root / LEGACY_CATALOG_PATH).resolve()
     if legacy.is_file():
         return legacy
-    raise FileNotFoundError(
-        "Missing plan catalog file. Expected docs/index.md (preferred) or docs/plans/index.md (legacy)."
-    )
+    return None
 
 
 def infer_file_from_target(repo_root: Path, target: str) -> tuple[str | None, str | None]:
@@ -265,25 +275,29 @@ def parse_plan_file(  # skipcq: PY-R1000
     )
 
 
-def collect_ui_surfaces(repo_root: Path) -> list[str]:
+def collect_ui_surfaces(repo_root: Path, ui_surfaces_dir: str | None) -> list[str]:
+    if not ui_surfaces_dir:
+        return []
+    surfaces_root = repo_root / ui_surfaces_dir
+    if not surfaces_root.exists():
+        return []
     ui_surfaces: set[str] = set()
-    app_root = repo_root / "main/app/app"
-    if app_root.exists():
-        for file_path in app_root.rglob("*.tsx"):
-            if "__tests__" in file_path.parts:
-                continue
-            ui_surfaces.add(str(file_path.relative_to(repo_root)))
-    side_menu = repo_root / "main/app/components/side-menu.tsx"
-    if side_menu.is_file():
-        ui_surfaces.add(str(side_menu.relative_to(repo_root)))
+    for file_path in surfaces_root.rglob("*"):
+        if not file_path.is_file():
+            continue
+        if "__tests__" in file_path.parts:
+            continue
+        ui_surfaces.add(str(file_path.relative_to(repo_root)))
     return sorted(ui_surfaces)
 
 
-def collect_server_api_surfaces(repo_root: Path) -> list[str]:
-    api_root = repo_root / "main/server/api"
+def collect_server_api_surfaces(repo_root: Path, api_surfaces_dir: str | None) -> list[str]:
+    if not api_surfaces_dir:
+        return []
+    api_root = repo_root / api_surfaces_dir
     if not api_root.exists():
         return []
-    return sorted(str(path.relative_to(repo_root)) for path in api_root.rglob("app.py"))
+    return sorted(str(path.relative_to(repo_root)) for path in api_root.rglob("*") if path.is_file())
 
 
 def ensure_dir(path: Path) -> None:
@@ -349,6 +363,8 @@ def summarize_findings(  # skipcq: PY-R1000
     repo_root: Path,
     plans: list[PlanParse],
     catalog_entries: set[str],
+    ui_surfaces_dir: str | None = None,
+    api_surfaces_dir: str | None = None,
 ) -> dict[str, list[str]]:
     findings = {
         "extra": [],
@@ -368,17 +384,17 @@ def summarize_findings(  # skipcq: PY-R1000
                 f"`{plan.plan_file}` references missing path `{missing_ref}`."
             )
 
-    # missing: UI/API entry surfaces not covered by plans.
+    # missing: UI/API entry surfaces not covered by docs.
     plan_refs = collect_plan_refs(plans)
-    for ui_surface in collect_ui_surfaces(repo_root):
+    for ui_surface in collect_ui_surfaces(repo_root, ui_surfaces_dir):
         if ui_surface not in plan_refs:
             findings["missing"].append(
-                f"UI surface `{ui_surface}` is not referenced by any plan flow."
+                f"UI surface `{ui_surface}` is not referenced by any doc flow."
             )
-    for api_surface in collect_server_api_surfaces(repo_root):
+    for api_surface in collect_server_api_surfaces(repo_root, api_surfaces_dir):
         if api_surface not in plan_refs:
             findings["missing"].append(
-                f"Server API surface `{api_surface}` is not referenced by any plan."
+                f"API surface `{api_surface}` is not referenced by any doc."
             )
 
     # different: flow tests declared but missing.
@@ -447,6 +463,7 @@ def write_ui_checklists(
     plans: list[PlanParse],
     output_ui_dir: Path,
     skill_root: Path,
+    ui_surfaces_dir: str | None = None,
 ) -> None:
     ensure_dir(output_ui_dir)
     clear_markdown_files(output_ui_dir)
@@ -462,7 +479,7 @@ def write_ui_checklists(
             for test_file in flow.test_files:
                 flow_test_map.setdefault(flow.target_file, set()).add(test_file)
 
-    for ui_surface in collect_ui_surfaces(repo_root):
+    for ui_surface in collect_ui_surfaces(repo_root, ui_surfaces_dir):
         owners = sorted(plan_refs.get(ui_surface, set()))
         test_refs = sorted(flow_test_map.get(ui_surface, set()))
         content = render_template(
@@ -524,14 +541,18 @@ def main() -> int:
 
     skill_root = script_path.parent.parent
     catalog_path = resolve_catalog_path(repo_root)
-    catalog_entries = parse_catalog(catalog_path, plans_dir)
-    catalog_display_path = str(catalog_path.relative_to(repo_root))
+    if catalog_path is not None:
+        catalog_entries = parse_catalog(catalog_path, plans_dir)
+        catalog_display_path = str(catalog_path.relative_to(repo_root))
+    else:
+        catalog_entries = set()
+        catalog_display_path = "N/A"
 
     plan_files = sorted(path for path in plans_dir.glob("*.md") if path.name != "index.md")
     parsed_plans = [parse_plan_file(repo_root, plan_path, catalog_entries) for plan_path in plan_files]
 
     ensure_dir(output_dir)
-    output_plans_dir = output_dir / "plans"
+    output_plans_dir = output_dir / "docs"
     output_ui_dir = output_dir / "ui-surfaces"
     summary_path = output_dir / "DRIFT-SUMMARY.md"
 
@@ -542,13 +563,20 @@ def main() -> int:
         skill_root,
         catalog_display_path,
     )
-    write_ui_checklists(repo_root, parsed_plans, output_ui_dir, skill_root)
-    findings = summarize_findings(repo_root, parsed_plans, catalog_entries)
+    write_ui_checklists(repo_root, parsed_plans, output_ui_dir, skill_root, args.ui_surfaces_dir)
+    findings = summarize_findings(
+        repo_root,
+        parsed_plans,
+        catalog_entries,
+        args.ui_surfaces_dir,
+        args.api_surfaces_dir,
+    )
     write_summary(findings, summary_path)
 
     print(f"Wrote summary: {summary_path.relative_to(repo_root)}")
-    print(f"Wrote plan checklists: {output_plans_dir.relative_to(repo_root)}")
-    print(f"Wrote UI checklists: {output_ui_dir.relative_to(repo_root)}")
+    print(f"Wrote doc checklists: {output_plans_dir.relative_to(repo_root)}")
+    if args.ui_surfaces_dir:
+        print(f"Wrote UI checklists: {output_ui_dir.relative_to(repo_root)}")
     return 0
 
 


### PR DESCRIPTION
## Description

This PR introduces two new documentation agents and generalizes the detect-drift skill to work across projects.

**Changes:**

1. **New `detect-drift-agent.md`**: Adds a new agent that audits `docs/docs/` against the actual codebase and fixes any documentation drift in place. Works in conjunction with the detect-drift skill.

2. **Rename `update-documentatioin-agent.md` → `update-documentation-agent.md`**: Fixes a spelling error in the filename and populates the file with full agent instructions for updating docs after a plan is implemented.

3. **Updated `agents/documentation/skills/detect-drift/SKILL.md`**: Retargeted from `docs/plans/` to `docs/docs/` to align with where structured documentation lives. Updated checklist output paths to `tmp/drift-checklists/`.

4. **Generalized `generate_checklists.py`**: Removed hardcoded encache-specific paths (`main/app/app`, `main/server/api`). Made UI/API surface directories configurable via `--ui-surfaces-dir` and `--api-surfaces-dir` CLI args. Changed defaults to `docs/docs` and `tmp/drift-checklists`. Made catalog optional so the script works in any project, not just encache.