### PR TITLE
chore(agents): standardize headers across all agents and skills

### DIFF
--- a/agents/code-review/agents/code-review-orchestrator-agent.md
+++ b/agents/code-review/agents/code-review-orchestrator-agent.md
@@ -1,9 +1,13 @@
 ---
 name: code-review-orchestrator-agent
-user-invocable: true
+user-invocable: false
 description: Orchestrates automated code review by spawning high-level and low-level reviewers in parallel, then running the resolver in a loop until all issues are resolved.
 tools: Read, Write, Edit, Bash, Agent
 model: sonnet
+allowed-tools:
+  - Bash(cat > tmp/issues.md)
+  - Bash(rm tmp/issues.md)
+  - Bash(mkdir -p tmp)
 ---
 
 You are the code-review-orchestrator-agent. Your job is to orchestrate the full code review loop: spawn two parallel reviewers, collect issues, then run the resolver until the issue list is clean.

--- a/agents/code-review/agents/high-level-review-agent.md
+++ b/agents/code-review/agents/high-level-review-agent.md
@@ -4,6 +4,7 @@ user-invocable: false
 description: Reviews code against a plan file for structural and architectural conformance. Appends high-level IssueItems to tmp/issues.md.
 tools: Read, Write, Edit, Bash, Glob
 model: sonnet
+allowed-tools: Bash(git diff *), Bash(grep -r *), Bash(find *)
 ---
 
 You are the high-level-review-agent. Your job is to review code against an approved plan and identify structural or architectural divergences. You append each finding as an unchecked item to `tmp/issues.md`.

--- a/agents/code-review/agents/low-level-review-agent.md
+++ b/agents/code-review/agents/low-level-review-agent.md
@@ -4,6 +4,7 @@ user-invocable: false
 description: Reviews code at the function level for bugs, untested paths, inter-agent conflicts, and refactor opportunities. Appends low-level IssueItems to tmp/issues.md.
 tools: Read, Write, Edit, Bash, Glob
 model: sonnet
+allowed-tools: Bash(grep -r *), Bash(git diff *), Bash(find *)
 ---
 
 You are the low-level-review-agent. Your job is to read all source files under the given code path and find function-level issues. You append each finding as an unchecked item to `tmp/issues.md`.

--- a/agents/code-review/agents/resolver-agent.md
+++ b/agents/code-review/agents/resolver-agent.md
@@ -4,6 +4,7 @@ user-invocable: false
 description: Reads tmp/issues.md, applies fixes for each unchecked item, checks them off, and returns whether any items remain unresolved.
 tools: Read, Write, Edit, Bash, Glob
 model: sonnet
+allowed-tools: Bash(grep -r *), Bash(find *), Bash(bash *)
 ---
 
 You are the resolver-agent. Your job is to read `tmp/issues.md`, work through every unchecked item, apply the appropriate fix, and check each item off. You return whether any items remain after your pass.

--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -4,6 +4,8 @@ user-invocable: true
 description: Top-level dark-factory orchestrator. Preps an isolated work dir, routes to the right worker agent (feature/debug/fix-flow), runs code review and doc housekeeping, opens a PR, then removes the work dir.
 tools: Read, Bash, Agent
 model: sonnet
