### PR TITLE
init: dark factory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,14 @@ You are the orchestrator of this skills factory. Your job is to route work to th
 | `planning-agent` | Works with the user at a high level to design architecture before implementation. Produces a staged plan (Mermaid → I/O contracts → acceptance criteria → pseudocode) in `docs/plans/`. Can invoke `investigation-agent` to research existing systems. |
 | `execution-agent` | Executes an approved plan file end-to-end: scaffolds skeleton files, writes failing tests, implements flows one at a time until all tests pass. Invokes deviation protocol on plan conflicts. |
 | `feature-agent` | Orchestrates end-to-end feature work: invokes planning-agent, gates on human approval (with feedback-and-retry), then invokes execution-agent. |
+| `init-orchestrator-agent` | Entry point for setting up a project with dark factory. Runs `init.sh`, generates `CLAUDE.md` via `init-docs-agent`, then opens a PR titled "init: dark factory". |
+| `init-docs-agent` | Explores a newly initialized project directory and generates a `CLAUDE.md` at its root. Called by `init-orchestrator-agent`. |
+
+## Scripts
+
+| Script | Description |
+|---|---|
+| `agents/initialization/scripts/init.sh [github-url]` | Sets up dark-factory project structure. With a URL: `mkdir <repo> && git clone`. Without: reorganizes current dir into `<dirname>/<dirname>/`. |
 
 ## Skills
 

--- a/agents/featurework/planning/templates/plan-template.md
+++ b/agents/featurework/planning/templates/plan-template.md
@@ -4,8 +4,7 @@
 
 - Plan type: `plan` | `sub-plan`
 - Parent plan: `required for sub-plan; otherwise N/A`
-- Depends on:  `N/A`
-  - `plan-link`
+- Depends on: `N/A`
   - `plan-link`
 - Status: `draft` | `approved` | `documentation`
 
@@ -13,7 +12,6 @@ Status semantics:
 - `draft`: Plan is being created or updated and is not final.
 - `approved`: Plan is approved but not yet applied in code.
 - `documentation`: Code currently exists and matches the plan contract.
-
 
 Update rule:
 - When an existing plan is edited, set status to `draft` until re-approved.
@@ -27,141 +25,87 @@ Update rule:
 ## Stage Gate Tracker
 
 - [ ] Stage 1 Mermaid approved
-- [ ] Stage 2 I/O contracts approved
-- [ ] Stage 3 pseudocode/technical details approved or skipped
+- [ ] Stage 2 Flows approved
+- [ ] Stage 3 Logs + Deployment approved or skipped
 
-## 1. Mermaid Diagram
+## Mermaid Diagram
 
-Reference: `.agent/skills/create-mermaid-diagram/SKILL.md`
+> Use the `create-mermaid-diagram` skill to generate this diagram.
 
 ```mermaid
-flowchart TD
-  In[Input Contract] -->|Typed payload| Box[System Boundary]
-  Box -->|Typed response/event| Out[Output Contract]
+graph TD
+  In[Input Contract]:::unchanged -->|Typed payload| Box[System Boundary]:::created
+  Box -->|Typed response| Out[Output Contract]:::unchanged
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
 ```
 
 ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
 
-## 2. Black-Box Inputs and Outputs
+## Flows
 
-Keep this short. Define types in JSON-style blocks and capture each flow with path-level rows.
-- Flow naming rule: each flow uses this format:
-  - ``### Flow: `<flowname>` ``
-  - ``- Test files: <path/to/test_file.ext>, ...`` (or `N/A` when no automated test is required)
-  - ``- Core files: <path/to/core_file.ext>, ...``
-- `N/A` means explicit no-test-required waiver for that flow (not a missing mapping).
+- Flow naming rule: ``### Flow: `<flowname>` ``
+- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).
 
 ### Global Types
 
-Define shared types used across multiple flows.
-
 ```txt
-Identifier {
-  value: string (stable unique identifier)
-}
-
-RequestMetadata {
-  trace_id: string (request trace identifier)
-  requested_at: timestamp (request timestamp)
-}
-
 StandardError {
-  status: number (HTTP status)
-  code: string (stable machine-readable code)
-  message: string (human-readable summary)
+  message: string (human-readable description of what went wrong)
 }
 ```
 
