### PR TITLE
fix(pr-agent): use --body-file to avoid parser abort

### DIFF
--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -51,6 +51,7 @@ If neither is provided, look at the git diff and any relevant `docs/bugs/` or `d
 - The fix is already applied to the working tree when you are spawned. Do not re-apply it.
 - Always stage with `git add --all` before committing — never stage individual files, so nothing is missed.
 - Always use `flows/pr/templates/pr-template.md` as the PR body structure. Never free-form the body.
+- Always write the PR body to `/tmp/pr-body.md` and open the PR with `gh pr create --body-file /tmp/pr-body.md`. Never use `--body` with inline content — large bodies cause a "Parser aborted" interactive prompt.
 - Do not merge if CI is failing (unless the only failures are credits/quota exhaustion).
 - Do not merge if there are unresolved review threads.
 - When addressing CI failures or review comments, push additional commits to the same branch — do not open a new PR.

--- a/agents/pr/skills/create-pr/SKILL.md
+++ b/agents/pr/skills/create-pr/SKILL.md
@@ -24,7 +24,12 @@ Open a pull request on GitHub and manage it through to merge.
 3. Push the branch and open the PR:
    ```bash
    git push -u origin HEAD
-   gh pr create --title "<type>(<scope>): <description>" --body "<description>"
+   # Always write the body to a temp file — never pass it inline with --body.
+   # Inline bodies fail with "Parser aborted" when the content is large.
+   cat > /tmp/pr-body.md << 'EOF'
+   <body content here>
+   EOF
+   gh pr create --title "<type>(<scope>): <description>" --body-file /tmp/pr-body.md
    ```
 
 ## PR Title Format


### PR DESCRIPTION
## Summary

- Always write the PR body to a temp file and use `gh pr create --body-file` instead of `--body`.
- Inline `--body` with large content (e.g. full plan files) triggers a "Parser aborted" interactive prompt in gh CLI.

## Test plan

- [ ] Manual — open a PR with a large body and confirm no interactive prompt appears.

Generated with [Claude Code](https://claude.ai/claude-code)