+scripts: agents/dark-factory/scripts/prep-feature-dir.sh
+allowed-tools: Bash(bash agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(rm -rf dark_factory-*), Bash(cd *)
 ---
 
 You are the dark-factory-agent. Your job is to orchestrate an entire unit of work end-to-end: isolate it in a fresh working directory, delegate to the right worker, review the result, keep docs current, ship a PR, and clean up. You do not write code or modify files yourself — you delegate entirely.

--- a/agents/debugger/agents/debugger-agent.md
+++ b/agents/debugger/agents/debugger-agent.md
@@ -2,6 +2,10 @@
 name: debugger-agent
 user-invocable: false
 description: Runs systematic debugging on a non-obvious bug by following the debug skill checklist step by step.
+tools: Read, Write, Edit, Bash, Glob, Agent
+model: sonnet
+skills: systematic-debugging
+allowed-tools: Bash(bash *), Bash(pytest *), Bash(python *), Bash(npm test *), Bash(grep -r *), Bash(find *)
 ---
 
 You are a systematic debugger. Your only job is to follow the steps in `flows/debugger/skills/debug/SKILL.md` in order, without skipping.

--- a/agents/documentation/agents/detect-drift-agent.md
+++ b/agents/documentation/agents/detect-drift-agent.md
@@ -4,6 +4,8 @@ user-invocable: false
 description: Audits parity between docs/docs/ system documentation and actual code. Detects stale references, undocumented flows, and broken claims. Fixes straightforward drift in place and reports findings.
 tools: Read, Grep, Glob, Bash, Write, Edit
 model: sonnet
+skills: detect-drift
+allowed-tools: Bash(python agents/documentation/skills/detect-drift/scripts/*), Bash(find *), Bash(grep -r *)
 ---
 
 # detect-drift-agent

--- a/agents/documentation/agents/investigation-agent.md
+++ b/agents/documentation/agents/investigation-agent.md
@@ -4,6 +4,8 @@ user-invocable: false
 description: General-purpose investigation agent. Given a system or topic, explores the codebase, validates or creates authoritative docs, and returns the paths to what was written.
 tools: Read, Grep, Glob, Bash, Write, Edit
 model: sonnet
+skills: investigate, documentation
+allowed-tools: Bash(find *), Bash(grep -r *), Bash(ls *)
 ---
 
 You are the investigation-agent. Your job is to investigate a system and produce accurate documentation. You do not fix code, run flows, or open PRs. You only read, document, and return file paths.

--- a/agents/documentation/agents/update-documentation-agent.md
+++ b/agents/documentation/agents/update-documentation-agent.md
@@ -4,6 +4,8 @@ user-invocable: false
 description: Updates docs/ based on an implemented plan. Given a plan path, identifies affected flows and docs, then deletes stale content, updates modified sections, and adds new information.
 tools: Read, Grep, Glob, Bash, Write, Edit
 model: sonnet
+skills: documentation
+allowed-tools: Bash(find *), Bash(grep -r *), Bash(ls *)
 ---
 
 # update-documentation-agent

--- a/agents/documentation/skills/detect-drift/SKILL.md
+++ b/agents/documentation/skills/detect-drift/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: detect-drift
+user-invocable: false
 description: Audit parity between docs/docs/ system documentation and actual implementation. Detects stale references, undocumented flows, and broken behavioral claims. Use when validating whether documented systems match implemented code.
 ---
 

--- a/agents/featurework/agents/feature-agent.md
+++ b/agents/featurework/agents/feature-agent.md
@@ -1,9 +1,10 @@
 ---
 name: feature-agent
-user-invocable: true
+user-invocable: false
 description: End-to-end feature orchestrator. Calls planning-agent, gates on human approval (with feedback-and-retry), then calls execution-agent. The approval gate lives here — neither planning-agent nor execution-agent are modified.
 tools: Read, Bash, Agent
 model: sonnet
+allowed-tools: Bash(find *), Bash(grep -r *)
 ---
 
 You are the feature-agent. Your job is to orchestrate end-to-end feature work by sequencing the planning-agent and execution-agent with a human approval gate in between. You do not write code, modify plans, or open PRs yourself — you delegate.

--- a/agents/featurework/execution/agents/execution-agent.md
+++ b/agents/featurework/execution/agents/execution-agent.md
@@ -1,6 +1,6 @@
 ---
 name: execution-agent
-user-invocable: true
+user-invocable: false
 description: Orchestrates end-to-end execution of an approved plan file. Spawns skeleton-agent, testing-agent, and implementation-agent in sequence. Enters planning mode if a hard-stop deviation is triggered.
 tools: Read, Write, Edit, Bash, Agent
 allowed-tools: Bash(rm tmp/files-checklist.md), Bash(rm tmp/flows-checklist.md)

--- a/agents/featurework/execution/agents/implementation-agent.md
+++ b/agents/featurework/execution/agents/implementation-agent.md
@@ -5,6 +5,7 @@ description: Phase 3 of plan execution. Implements each flow from the flows chec
 tools: Read, Write, Edit, Bash, Glob, Agent
 skills: deviation-protocol
 model: sonnet
+allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(bash *), Bash(mkdir -p *), Bash(find *), Bash(grep -r *)
 ---
 
 You are the implementation-agent. Your job is Phase 3 of plan execution: implement each flow from the flows checklist one at a time, run its tests, and confirm they pass before moving on.

--- a/agents/featurework/execution/agents/skeleton-agent.md
+++ b/agents/featurework/execution/agents/skeleton-agent.md
@@ -3,7 +3,8 @@ name: skeleton-agent
 user-invocable: false
 description: Phase 1 of plan execution. Reads a plan file, builds a files checklist, and creates all skeleton files (correct structure, no implementation logic). Returns when the checklist is fully checked off.
 tools: Read, Write, Edit, Bash, Glob
-model: sonnet
+model: haiku
+allowed-tools: Bash(mkdir -p *), Bash(touch *), Bash(find *)
 ---
 
 You are the skeleton-agent. Your job is Phase 1 of plan execution: read the plan, identify every file that needs to exist, and create them all as skeletons with no implementation logic.

--- a/agents/featurework/execution/agents/testing-agent.md
+++ b/agents/featurework/execution/agents/testing-agent.md
@@ -3,7 +3,8 @@ name: testing-agent
 user-invocable: false
 description: Phase 2 of plan execution. Reads a plan file, builds a flows checklist, and writes one failing test per flow path. Confirms all new tests fail before returning.
 tools: Read, Write, Edit, Bash, Glob
-model: sonnet
+model: haiku
+allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(bash *), Bash(find *)
 ---
 
 You are the testing-agent. Your job is Phase 2 of plan execution: read every flow in the plan, write tests for each path row, and confirm all new tests fail before returning.

--- a/agents/featurework/planning/agents/planning-agent.md
+++ b/agents/featurework/planning/agents/planning-agent.md
@@ -5,6 +5,7 @@ description: High-level planning agent. Works with the user to design architectu
 tools: Read, Grep, Glob, Bash, Write, Edit, Agent
 skills: create-mermaid-diagram
 model: sonnet
+allowed-tools: Bash(find *), Bash(grep -r *), Bash(ls *)
 ---
 
 You are the planning-agent. Your job is to work with the user at a high level to produce an architecture plan before implementation begins. You do not write code, fix bugs, or open PRs. You only plan.

--- a/agents/fix-flow/agents/debug-flow-agent.md
+++ b/agents/fix-flow/agents/debug-flow-agent.md
@@ -2,8 +2,10 @@
 name: debug-flow-agent
 user-invocable: false
 description: Runs an integration flow, waits for it to finish, fetches logs, and hands off to debugger-agent for the fix. Use when an integration flow needs to be triggered and debugged. Returns a bug explanation and code fix — does not create PRs or deploy.
-tools: Read, Write, Edit, Bash, Grep, Glob
+tools: Read, Write, Edit, Bash, Grep, Glob, Agent
 model: sonnet
+scripts: trigger.sh, wait-for-completion.sh, fetch-logs.sh
+allowed-tools: Bash(bash trigger.sh), Bash(bash wait-for-completion.sh), Bash(bash fetch-logs.sh)
 ---
 
 You are the debug-flow-agent. Your job is to run the flow, wait for it to finish, and fetch the logs. You do not debug, create PRs, or deploy. Once you have the logs, you hand off to debugger-agent to do the actual debugging.

--- a/agents/fix-flow/agents/fix-flow-orchestrator.md
+++ b/agents/fix-flow/agents/fix-flow-orchestrator.md
@@ -4,6 +4,7 @@ user-invocable: false
 description: Autonomously drives a failing integration flow to green. Given a required flow name argument, it understands the system, generates test/log/deploy scripts, then loops: trigger → debug → PR → deploy until the flow passes. Use when you want to fix a broken integration flow end-to-end without manual iteration.
 tools: Read, Bash
 model: sonnet
+allowed-tools: Bash(find *), Bash(grep -r *)
 ---
 
 # fix-flow-orchestrator

--- a/agents/fix-flow/agents/ralph-fix-and-push.md
+++ b/agents/fix-flow/agents/ralph-fix-and-push.md
@@ -1,9 +1,10 @@
 ---
 name: ralph-fix-and-push
 description: Owns the bug-fixing loop for fix-flow-orchestrator. Spawns debugger-agent and pr-agent repeatedly until the integration flow passes green. Use after setup-wizard has generated the scripts.
-tools: Read, Bash
+tools: Read, Bash, Agent
 model: sonnet
 user-invocable: false
+allowed-tools: Bash(bash *), Bash(find *)
 ---
 
 You are ralph-fix-and-push. You own the fix loop. Your job is to keep iterating — trigger the flow, debug failures, ship fixes as PRs — until the flow passes green.

--- a/agents/fix-flow/agents/setup-wizard.md
+++ b/agents/fix-flow/agents/setup-wizard.md
@@ -4,6 +4,11 @@ description: Generates the scripts needed to trigger, monitor, and fetch logs fo
 tools: Read, Write, Bash
 model: sonnet
 user-invocable: false
+skills: generate-trigger, generate-wait-for-completion, generate-fetch-logs, generate-deploy
+allowed-tools:
+  - Bash(chmod +x *)
+  - Bash(bash *)
+  - Bash(find *)
 ---
 
 You are the setup-wizard for fix-flow-orchestrator. Your job is to read the system document and generate the scripts the ralph-fix-and-push needs. You do not run the flow. You only generate scripts.

--- a/agents/initialization/agents/init-docs-agent.md
+++ b/agents/initialization/agents/init-docs-agent.md
@@ -4,6 +4,7 @@ user-invocable: false
 description: Explores a newly initialized project and generates a CLAUDE.md at its root. Called after init.sh sets up the project structure.
 tools: Read, Grep, Glob, Bash, Write
 model: sonnet
+allowed-tools: Bash(ls *), Bash(find *), Bash(cat *), Bash(grep -r *)
 ---
 
 You are the init-docs-agent. Your job is to explore a project directory and produce a `CLAUDE.md` at its root that gives future Claude sessions an accurate mental model of the codebase.

--- a/agents/initialization/agents/init-orchestrator-agent.md
+++ b/agents/initialization/agents/init-orchestrator-agent.md
@@ -1,9 +1,11 @@
 ---
 name: init-orchestrator-agent
-user-invocable: true
+user-invocable: false
 description: Sets up a project to use dark factory. Runs init.sh, generates CLAUDE.md via init-docs-agent, then opens a PR titled "init: dark factory".
 tools: Bash, Agent
 model: sonnet
+scripts: agents/initialization/scripts/init.sh
+allowed-tools: Bash(bash agents/initialization/scripts/init.sh *), Bash(find *)
 ---
 
 You are the init-orchestrator-agent. Your job is to set up a project to use dark factory end-to-end.

--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -3,7 +3,8 @@ name: pr-agent
 user-invocable: false
 description: Manages the full PR lifecycle for a code fix. Opens a PR, waits for CI, addresses review comments, and auto-merges. Accepts a file path or description string as input for the PR body; falls back to looking at the changes.
 tools: Read, Bash, Write, Edit
-allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr comment *), Bash(gh pr merge *), Bash(gh pr review *), Bash(gh api graphql *), Bash(git push *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *)
+skills: create-pr
+allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr comment *), Bash(gh pr merge *), Bash(gh pr review *), Bash(gh api graphql *), Bash(git push *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *), Bash(gh pr create *), Bash(cat > /tmp/pr-body.md *), Bash(git status *), Bash(git log *)
 model: sonnet
 ---
 

--- a/agents/pr/agents/resolve-pr-issue.md
+++ b/agents/pr/agents/resolve-pr-issue.md
@@ -3,7 +3,7 @@ name: resolve-pr-issue
 description: Resolves a single PR issue — either a CI failure or an unresolved review thread. Reads the issue, applies a fix, pushes, and resolves the thread if applicable. Called by pr-agent.
 user-invocable: false
 tools: Read, Bash, Write, Edit
-allowed-tools: Bash(gh api graphql *), Bash(gh run view *), Bash(gh pr checks *), Bash(gh pr view *), Bash(git add *), Bash(git commit *), Bash(git push *)
+allowed-tools: Bash(gh api graphql *), Bash(gh run view *), Bash(gh pr checks *), Bash(gh pr view *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git status *), Bash(git log *), Bash(grep -r *), Bash(find *)
 model: sonnet
 ---
 


### PR DESCRIPTION
## Summary

Audited and updated YAML frontmatter on all 33 agent/skill files. Changes: set user-invocable:false on all sub-agents, added skills/scripts/allowed-tools fields so agents run without permission prompts, set model:haiku on skeleton-agent and testing-agent (deterministic steps), sonnet everywhere else.

## Test plan

- Review changed headers in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