-### Flow: `createResource`
-- Test files: `tests/test_create_resource.py`
-- Core files: `src/resource_service.py`
+### Flow: `exampleFlow`
+- Test files: `tests/test_example.py`
+- Core files: `src/example.py`
 
-#### Type Definitions
+#### Types
 
 ```txt
-CreateResourceInput {
-  id: Identifier (required)
-  metadata: RequestMetadata (required)
+ExampleInput {
+  id: string (required)
 }
 
-CreateResourceOutput {
-  result_id: Identifier (identifier for created/updated result)
-  status: string (domain-specific success status)
+ExampleOutput {
+  result: string (description)
 }
 ```
 
 #### Paths
 
-| path-name | input | output/expected state change | path-type | notes | updated |
+| path | input | output | path-type | notes | updated |
 | --- | --- | --- | --- | --- | --- |
-| `createResource.success` | `CreateResourceInput` | `CreateResourceOutput; primary resource is created/updated` | `happy path` | `use real business rule notes here` | `Y` |
-| `createResource.validation-failure` | `CreateResourceInput` | `StandardError status=400 code=invalid-input` | `error` | `no state change on validation failure` | |
+| `exampleFlow.success` | `ExampleInput` | `ExampleOutput` | `happy path` | | |
+| `exampleFlow.not-found` | `ExampleInput` | `StandardError` | `error` | | |
 
-### Flow: `transitionResource`
-- Test files: `tests/test_transition_resource.py`
-- Core files: `src/resource_state.py`
+#### Pseudocode
 
-#### Type Definitions
+> Only include if this flow has non-obvious implementation details worth preserving.
 
-```txt
-TransitionResourceInput {
-  source_id: Identifier (required)
-  metadata: RequestMetadata (required)
-}
-
-TransitionResourceOutput {
-  state: string (resulting state label)
-  updated_at: timestamp (state transition timestamp)
-}
 ```
-
-#### Paths
-
-| path-name | input | output/expected state change | path-type | notes | updated |
-| --- | --- | --- | --- | --- | --- |
-| `transitionResource.success` | `TransitionResourceInput` | `TransitionResourceOutput; resource transitions to expected state` | `happy path` | `document downstream effects if any` | `Y` |
-| `transitionResource.not-allowed` | `TransitionResourceInput` | `StandardError status=409 code=state-conflict` | `error` | `state transition is rejected` | |
-
-### Flow: `linkChildToParent`
-- Test files: `tests/test_link_child_to_parent.py`
-- Core files: `src/resource_links.py`
-
-#### Type Definitions
-
-```txt
-LinkChildToParentInput {
-  parent_id: Identifier (required)
-  child_id: Identifier (required)
-}
-
-LinkChildToParentOutput {
-  linked: boolean (whether relationship exists after operation)
-}
+omit this section if not needed
 ```
-
-#### Paths
-
-| path-name | input | output/expected state change | path-type | notes | updated |
-| --- | --- | --- | --- | --- | --- |
-| `linkChildToParent.success` | `LinkChildToParentInput` | `LinkChildToParentOutput linked=true; relationship is stored` | `happy path` | `idempotent behavior can be documented here` | `Y` |
-| `linkChildToParent.already-linked` | `LinkChildToParentInput` | `LinkChildToParentOutput linked=true; no additional state change` | `subpath` | `example idempotent subpath` | |
-| `linkChildToParent.missing-parent` | `LinkChildToParentInput` | `StandardError status=404 code=not-found` | `error` | `parent resource must exist` | |
-
-## 3. Pseudocode / Technical Details for Critical Flows (Optional)
-
-Use this section for implementation-oriented details that are too low-level for System Intent, including:
-- Deployment/build prerequisites (required inputs, generated artifacts, external setup steps).
-- Required secrets/config injection steps and ownership/sign-off checkpoints.
-- Critical execution strategy details needed for successful implementation.
-
-- Flow name::
-```
-pseudocode goes in here
-```
-- Implementation notes:
 
 ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
 
