### PR TITLE
feat(logging): add logging skill for structured flow instrumentation

### DIFF
--- a/skills/logging/SKILL.md
+++ b/skills/logging/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: logging
+description: Instruments code flows with structured logs. Given a plan/bug/doc file, adds a log statement at each step of every flow using the format: flow | step | data. Use when adding observability to a feature, debugging a flow, or setting up structured logging.
+user-invocable: true
+---
+
+# Logging
+
+Instruments flows with consistent, machine-readable log statements that can be parsed later for debugging.
+
+## Log Format
+
+```
+log<flow><step><data>
+```
+
+```js
+// JavaScript
+console.log("login", "submit", { username })
+console.log("login", "response", { status, userId })
+```
+
+```python
+# Python
+logger.info("login", "submit", {"username": username})
+logger.info("login", "response", {"status": status, "user_id": user_id})
+```
+
+## Steps
+
+### 1. Identify the source file
+
+Accept a path to a plan (`docs/plans/`), bug (`docs/bugs/`), or doc (`docs/docs/`) file. If none is provided, ask for one before proceeding.
+
+### 2. Build a flow checklist
+
+Read the source file and extract every flow. Write a checklist to `tmp/logging-checklist.md` using `skills/logging/templates/logging-checklist-template.md`:
+
+- Set `{{PLAN_BUG_DOC}}` to the path of the plan/bug/doc file
+- Set `{{FLOW_ROWS}}` to one row per flow: `| <flow-name> | <file> | [ ] |`
+- Leave `{{LOG_STATEMENTS}}` empty for now
+
+### 3. Add logs to each flow
+
+For each flow in the checklist:
+1. Open the implementation file
+2. Add a log at each meaningful step (entry, branch, error, exit)
+3. Use the flow name from the doc as the first argument — keep it consistent across all log calls in that flow
+4. Include the most relevant in-scope variables as the data argument
+5. Append each added log statement to `{{LOG_STATEMENTS}}` in the checklist
+6. Mark the flow row as done (`[x]`)
+
+### 4. Cleanup
+
+Delete `tmp/logging-checklist.md` after all flows are instrumented.
+
+## Notes
+
+- Use the existing logger for the project (`console.log`, `logger.info`, Python `logging`, etc.) — do not introduce a new dependency.
+- Keep log messages lowercase and consistent with existing style in the file.
+- Do not log sensitive data (passwords, tokens, PII).

--- a/skills/logging/templates/logging-checklist-template.md
+++ b/skills/logging/templates/logging-checklist-template.md
@@ -1,0 +1,11 @@
+# Logging Checklist: {{PLAN_BUG_DOC}}
+
+## Flows
+
+| Flow | File | Logged |
+|---|---|---|
+{{FLOW_ROWS}}
+
+## Log Statements Added
+
+{{LOG_STATEMENTS}}


### PR DESCRIPTION
## Description

Adds a new `logging` skill (`skills/logging/SKILL.md`) that instruments code flows with structured, machine-readable log statements. The skill follows the format `log<flow><step><data>` — e.g. `console.log("login", "submit", { username })` — making logs parseable by downstream debugger agents.

**What was planned:** A code-writing skill that reads a source-of-truth doc file (plan, bug report, or documentation file), identifies the flows present in that codebase, builds a per-flow checklist in `tmp/`, then writes structured log calls directly into the relevant implementation files. See `docs/plans/2026-04-25-logging-skill.md` for the full approved plan.

**What changed:**
- `skills/logging/SKILL.md` — new skill with steps: identify source file → build flow checklist → add logs to each flow → cleanup checklist
- `skills/logging/templates/logging-checklist-template.md` — template for the per-flow checklist written to `tmp/logging-checklist.md` during execution

The skill replaces the old `old_skills/logging-standards/SKILL.md` (deleted separately) with a more structured, agent-executable workflow.