### PR TITLE
fix(plugin): update agent and skill paths

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dark-factory",
-  "description": "Reusable skills and agents for debugging, PR management, documentation, and fix flows.",
+  "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
   "version": "1.0.0",
   "author": {
     "name": "lewibs",
@@ -9,16 +9,23 @@
   "repository": "https://github.com/lewibs/dark-factory",
   "license": "MIT",
   "agents": [
-    "./flows/debugger/agents/",
-    "./flows/documentation/agents/",
-    "./flows/fix-flow/agents/",
-    "./flows/pr/agents/"
+    "./agents/dark-factory/agents/",
+    "./agents/code-review/agents/",
+    "./agents/debugger/agents/",
+    "./agents/documentation/agents/",
+    "./agents/featurework/agents/",
+    "./agents/featurework/execution/agents/",
+    "./agents/featurework/planning/agents/",
+    "./agents/fix-flow/agents/",
+    "./agents/initialization/agents/",
+    "./agents/pr/agents/"
   ],
   "skills": [
     "./skills/",
-    "./flows/debugger/skills/",
-    "./flows/documentation/skills/",
-    "./flows/fix-flow/skills/",
-    "./flows/pr/skills/"
+    "./agents/debugger/skills/",
+    "./agents/documentation/skills/",
+    "./agents/featurework/execution/skills/",
+    "./agents/fix-flow/skills/",
+    "./agents/pr/skills/"
   ]
 }


### PR DESCRIPTION
## fix(plugin): update agent and skill paths

Updated `.claude-plugin/plugin.json` to replace stale `./flows/` paths with the current `./agents/` directory structure.

### Changes
- Replaced all `./flows/debugger/`, `./flows/documentation/`, `./flows/fix-flow/`, and `./flows/pr/` agent/skill paths with their correct `./agents/` equivalents.
- Added newly introduced agent directories: `./agents/dark-factory/agents/`, `./agents/code-review/agents/`, `./agents/featurework/agents/`, `./agents/featurework/execution/agents/`, `./agents/featurework/planning/agents/`, and `./agents/initialization/agents/`.
- Added skill path `./agents/featurework/execution/skills/`.
- Updated plugin description to mention feature work alongside the existing capabilities.