-## 4. Handoff to Related Plan Reconciliation
+## Logs
+
+| Source | Location |
+|--------|----------|
+| example | `CloudWatch: /aws/lambda/example` |
+
+## Deployment
+
+- Mechanism: `SAM` | `docker` | `Lambda direct` | `local only` | other
+- Deploy command:
+  ```bash
+  # command here
+  ```
+- Notes:
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Handoff to Related Plan Reconciliation
 
 After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans.

--- a/agents/initialization/agents/init-docs-agent.md
+++ b/agents/initialization/agents/init-docs-agent.md
@@ -1,0 +1,61 @@
+---
+name: init-docs-agent
+user-invocable: false
+description: Explores a newly initialized project and generates a CLAUDE.md at its root. Called after init.sh sets up the project structure.
+tools: Read, Grep, Glob, Bash, Write
+model: sonnet
+---
+
+You are the init-docs-agent. Your job is to explore a project directory and produce a `CLAUDE.md` at its root that gives future Claude sessions an accurate mental model of the codebase.
+
+## Input
+
+You receive a `project_path` — the path to the project directory to document (e.g., `myrepo/myrepo/`).
+
+## Steps
+
+1. **Orient yourself**: read the top-level directory listing (`ls -la <project_path>`). Identify the language(s), framework hints, and entry points.
+
+2. **Explore the codebase**:
+   - Look for README, package.json, pyproject.toml, Cargo.toml, go.mod, Makefile, or any other project descriptor at the root.
+   - Identify the main entry point(s) and primary source directories.
+   - Find the test directory/convention used.
+   - Identify any CI config (`.github/workflows/`, `Makefile` targets, etc.).
+   - Look for a deploy or run script.
+
+3. **Write `CLAUDE.md`** at `<project_path>/CLAUDE.md` using the structure below. Fill every section from code evidence — never invent details.
+
+## CLAUDE.md structure
+
+```markdown
+# <Project Name>
+
+One paragraph: what this project does and who it is for.
+
+## Architecture
+
+Short description of how it is structured (monolith, services, layers, etc.).
+List primary directories and their roles.
+
+## Key Entry Points
+
+| File | Purpose |
+|---|---|
+| path/to/file | what it does |
+
+## Development
+
+How to install dependencies, run the project locally, and run tests.
+
+## Deploy
+
+How code gets deployed (CI pipeline, manual script, etc.). Omit if not found.
+
+## Notes
+
+Anything non-obvious a new contributor needs to know (env vars required, quirks, known issues found in README).
+```
+
+## Output
+
+Return the path to the `CLAUDE.md` file written.

--- a/agents/initialization/agents/init-orchestrator-agent.md
+++ b/agents/initialization/agents/init-orchestrator-agent.md
@@ -1,0 +1,48 @@
+---
+name: init-orchestrator-agent
+user-invocable: true
+description: Sets up a project to use dark factory. Runs init.sh, generates CLAUDE.md via init-docs-agent, then opens a PR titled "init: dark factory".
+tools: Bash, Agent
+model: sonnet
+---
+
+You are the init-orchestrator-agent. Your job is to set up a project to use dark factory end-to-end.
+
+## Input
+
+Optionally receive a `github_url`. If not provided, treat the current directory as the existing project to initialize.
+
+## Orchestration
+
+```
+init-orchestrator-agent(github_url?):
+
+  # Step 1: run init.sh to set up directory structure
+  SCRIPT = path to agents/initialization/scripts/init.sh (find it relative to where dark factory is installed)
+
+  If github_url is provided:
+    run: bash <SCRIPT> <github_url>
+  Else:
+    run: bash <SCRIPT>
+
+  Capture PROJECT_PATH from the script's stdout line: `PROJECT_PATH=<value>`
+
+  If the script fails, report the error and STOP.
+
+  # Step 2: generate CLAUDE.md for the project
+  invoke init-docs-agent with: project_path = PROJECT_PATH
+
+  If init-docs-agent fails or returns no path, report the error and STOP.
+
+  # Step 3: open a PR for the generated docs
+  invoke pr-agent with: description = "init: dark factory\n\nAdds CLAUDE.md to <PROJECT_PATH> to bootstrap dark factory integration."
+
+  Report the PR URL to the user.
+  STOP
+```
+
+## Rules
+
+- Never modify init.sh or init-docs-agent.
+- Do not create or edit any files yourself — delegate entirely to the script and agents.
+- If init.sh fails because the target directory already exists, report that to the user and stop — do not attempt to recover.

