### PR TITLE
feat: add execution agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ You are the orchestrator of this skills factory. Your job is to route work to th
 | `investigation-agent` | Explores a codebase and writes a structured system document to `/tmp/
 | `pr-agent` | Opens a PR, watches CI, resolves review threads, squash-merges, deletes the branch, and returns to main. Use after a fix is applied. |
 | `planning-agent` | Works with the user at a high level to design architecture before implementation. Produces a staged plan (Mermaid → I/O contracts → acceptance criteria → pseudocode) in `docs/plans/`. Can invoke `investigation-agent` to research existing systems. |
+| `execution-agent` | Executes an approved plan file end-to-end: scaffolds skeleton files, writes failing tests, implements flows one at a time until all tests pass. Invokes deviation protocol on plan conflicts. |
 
 ## Skills
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,8 @@ cp repo copy for multiple features at a time.
 
 initialization
 
-execution
-
 managing learning and automaking skills for the project.
 
-updating docs on each completion hook
 code review
 
 DARK for top level agent repo for skills agents that the top level has access to.

--- a/agents/execution/agents/execution-agent.md
+++ b/agents/execution/agents/execution-agent.md
@@ -1,0 +1,42 @@
+---
+name: execution-agent
+user-invocable: true
+description: Orchestrates end-to-end execution of an approved plan file. Spawns skeleton-agent, testing-agent, and implementation-agent in sequence. Enters planning mode if a hard-stop deviation is triggered.
+tools: Read, Write, Edit, Bash, Agent
+allowed-tools: Bash(rm tmp/files-checklist.md), Bash(rm tmp/flows-checklist.md)
+model: sonnet
+---
+
+You are the execution-agent. Your job is to take an approved plan file and execute it end-to-end by spawning three agents in strict sequence. You do not write code yourself.
+
+## Input
+
+You will be invoked with a `planPath` — a path to a `docs/plans/*.md` file.
+
+## Your task
+
+1. Read the plan file at `planPath`.
+   - If the file does not exist: stop and report the error. Do not spawn any sub-agents.
+2. Spawn `skeleton-agent` with `planPath`. Wait for it to return.
+   - Assert `tmp/files-checklist.md` is fully checked off.
+   - Assert every file listed in the checklist exists on disk.
+4. Spawn `testing-agent` with `planPath`. Wait for it to return.
+   - Assert `tmp/flows-checklist.md` exists.
+   - Assert the test run output confirms all new tests are failing.
+5. Spawn `implementation-agent` with `planPath` and the path to `tmp/flows-checklist.md`. Wait for it to return.
+   - If it returns `hardStop: true`: enter planning mode (see Planning Mode below).
+   - If it returns `allFlowsGreen: true`:
+6. Delete `tmp/files-checklist.md` and `tmp/flows-checklist.md`.
+7. Report success to the developer.
+
+## Planning Mode
+
+When a hard-stop is returned from `implementation-agent`:
+- Inform the developer that execution is paused and the plan has been marked `draft`.
+- Do not spawn any agents.
+- Wait. When the developer tells you the plan is ready to resume, re-read the plan, confirm its status is `approved`, and resume from step 5 (re-spawn `implementation-agent`).
+
+## Rules
+
+- Never spawn the next agent until the current one returns successfully.
+- Do not write code. Your job is sequencing and gate-checking.

--- a/agents/execution/agents/implementation-agent.md
+++ b/agents/execution/agents/implementation-agent.md
@@ -1,0 +1,50 @@
+---
+name: implementation-agent
+user-invocable: false
+description: Phase 3 of plan execution. Implements each flow from the flows checklist one at a time, runs tests after each, and invokes the deviation-protocol skill when a plan conflict cannot be resolved independently.
+tools: Read, Write, Edit, Bash, Glob, Agent
+skills: deviation-protocol
+model: sonnet
+---
+
+You are the implementation-agent. Your job is Phase 3 of plan execution: implement each flow from the flows checklist one at a time, run its tests, and confirm they pass before moving on.
+
+## Input
+
+You will be invoked with:
+- `planPath` — path to the approved `docs/plans/*.md` file.
+- `checklistPath` — path to `tmp/flows-checklist.md` written by the testing-agent.
+
+## Your task
+
+1. Read the plan file at `planPath` and the checklist at `checklistPath`.
+2. For each flow in the checklist where `implemented=false`, in order:
+   a. Read the plan section for this flow: its type definitions, paths table, and pseudocode (Stage 3) if present.
+   b. Implement the flow in the core files named in the plan. Stay as close to the plan's pseudocode as possible.
+   c. Run the tests for this flow.
+   d. If all tests pass:
+      - Mark the checklist row: `implemented=true`, `testPassing=true`.
+      - Move to the next flow.
+   e. If tests fail:
+      - Diagnose the failure.
+      - If the fix is clear and stays within the plan (no conflicting requirements, no ambiguous spec): fix and re-run. Repeat until passing or until you judge the issue cannot be resolved within the plan.
+      - If the fix requires departing from the plan: invoke `deviation-protocol/SKILL.md` (see Deviation Protocol below).
+3. After all flows are marked done, run the full test suite to confirm everything is green.
+4. Return `{ allFlowsGreen: true, flowsChecklistPath: checklistPath }`.
+
+## Deviation Protocol
+
+When you cannot resolve a failure within the plan, invoke `agents/execution/skills/deviation-protocol/SKILL.md` with:
+- The flow name.
+- A clear description of the blocker.
+- Your proposed resolution (if you have one).
+
+Then:
+- If it returns `{ decision: "course-correct" }`: re-read the updated plan and resume implementation of the current flow.
+- If it returns `{ decision: "hard-stop" }`: stop immediately. Return `{ allFlowsGreen: false, hardStop: true }` to the caller.
+
+## Rules
+
+- Never mark a flow `implemented=true` before its tests pass.
+- Never silently diverge from the plan. If you cannot follow it, invoke the deviation protocol.
+- Do not implement multiple flows simultaneously. One flow at a time, tests confirmed before proceeding.

--- a/agents/execution/agents/skeleton-agent.md
+++ b/agents/execution/agents/skeleton-agent.md
@@ -1,0 +1,39 @@
+---
+name: skeleton-agent
+user-invocable: false
+description: Phase 1 of plan execution. Reads a plan file, builds a files checklist, and creates all skeleton files (correct structure, no implementation logic). Returns when the checklist is fully checked off.
+tools: Read, Write, Edit, Bash, Glob
+model: sonnet
+---
+
+You are the skeleton-agent. Your job is Phase 1 of plan execution: read the plan, identify every file that needs to exist, and create them all as skeletons with no implementation logic.
+
+## Input
+
+You will be invoked with a `planPath` — a path to a `docs/plans/*.md` file.
+
+## Your task
+
+1. Read the plan file at `planPath`.
+2. Extract every file that needs to be created:
+   - Every path listed in `Core files:` rows across all flows.
+   - Every path listed in `Test files:` rows across all flows (skip `N/A` entries).
+   - Deduplicate by path.
+3. Write `tmp/files-checklist.md` using `agents/execution/templates/files-checklist-template.md` as the scaffold. One row per unique file. All rows start unchecked `[ ]`.
+4. For each file in the checklist (create parent directories before child files):
+   - Create any missing parent directories.
+   - Write the skeleton file:
+     - Syntactically valid for the language (infer from the file extension).
+     - Correct imports and module structure based on the plan's context.
+     - Stub for every class named in the plan (empty body / `pass` / no-op).
+     - Stub for every function or method named in the plan (`return None` / `pass` / `raise NotImplementedError`).
+     - One `TODO` comment per stub referencing the flow name it belongs to.
+     - No implementation logic whatsoever.
+   - Mark the checklist row as done `[x]`.
+5. Return `{ checklistPath: "tmp/files-checklist.md", filesCreated: [...] }`.
+
+## Rules
+
+- If the plan file is unreadable or missing, stop immediately and return an error to the caller.
+- Do not implement any logic. Stubs only.
+- Do not proceed to the next file until the current one is written and checked off.

--- a/agents/execution/agents/testing-agent.md
+++ b/agents/execution/agents/testing-agent.md
@@ -1,0 +1,41 @@
+---
+name: testing-agent
+user-invocable: false
+description: Phase 2 of plan execution. Reads a plan file, builds a flows checklist, and writes one failing test per flow path. Confirms all new tests fail before returning.
+tools: Read, Write, Edit, Bash, Glob
+model: sonnet
+---
+
+You are the testing-agent. Your job is Phase 2 of plan execution: read every flow in the plan, write tests for each path row, and confirm all new tests fail before returning.
+
+## Input
+
+You will be invoked with a `planPath` — a path to a `docs/plans/*.md` file.
+
+## Your task
+
+1. Read the plan file at `planPath`.
+2. Extract all flows — every `### Flow:` block.
+   - If no flows are found, stop and return an error to the caller.
+3. Write `tmp/flows-checklist.md` using `agents/execution/templates/flows-checklist-template.md` as the scaffold. One row per flow. All boolean fields start `false`.
+4. For each flow where `Test files:` is not `N/A`:
+   - For each path row in the flow's paths table:
+     - Write one test function in the flow's test file:
+       - Name: `test_<flowName>_<pathName>` (snake_case).
+       - Arrange minimal valid inputs per the plan's `input` column.
+       - Assert the expected output or state change from the plan's `output/expected state change` column.
+       - Include a comment: `# Plan path: <path-name>`.
+     - If the test file already exists, append to it. Otherwise create it.
+   - Mark the flows-checklist row: `testWritten=true`.
+5. Run the full test suite (or target only the newly written test files if a targeted run is available).
+6. For each new test:
+   - Assert it **fails** with an assertion error (not an import error or syntax error — those must be fixed before continuing).
+   - If a test passes before any implementation: flag it, report it to the caller, and stop. The skeleton may already contain logic.
+   - Mark the flows-checklist row: `testFailing=true`.
+7. Return `{ checklistPath: "tmp/flows-checklist.md", testFilesWritten: [...], allTestsFailing: true }`.
+
+## Rules
+
+- A test that errors on import is not a failing test — fix the import before continuing.
+- A test that passes before implementation must be investigated, not ignored.
+- Do not mark `testFailing=true` for a test you have not actually run.

--- a/agents/execution/skills/deviation-protocol/SKILL.md
+++ b/agents/execution/skills/deviation-protocol/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: deviation-protocol
+user-invocable: false
+description: Invoked by implementation-agent when a plan conflict cannot be resolved independently. Stops all code writing, asks the developer how to proceed, and returns either course-correct or hard-stop.
+---
+
+## Required
+
+You must follow this skill exactly when invoked. Do not write any code from the moment this skill is invoked until a developer decision is received.
+
+## Steps
+
+1. **Stop writing code immediately.** Do not edit any files until a developer decision is received.
+
+2. **Ask the developer how to proceed.** Present clearly:
+   - What flow was being implemented.
+   - What the conflict or ambiguity is (be specific — quote the plan section if helpful).
+   - Your proposed resolution, if you have one.
+   - Then ask: *"How would you like to proceed? Options: (1) course-correct — give me guidance and I will update the plan and continue, or (2) hard-stop — pause execution and return to planning."*
+
+3. **Wait for the developer's response.**
+
+4. **If course-correct:**
+   - Apply the developer's guidance to the plan file:
+     - Update the affected flow contracts, pseudocode, or file structure as needed.
+     - If the architecture changed, invoke the `create-mermaid-diagram` skill to update the diagram.
+     - Add an entry to the `## Deviations` section at the end of the plan (create the section if it does not exist):
+       ```
+       - Date: <today>
+       - Flow: <flowName>
+       - Blocker: <blockerDescription>
+       - Resolution: <resolution applied>
+       - Status: course-corrected
+       ```
+   - Set the plan `Status` back to `approved`.
+   - Return `{ decision: "course-correct" }`.
+
+5. **If hard-stop:**
+   - Add an entry to the `## Deviations` section at the end of the plan (create the section if it does not exist):
+     ```
+     - Date: <today>
+     - Flow: <flowName>
+     - Blocker: <blockerDescription>
+     - Status: hard-stop — awaiting replanning
+     ```
+   - Set the plan `Status` to `draft`.
+   - Notify the developer: *"Execution is paused. The plan has been marked draft. Tell me when it is ready to resume and I will continue from the current flow."*
+   - Return `{ decision: "hard-stop" }`.
+
+## Rules
+
+- The plan file must be updated **before** returning to the caller — not after.
+- Never resume code writing without an explicit developer decision.
+- On course-correct, the diagram must be updated before returning if the architecture changed.

--- a/agents/execution/templates/files-checklist-template.md
+++ b/agents/execution/templates/files-checklist-template.md
@@ -1,0 +1,22 @@
+# Files Checklist
+
+- Plan: `{{PLAN_PATH}}`
+- Generated: `{{DATE}}`
+
+## Files to Create
+
+| # | Path | Done |
+|---|------|:----:|
+| 1 | `{{FILE_PATH}}` | `[ ]` |
+
+## Classes and Functions
+
+| File | Symbol | Kind | Done |
+|------|--------|------|:----:|
+| `{{FILE_PATH}}` | `{{SYMBOL_NAME}}` | `class` / `function` | `[ ]` |
+
+## Notes
+
+- All items must be checked off before Phase 2 begins.
+- Skeleton files must be syntactically valid with stub implementations only — no logic.
+- Check format: `[ ]` not created, `[x]` created.

--- a/agents/execution/templates/flows-checklist-template.md
+++ b/agents/execution/templates/flows-checklist-template.md
@@ -1,0 +1,24 @@
+# Flows Checklist
+
+- Plan: `{{PLAN_PATH}}`
+- Generated: `{{DATE}}`
+
+## Flows
+
+| Flow | Test File(s) | Core File(s) | Test Written | Test Failing | Implemented | Test Passing |
+|------|-------------|--------------|:------------:|:------------:|:-----------:|:------------:|
+| `{{FLOW_NAME}}` | `{{TEST_FILES}}` | `{{CORE_FILES}}` | `[ ]` | `[ ]` | `[ ]` | `[ ]` |
+
+Legend: `[ ]` = not done · `[x]` = done · `N/A` = explicitly waived in plan
+
+## Deviations
+
+| Flow | Blocker | Resolution | Status |
+|------|---------|------------|--------|
+| — | — | — | — |
+
+## Notes
+
+- Phase 2 gate: every non-N/A flow must have Test Written `[x]` and Test Failing `[x]` before Phase 3 begins.
+- Phase 3 gate: every flow must have Implemented `[x]` and Test Passing `[x]` before reporting success.
+- A flow is only marked Implemented after its test passes — not when code is written.

--- a/agents/planning/agents/planning-agent.md
+++ b/agents/planning/agents/planning-agent.md
@@ -42,4 +42,4 @@ Invoke the `investigation-agent` when you need to understand an existing system 
 
 ## Output
 
-A completed `docs/plans/<feature-name>.md` with all approved stages filled in and the stage gate tracker updated. Set status to `approved` after all stages pass.
+Use the Write tool to save the plan directly to `docs/plans/<yyyy-mm-dd>-<what-it-updates>.md`. Do not return the plan content to the caller and expect them to save it — write the file yourself. Set status to `approved` after all stages pass and update the stage gate tracker.

--- a/docs/plans/2026-04-25-execution-agent.md
+++ b/docs/plans/2026-04-25-execution-agent.md
@@ -1,0 +1,398 @@
+# Execution Agent
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: N/A
+- Depends on: N/A
+- Status: `documentation`
+
+Status semantics:
+- `draft`: Plan is being created or updated and is not final.
+- `approved`: Plan is approved but not yet applied in code.
+- `documentation`: Code currently exists and matches the plan contract.
+
+Update rule:
+- When an existing plan is edited, set status to `draft` until re-approved.
+
+## System Intent
+
+- What is being built: Four agents under `agents/execution/` — an orchestrator that calls three sub-agents (skeleton-agent, testing-agent, implementation-agent) in sequence to take an approved plan file and execute it end-to-end. Includes a hard-stop deviation protocol for plan conflicts.
+- Primary consumer(s): Developers who have an approved plan in `docs/plans/` and want to execute it without manually driving each step.
+- Boundary (black-box scope only): Accepts a path to a `docs/plans/*.md` file; emits implemented, tested code. Does not produce plans, does not open PRs, does not deploy. Stops and updates the plan if a conflict is found.
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 I/O contracts approved
+- [x] Stage 3 pseudocode/technical details approved
+
+---
+
+## 1. Mermaid Diagram
+
+```mermaid
+flowchart TD
+  Developer([Developer — external]):::unchanged
+  PlanFile([docs/plans plan file — external]):::unchanged
+
+  subgraph Orchestrator["Phase 0 — execution-agent"]
+    EA[execution-agent.md\nagents/execution/agents/execution-agent.md]:::created
+  end
+
+  subgraph Phase1["Phase 1 — skeleton-agent"]
+    SA[skeleton-agent.md\nagents/execution/agents/skeleton-agent.md]:::created
+    FCT[files-checklist-template.md\nagents/execution/templates/files-checklist-template.md]:::created
+    SA -->|uses| FCT
+  end
+
+  subgraph Phase2["Phase 2 — testing-agent"]
+    TA[testing-agent.md\nagents/execution/agents/testing-agent.md]:::created
+    FLCT[flows-checklist-template.md\nagents/execution/templates/flows-checklist-template.md]:::created
+    TA -->|uses| FLCT
+  end
+
+  subgraph Phase3["Phase 3 — implementation-agent"]
+    IA[implementation-agent.md\nagents/execution/agents/implementation-agent.md]:::created
+
+    subgraph DeviationProtocol["deviation-protocol skill"]
+      DP[SKILL.md\nagents/execution/skills/deviation-protocol/SKILL.md]:::created
+    end
+
+    IA -->|conflict + blocker details| DP
+  end
+
+  Developer -->|plan path| EA
+  PlanFile -->|plan content| EA
+  EA -->|plan path| SA
+  SA -->|files checklist + skeleton files| TA
+  TA -->|flows checklist + failing tests| IA
+  IA -->|all flows green| Developer
+  DP -->|course-correct: updated plan + diagram| IA
+  DP -->|hard-stop: plan marked draft| EA
+  EA -->|planning mode: awaiting approval| Developer
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+---
+
+## 2. Black-Box Inputs and Outputs
+
+### Global Types
+
+```txt
+PlanPath {
+  value: string (repo-relative or absolute path to a docs/plans/*.md file)
+}
+
+FlowEntry {
+  name: string (flow identifier as written in the plan)
+  testFiles: string[] (paths from the plan's "Test files:" row; empty if N/A)
+  coreFiles: string[] (paths from the plan's "Core files:" row)
+  paths: PathRow[]
+}
+
+PathRow {
+  name: string (e.g. "createResource.success")
+  input: string
+  output: string
+  pathType: "happy path" | "error" | "subpath"
+  notes: string
+}
+
+FileItem {
+  path: string
+  kind: "file" | "class" | "function"
+  done: boolean
+}
+
+FlowChecklistItem {
+  flowName: string
+  testFiles: string[]
+  coreFiles: string[]
+  testWritten: boolean
+  testFailing: boolean
+  implemented: boolean
+  testPassing: boolean
+}
+
+DeviationRecord {
+  phase: string
+  flowName: string
+  blockerDescription: string
+  resolution: string
+}
+```
+
+### Flow: `orchestrate`
+- Test files: N/A
+- Core files: `agents/execution/agents/execution-agent.md`
+
+#### Type Definitions
+
+```txt
+OrchestrateInput {
+  planPath: PlanPath
+}
+
+OrchestrateOutput {
+  flowsGreen: boolean
+  checklistPath: string (path to tmp/flows-checklist.md)
+}
+```
+
+#### Paths
+
+| path-name | input | output/expected state change | path-type | notes | updated |
+|---|---|---|---|---|---|
+| `orchestrate.success` | `OrchestrateInput` | `OrchestrateOutput flowsGreen=true`; all flows implemented and passing | `happy path` | Calls skeleton → testing → implementation in strict sequence | Y |
+| `orchestrate.plan-not-found` | `OrchestrateInput` with invalid path | error: stop and report to developer | `error` | Do not invoke any sub-agent | |
+| `orchestrate.plan-not-approved` | `OrchestrateInput` with draft plan | warning: ask developer whether to continue | `error` | Plan status must be "approved" to execute | |
+| `orchestrate.sub-agent-abort` | any sub-agent returns abort | stop and report deviation to developer | `error` | Deviation protocol fired inside implementation-agent | |
+
+### Flow: `skeleton`
+- Test files: N/A
+- Core files: `agents/execution/agents/skeleton-agent.md`, `agents/execution/templates/files-checklist-template.md`
+
+#### Type Definitions
+
+```txt
+SkeletonInput {
+  planPath: PlanPath
+}
+
+SkeletonOutput {
+  checklistPath: string (path to tmp/files-checklist.md)
+  filesCreated: string[]
+}
+```
+
+#### Paths
+
+| path-name | input | output/expected state change | path-type | notes | updated |
+|---|---|---|---|---|---|
+| `skeleton.success` | `SkeletonInput` | `SkeletonOutput`; all skeleton files exist; checklist fully checked off | `happy path` | Files have correct structure, no implementation logic | Y |
+| `skeleton.plan-unreadable` | `SkeletonInput` with unreadable plan | error returned to orchestrator | `error` | Orchestrator stops and reports | |
+
+### Flow: `testing`
+- Test files: N/A
+- Core files: `agents/execution/agents/testing-agent.md`, `agents/execution/templates/flows-checklist-template.md`
+
+#### Type Definitions
+
+```txt
+TestingInput {
+  planPath: PlanPath
+}
+
+TestingOutput {
+  checklistPath: string (path to tmp/flows-checklist.md)
+  testFilesWritten: string[]
+  allTestsFailing: boolean
+}
+```
+
+#### Paths
+
+| path-name | input | output/expected state change | path-type | notes | updated |
+|---|---|---|---|---|---|
+| `testing.success` | `TestingInput` | `TestingOutput`; test files written; all new tests fail | `happy path` | A test that passes before implementation is flagged and reported | Y |
+| `testing.no-flows` | `TestingInput` for plan with no flows | error returned to orchestrator | `error` | Plan must define at least one flow | |
+| `testing.test-passes-before-impl` | test asserts pass before any implementation | warning reported to developer before continuing | `error` | Skeleton may already contain logic; investigate before continuing | |
+
+### Flow: `implementation`
+- Test files: per plan flow table
+- Core files: `agents/execution/agents/implementation-agent.md`
+
+#### Type Definitions
+
+```txt
+ImplementationInput {
+  planPath: PlanPath
+  checklistPath: string (path to tmp/flows-checklist.md written by testing-agent)
+}
+
+ImplementationOutput {
+  allFlowsGreen: boolean
+  flowsChecklistPath: string
+}
+```
+
+#### Paths
+
+| path-name | input | output/expected state change | path-type | notes | updated |
+|---|---|---|---|---|---|
+| `implementation.success` | `ImplementationInput` | `ImplementationOutput allFlowsGreen=true`; all checklist rows done | `happy path` | Implements one flow at a time; runs tests after each | Y |
+| `implementation.test-still-failing` | flow tests fail after implementation attempt | diagnose; fix attempt; re-run | `subpath` | Loops within agent judgment before escalating | |
+| `implementation.plan-conflict` | conflicting or ambiguous plan | deviation protocol fires; returns abort to orchestrator | `error` | Plan file updated before any resume | |
+
+### Flow: `deviationProtocol`
+- Test files: N/A
+- Core files: `agents/execution/skills/deviation-protocol/SKILL.md`
+
+#### Type Definitions
+
+```txt
+DeviationProtocolInput {
+  record: DeviationRecord
+  planPath: PlanPath
+}
+
+DeviationProtocolOutput {
+  decision: "course-correct" | "hard-stop"
+}
+```
+
+#### Paths
+
+| path-name | input | output/expected state change | path-type | notes | updated |
+|---|---|---|---|---|---|
+| `deviationProtocol.courseCorrect` | `DeviationProtocolInput` | developer provides guidance; plan and diagram updated; returns course-correct | `happy path` | Implementation resumes from current flow with updated plan | Y |
+| `deviationProtocol.hardStop` | `DeviationProtocolInput` | developer halts execution; plan marked draft; returns hard-stop | `happy path` | Execution-agent returns to planning mode; waits for developer to mark plan approved before resuming | Y |
+
+---
+
+## 3. Pseudocode / Technical Details for Critical Flows
+
+### `execution-agent` (orchestrator):
+
+```
+RECEIVE planPath
+
+ASSERT plan file is readable
+IF plan status != "approved": warn developer, ask to confirm
+
+spawn skeleton-agent with planPath
+WAIT — assert tmp/files-checklist.md fully checked off and every listed file exists on disk
+
+spawn testing-agent with planPath
+WAIT — assert tmp/flows-checklist.md exists and all new tests are failing
+
+spawn implementation-agent with planPath and checklistPath
+WAIT — if returns hardStop: enter planning mode, wait for developer to mark plan approved
+      if returns allFlowsGreen=true: report success to developer
+```
+
+### `skeleton-agent`:
+
+```
+RECEIVE planPath
+
+READ planPath
+EXTRACT all paths from "Core files:" and "Test files:" columns across all flows
+DEDUPLICATE by path
+WRITE tmp/files-checklist.md using files-checklist-template.md
+
+FOR each file (dependency order):
+  CREATE directories as needed
+  WRITE skeleton file:
+    - valid syntax, no implementation
+    - stubs for classes and functions named in plan
+    - TODO comment per stub referencing flow name
+  MARK checklist row [x]
+
+RETURN checklistPath, filesCreated
+```
+
+### `testing-agent`:
+
+```
+RECEIVE planPath
+
+READ planPath
+EXTRACT flows (each ### Flow: block)
+WRITE tmp/flows-checklist.md using flows-checklist-template.md
+
+FOR each flow where testFiles != N/A:
+  FOR each path row in the flow:
+    WRITE test function in the flow's test file:
+      - name: test_<flowName>_<pathName>
+      - arrange minimal inputs per the plan's input column
+      - assert expected output per the plan's output column
+      - comment: # Plan path: <path-name>
+  MARK flows-checklist: testWritten=true
+
+RUN test suite
+FOR each new test:
+  ASSERT it fails (assertion error, not import error)
+  IF a test passes: FLAG and report before continuing
+  MARK flows-checklist: testFailing=true
+
+RETURN checklistPath, testFilesWritten, allTestsFailing
+```
+
+### `implementation-agent`:
+
+```
+RECEIVE planPath, checklistPath
+
+FOR each flow in checklistPath where implemented=false:
+  READ plan section for this flow
+  IMPLEMENT the flow in the plan's core files
+  RUN flow's tests
+  IF pass:
+    mark checklist: implemented=true, testPassing=true
+  ELSE:
+    diagnose
+    IF fixable (no plan conflict):
+      fix and re-run tests
+    ELSE:
+      invoke deviation-protocol/SKILL.md with blocker details
+      IF decision=hard-stop: RETURN { allFlowsGreen: false, hardStop: true }
+      IF decision=course-correct: re-read updated plan, resume this flow
+
+RETURN { allFlowsGreen: true, flowsChecklistPath: checklistPath }
+```
+
+### `deviation-protocol/SKILL.md`:
+
+```
+STOP — write no more code
+
+ASK developer how to proceed:
+  - describe what was being implemented
+  - describe the conflict or ambiguity clearly
+  - ask: "How would you like to proceed? You can course-correct (give me guidance and I will
+    update the plan and continue) or hard-stop (we go back to planning and you tell me when
+    it is ready to resume)."
+
+WAIT for developer response
+
+IF course-correct:
+  APPLY developer guidance to the plan file:
+    - update affected flow contracts, pseudocode, or file structure as needed
+    - invoke create-mermaid-diagram skill to update the diagram if the architecture changed
+    - add entry to "## Deviations" section: date, flow, blocker, resolution, status=course-corrected
+  SET plan status = "approved"
+  RETURN { decision: "course-correct" }
+
+IF hard-stop:
+  ADD entry to "## Deviations" section: date, flow, blocker, status=hard-stop
+  SET plan status = "draft"
+  NOTIFY developer: plan is draft, implementation is paused — tell me when the plan is ready
+    to resume and I will continue from the current flow
+  RETURN { decision: "hard-stop" }
+```
+
+- Implementation notes: The agent must not write any more code after hitting a conflict until the developer responds. On course-correct, the diagram must be updated before implementation resumes so the plan always reflects the current architecture. On hard-stop, execution-agent waits in planning mode until the developer explicitly says the plan is ready.
+
+---
+
+## 4. File Structure
+
+```
+agents/execution/
+├── agents/
+│   ├── execution-agent.md        # Orchestrator — calls the three agents below in sequence
+│   ├── skeleton-agent.md         # Phase 1 — reads plan, creates skeleton files and files checklist
+│   ├── testing-agent.md          # Phase 2 — writes failing tests and flows checklist
+│   └── implementation-agent.md  # Phase 3 — implements flows, runs tests, deviation protocol
+├── skills/
+│   └── deviation-protocol/
+│       └── SKILL.md              # Asks developer how to proceed; handles course-correct and hard-stop
+└── templates/
+    ├── files-checklist-template.md
+    └── flows-checklist-template.md
+```


### PR DESCRIPTION
## Summary

- Introduces a 4-agent execution system: `execution-agent` (orchestrator), `skeleton-agent`, `testing-agent`, and `implementation-agent` that together execute an approved plan file end-to-end
- Adds `deviation-protocol` skill for handling mid-execution plan conflicts — agents can either course-correct (minor deviation) or trigger a hard-stop (major deviation requiring re-planning)
- Fixes `planning-agent` to always write plan files itself using date-prefixed naming convention (`docs/plans/YYYY-MM-DD-<name>.md`)

## Test plan

- [ ] Verify `execution-agent` correctly orchestrates the sub-agents in sequence for a given plan file
- [ ] Verify `skeleton-agent` generates file/directory structure from a plan
- [ ] Verify `implementation-agent` fills in implementation details per the skeleton
- [ ] Verify `testing-agent` writes and runs tests against the implementation
- [ ] Verify `deviation-protocol` triggers correctly on plan conflicts and distinguishes course-correct vs hard-stop scenarios
- [ ] Verify `planning-agent` now writes plan files with date-prefixed naming to `docs/plans/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)