### PR TITLE
fix(init): make init-orchestrator-agent user-invocable

### DIFF
--- a/agents/initialization/agents/init-orchestrator-agent.md
+++ b/agents/initialization/agents/init-orchestrator-agent.md
@@ -1,6 +1,6 @@
 ---
 name: init-orchestrator-agent
-user-invocable: false
+user-invocable: true
 description: Sets up a project to use dark factory. Runs init.sh, generates CLAUDE.md via init-docs-agent, then opens a PR titled "init: dark factory".
 tools: Bash, Agent
 model: sonnet


### PR DESCRIPTION
## Summary

- Flipped `user-invocable` from `false` to `true` in `agents/initialization/agents/init-orchestrator-agent.md`
- This allows users to directly invoke the `init-orchestrator-agent` without needing another agent to call it on their behalf

## Test plan
- [ ] Verify `user-invocable: true` is set in the agent config
- [ ] Confirm the agent can be invoked directly by a user

🤖 Generated with [Claude Code](https://claude.com/claude-code)