--- a/agents/initialization/scripts/init.sh
+++ b/agents/initialization/scripts/init.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GITHUB_URL="${1:-}"
+
+if [ -n "$GITHUB_URL" ]; then
+    REPO_NAME=$(basename "$GITHUB_URL" .git)
+
+    if [ -d "$REPO_NAME" ]; then
+        echo "Error: directory '$REPO_NAME' already exists." >&2
+        exit 1
+    fi
+
+    mkdir "$REPO_NAME"
+    cd "$REPO_NAME"
+    git clone "$GITHUB_URL"
+    echo "PROJECT_PATH=${REPO_NAME}/${REPO_NAME}"
+else
+    DIRNAME=$(basename "$PWD")
+
+    if [ -d "$DIRNAME" ]; then
+        echo "Error: subdirectory '$DIRNAME' already exists in $(pwd)." >&2
+        exit 1
+    fi
+
+    mkdir "$DIRNAME"
+
+    find . -maxdepth 1 ! -name '.' ! -name "$DIRNAME" -exec cp -rp {} "$DIRNAME/" +
+    echo "PROJECT_PATH=${DIRNAME}/${DIRNAME}"
+fi

--- a/docs/plans/2026-04-25-init-dark-factory.md
+++ b/docs/plans/2026-04-25-init-dark-factory.md
@@ -1,0 +1,181 @@
+# Init Dark Factory
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: N/A
+- Depends on: N/A
+- Status: `approved`
+
+Status semantics:
+- `draft`: Plan is being created or updated and is not final.
+- `approved`: Plan is approved but not yet applied in code.
+- `documentation`: Code currently exists and matches the plan contract.
+
+Update rule:
+- When an existing plan is edited, set status to `draft` until re-approved.
+
+## System Intent
+
+- What is being built: An initialization system (`init-orchestrator-agent`) that sets up any project to use dark factory. It runs a shell script to establish the canonical `<name>/<name>/` directory structure, invokes `init-docs-agent` to generate a `CLAUDE.md` for the project, then opens a PR titled "init: dark factory" via `pr-agent`.
+- Primary consumer(s): Developers onboarding a new or existing project to the dark factory workflow.
+- Boundary (black-box scope only): `init-orchestrator-agent` owns sequencing only. `init.sh` owns filesystem setup. `init-docs-agent` owns CLAUDE.md generation. `pr-agent` owns PR lifecycle. GitHub and the target repository are external and out of scope.
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 Flows approved
+- [x] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+> Use the `create-mermaid-diagram` skill to generate this diagram.
+
+```mermaid
+graph TD
+  Dev([Developer]):::unchanged -->|github_url — optional| ORC["init-orchestrator-agent — agents/initialization/agents"]:::created
+  ORC -->|shell invocation with args| SCR["init.sh — agents/initialization/scripts"]:::created
+  SCR -->|PROJECT_PATH| ORC
+  ORC -->|PROJECT_PATH| DOCS["init-docs-agent — agents/initialization/agents"]:::created
+  DOCS -->|CLAUDE.md path| ORC
+  ORC -->|PR description string| PR["pr-agent — agents/pr/agents"]:::unchanged
+  PR -->|opens PR| GH([GitHub — external]):::unchanged
+  PR -->|PR URL| ORC
+  ORC -->|PR URL| Dev
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+### Global Types
+
+```txt
+ProjectPath {
+  value: string (relative path to the nested project root, e.g. "myrepo/myrepo/")
+}
+
+PrUrl {
+  value: string (URL of the opened pull request)
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+### Flow: `runInitScript`
+- Test files: N/A
+- Core files: `agents/initialization/scripts/init.sh`
+
+#### Types
+
+```txt
+RunInitScriptInput {
+  github_url: string | null (HTTPS or SSH GitHub remote URL; null for existing-project case)
+  cwd: string (current working directory when script is invoked)
+}
+
+RunInitScriptOutput {
+  project_path: ProjectPath
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `runInitScript.clone` | `RunInitScriptInput github_url!=null` | `RunInitScriptOutput; repo-name/repo-name/ created` | `happy path` | repo-name = basename of URL with .git stripped | |
+| `runInitScript.move` | `RunInitScriptInput github_url=null` | `RunInitScriptOutput; dirname/dirname/ created, all files copied in including dotfiles` | `happy path` | dirname = basename of cwd | |
+| `runInitScript.dir-exists` | `RunInitScriptInput` | `StandardError; no filesystem change` | `error` | script exits non-zero; orchestrator stops and reports | |
+
+#### Pseudocode
+
+```
+# clone case
+REPO_NAME = basename(github_url).replace(".git", "")
+mkdir REPO_NAME && cd REPO_NAME && git clone github_url
+echo "PROJECT_PATH=${REPO_NAME}/${REPO_NAME}"
+
+# move case (existing project)
+DIRNAME = basename(cwd)
+mkdir DIRNAME
+find . -maxdepth 1 ! -name '.' ! -name DIRNAME -exec cp -rp {} DIRNAME/ +
+# captures dotfiles (.git, .env, .github/, etc.)
+# set -euo pipefail propagates any cp failure as non-zero exit
+# using + batches cp calls for efficiency (one invocation per batch)
+echo "PROJECT_PATH=${DIRNAME}/${DIRNAME}"
+```
+
+---
+
+### Flow: `generateDocs`
+- Test files: N/A
+- Core files: `agents/initialization/agents/init-docs-agent.md`
+
+#### Types
+
+```txt
+GenerateDocsInput {
+  project_path: ProjectPath
+}
+
+GenerateDocsOutput {
+  claude_md_path: string (path to the written CLAUDE.md file)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `generateDocs.success` | `GenerateDocsInput` | `GenerateDocsOutput; CLAUDE.md written at project_path/CLAUDE.md` | `happy path` | init-docs-agent explores project and fills each CLAUDE.md section from code evidence | |
+| `generateDocs.failure` | `GenerateDocsInput` | `StandardError; no CLAUDE.md written` | `error` | orchestrator stops; does not attempt PR | |
+
+---
+
+### Flow: `orchestrateInit`
+- Test files: N/A
+- Core files: `agents/initialization/agents/init-orchestrator-agent.md`
+
+#### Types
+
+```txt
+OrchestrateInitInput {
+  github_url: string | null
+}
+
+OrchestrateInitOutput {
+  status: "complete" | "failed"
+  pr_url: PrUrl | null
+  reason: string | null (populated on failure)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `orchestrateInit.clone-success` | `OrchestrateInitInput github_url!=null` | `OrchestrateInitOutput status=complete; repo cloned, CLAUDE.md generated, PR opened` | `happy path` | | |
+| `orchestrateInit.move-success` | `OrchestrateInitInput github_url=null` | `OrchestrateInitOutput status=complete; files moved, CLAUDE.md generated, PR opened` | `happy path` | | |
+| `orchestrateInit.script-failure` | `OrchestrateInitInput` | `OrchestrateInitOutput status=failed` | `error` | init.sh exits non-zero; stop immediately | |
+| `orchestrateInit.docs-failure` | `OrchestrateInitInput` | `OrchestrateInitOutput status=failed` | `error` | init-docs-agent fails; stop before opening PR | |
+| `orchestrateInit.pr-failure` | `OrchestrateInitInput` | `OrchestrateInitOutput status=failed` | `error` | pr-agent fails; CLAUDE.md exists but no PR opened | |
+
+## Logs
+
+N/A — no runtime logging; all output is via agent console messages.
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  bash agents/initialization/scripts/init.sh [github-url]
+  ```
+- Notes: Script must be run from the intended parent directory. After script completes, invoke `init-docs-agent` with the resulting `PROJECT_PATH`, then `pr-agent`.
+
+## Handoff to Related Plan Reconciliation
+
+After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans.

--- a/docs/plans/2026-04-25-init-docs-agent.md
+++ b/docs/plans/2026-04-25-init-docs-agent.md
@@ -1,0 +1,292 @@
+# Init-Docs Agent Redesign — Documentation Orchestrator
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: N/A
+- Depends on: N/A
+- Status: `approved`
+
+Status semantics:
+- `draft`: Plan is being created or updated and is not final.
+- `approved`: Plan is approved but not yet applied in code.
+- `documentation`: Code currently exists and matches the plan contract.
+
+Update rule:
+- When an existing plan is edited, set status to `draft` until re-approved.
+
+## System Intent
+
+- What is being built: A redesigned `init-docs-agent` that acts as a documentation orchestrator instead of a single monolithic agent. It replaces the existing single-agent that wrote one CLAUDE.md with an orchestrator that identifies discrete features in a project, creates a checklist, then spawns a documentation agent per feature in parallel.
+- Primary consumer(s): Developers (and other agents, e.g. `init.sh`) who call `init-docs-agent` with a `project_path` to initialize documentation for a new or undocumented project.
+- Boundary (black-box scope only): The orchestrator owns investigation, checklist creation, agent spawning, and checklist status updates. Each spawned documentation agent owns the actual feature doc. The `investigate` skill and `documentation` skill (both under `agents/documentation/skills/`) are treated as black-box dependencies — this plan does not modify them.
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 Flows approved
+- [x] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+> Generated and validated with `mmdc` — no parse errors.
+
+```mermaid
+flowchart TD
+    Caller([Caller]):::unchanged -->|project_path| Orch["init-docs-orchestrator\nagents/initialization/agents/init-docs-agent.md"]:::updated
+
+    subgraph orchestrator boundary
+        Orch -->|explore project_path| Inv["Investigation Phase\nidentify features + collect files"]:::created
+        Inv -->|feature list with files| CW["Checklist Writer\nbuild checklist"]:::created
+        CW -->|writes| CL[("/tmp/init-checklist.md\n(deleted on completion)")]:::created
+        CW -->|feature + files per item| Swarm["Documentation Swarm\nspawn one agent per feature"]:::created
+        Swarm -->|checklist item path + feature files| DA["Documentation Agent x N\n(subagent per feature)"]:::created
+        DA -->|completed signal| Swarm
+        Swarm -->|mark item done| CL
+        Swarm -->|all docs generated| DD{"Detect-Drift Loop\nagents/documentation/skills/detect-drift"}:::created
+        DD -->|drift found: re-invoke agent for affected doc| DA
+        DD -->|no drift| Cleanup["Delete /tmp/init-checklist.md"]:::created
+    end
+
+    DA -->|uses| InvSkill["investigate skill\nagents/documentation/skills/investigate/SKILL.md"]:::unchanged
+    DA -->|uses| DocSkill["documentation skill\nagents/documentation/skills/documentation/SKILL.md"]:::unchanged
+    DA -->|writes feature doc| FD[("Feature Docs\ndocs/docs/feature-name.md")]:::created
+    Cleanup -->|returns| Out([feature doc paths]):::unchanged
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef updated fill:#ffe58a,stroke:#666,stroke-width:1px;
+classDef deleted fill:#f4a6a6,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+- Flow naming rule: ``### Flow: `<flowname>` ``
+- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+
+FeatureItem {
+  name: string (short label, e.g. "user auth", "image upload")
+  files: string[] (list of relevant file paths within project_path)
+  status: "pending" | "done"
+}
+
+DriftReport {
+  has_drift: boolean
+  affected_docs: string[] (paths to docs/docs/<feature>.md files that have drift)
+  findings: string (human-readable summary from detect-drift skill)
+}
+```
+
+---
+
+### Flow: `orchestrate`
+- Test files: N/A
+- Core files: `agents/initialization/agents/init-docs-agent.md`
+
+#### Types
+
+```txt
+OrchestratorInput {
+  project_path: string (required — absolute path to the project directory to document)
+}
+
+OrchestratorOutput {
+  feature_doc_paths: string[] (paths to all docs/docs/<feature>.md files written and verified)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `orchestrate.success` | `OrchestratorInput` | `OrchestratorOutput` | `happy path` | All features documented; detect-drift reports no drift; checklist deleted | |
+| `orchestrate.no-features-found` | `OrchestratorInput` | `StandardError` | `error` | Investigation phase finds no identifiable features; checklist not created | |
+| `orchestrate.agent-failure` | `OrchestratorInput` | `OrchestratorOutput (partial)` | `error` | One or more documentation agents fail; failed features are skipped in drift loop; orchestrator returns partial results; checklist deleted regardless | |
+
+#### Pseudocode
+
+```
+function orchestrate(project_path):
+  // Phase 1 — Investigation
+  features = investigateProject(project_path)
+    // explore directory tree, identify discrete features
+    // collect relevant files per feature
+  if features is empty:
+    return StandardError("No identifiable features found in project")
+
+  // Phase 2 — Checklist (written to /tmp, not inside the project)
+  checklist_path = "/tmp/init-checklist.md"
+  writeChecklist(checklist_path, features)
+    // write [ ] per feature + associated file list
+
+  // Phase 3 — Documentation Swarm (parallel)
+  doc_paths = []
+  for each feature in features (run in parallel):
+    doc_path = spawnDocumentationAgent(feature, project_path)
+      // agent uses investigate skill + documentation skill
+      // writes docs/docs/<feature-name>.md inside project_path
+    if doc_path succeeded:
+      updateChecklist(checklist_path, feature, done=true)
+      doc_paths.append(doc_path)
+
+  // Phase 4 — Detect-Drift Loop
+  loop:
+    report = runDetectDrift(doc_paths)
+      // calls agents/documentation/skills/detect-drift/SKILL.md
+      // audits all docs in doc_paths against actual code
+    if report.has_drift == false:
+      break
+    for each affected_doc in report.affected_docs:
+      feature = featureForDoc(affected_doc)
+      spawnDocumentationAgent(feature, project_path)
+        // re-generates the affected doc in-place
+
+  // Phase 5 — Cleanup
+  delete(checklist_path)
+
+  return { feature_doc_paths: doc_paths }
+```
+
+---
+
+### Flow: `investigate-project`
+- Test files: N/A
+- Core files: `agents/initialization/agents/init-docs-agent.md`
+
+#### Types
+
+```txt
+InvestigateInput {
+  project_path: string (absolute path to the project directory)
+}
+
+InvestigateOutput {
+  features: FeatureItem[] (list of identified features with associated files)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `investigate-project.success` | `InvestigateInput` | `InvestigateOutput` | `happy path` | One or more features found; each has at least one associated file | |
+| `investigate-project.no-features` | `InvestigateInput` | `InvestigateOutput { features: [] }` | `error` | Project is empty or structure is unrecognisable; caller handles this as fatal | |
+
+#### Pseudocode
+
+```
+function investigateProject(project_path):
+  // Walk directory tree; use investigation heuristics to identify discrete subsystems
+  // Group related files under a named feature
+  // Return list of FeatureItem with status = "pending"
+```
+
+---
+
+### Flow: `spawn-documentation-agent`
+- Test files: N/A
+- Core files: `agents/initialization/agents/init-docs-agent.md`, `agents/documentation/skills/investigate/SKILL.md`, `agents/documentation/skills/documentation/SKILL.md`
+
+#### Types
+
+```txt
+DocAgentInput {
+  feature: FeatureItem
+  project_path: string
+}
+
+DocAgentOutput {
+  doc_path: string (absolute path to the written docs/docs/<feature-name>.md)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `spawn-documentation-agent.success` | `DocAgentInput` | `DocAgentOutput` | `happy path` | Documentation written; file exists at doc_path | |
+| `spawn-documentation-agent.failure` | `DocAgentInput` | `StandardError` | `error` | Agent fails or produces no output; orchestrator marks this feature's checklist item as failed and continues | |
+
+#### Pseudocode
+
+```
+function spawnDocumentationAgent(feature, project_path):
+  // Subagent runs in parallel with other documentation agents
+  // Step 1: run investigate skill on feature.files to deepen context
+  // Step 2: run documentation skill to write docs/docs/<feature.name>.md
+  // Step 3: return absolute path of written doc
+```
+
+---
+
+### Flow: `detect-drift-loop`
+- Test files: N/A
+- Core files: `agents/initialization/agents/init-docs-agent.md`, `agents/documentation/skills/detect-drift/SKILL.md`
+
+#### Types
+
+```txt
+DetectDriftLoopInput {
+  doc_paths: string[] (paths to all generated feature docs to audit)
+}
+
+DetectDriftLoopOutput {
+  verified_doc_paths: string[] (paths to docs that passed drift check)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `detect-drift-loop.clean` | `DetectDriftLoopInput` | `DetectDriftLoopOutput` | `happy path` | First detect-drift pass finds no drift; loop exits immediately | |
+| `detect-drift-loop.fixed-on-retry` | `DetectDriftLoopInput` | `DetectDriftLoopOutput` | `happy path` | Drift found on first pass; affected docs re-generated; second pass finds no drift | |
+| `detect-drift-loop.persistent-drift` | `DetectDriftLoopInput` | `DetectDriftLoopOutput (partial)` | `error` | Drift in a doc cannot be resolved after re-generation (e.g. underlying code is ambiguous); orchestrator logs the unresolved doc and excludes it from output | |
+
+#### Pseudocode
+
+```
+function detectDriftLoop(doc_paths):
+  loop:
+    report = runDetectDrift(doc_paths)
+      // calls detect-drift skill
+      // report.has_drift: boolean
+      // report.affected_docs: string[] of doc paths with drift
+    if not report.has_drift:
+      return { verified_doc_paths: doc_paths }
+    for each doc in report.affected_docs:
+      feature = featureForDoc(doc)
+      spawnDocumentationAgent(feature, project_path)
+        // re-generates the affected doc in-place
+  // (loop continues until no drift is reported)
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| init-docs-orchestrator | local stdout (no persistent log target — agent-only execution) |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deploy step — agent file is invoked directly by the Claude Code harness
+  ```
+- Notes: The agent file at `agents/initialization/agents/init-docs-agent.md` is replaced in-place. No infrastructure changes required.
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Handoff to Related Plan Reconciliation
+
+After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans.


### PR DESCRIPTION
## Description

Implements the dark factory initialization system — a set of agents and a shell script that onboard any project to the dark factory workflow.

**What was planned:** Per `docs/plans/2026-04-25-init-dark-factory.md`, the system consists of three components working in sequence:
1. `init.sh` — shell script that sets up the canonical `<name>/<name>/` directory structure, either by cloning a GitHub repo or moving existing project files.
2. `init-docs-agent` — orchestrator agent that explores the project and generates a `CLAUDE.md` with codebase documentation.
3. `init-orchestrator-agent` — top-level agent that sequences the above, then invokes `pr-agent` to open a PR titled "init: dark factory".

**What changed:**
- `agents/initialization/scripts/init.sh` — new shell script implementing clone and move cases for directory setup
- `agents/initialization/agents/init-docs-agent.md` — new documentation orchestrator agent for CLAUDE.md generation
- `agents/initialization/agents/init-orchestrator-agent.md` — new top-level orchestrator that sequences init.sh → init-docs-agent → pr-agent
- `docs/plans/2026-04-25-init-dark-factory.md` — approved plan for this system
- `docs/plans/2026-04-25-init-docs-agent.md` — approved plan for the docs agent
- `CLAUDE.md` — updated agent table to include `init-orchestrator-agent` entry
- `agents/featurework/planning/templates/plan-template.md` — updated template structure

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)