### PR TITLE
fix: delete local branch after merging PR in step 7

### DIFF
--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -38,9 +38,9 @@ If neither is provided, look at the git diff and any relevant `docs/bugs/` or `d
    ```bash
    gh pr merge <PR_URL> --squash --delete-branch
    ```
-7. Switch back to main:
+7. Switch back to main and delete the local branch:
    ```bash
-   git checkout main && git pull
+   git checkout main && git pull && git branch -d <branch-name>
    ```
 8. Return `{ pr_url, merged: true }` to the caller.
 


### PR DESCRIPTION
## Summary

- Updates step 7 of the pr-agent instructions to also delete the local branch after switching back to main
- Previously, only the remote branch was cleaned up (via `--delete-branch` in the merge command); the local branch lingered
- Now step 7 runs: `git checkout main && git pull && git branch -d <branch-name>`

## Test plan

- [ ] Verify the updated step 7 in `agents/pr/agents/pr-agent.md` reads correctly
- [ ] Confirm that running through the pr-agent flow leaves no dangling local branch after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)