### PR TITLE
fix(agents): correct stale template paths

### DIFF
--- a/agents/featurework/planning/agents/planning-agent.md
+++ b/agents/featurework/planning/agents/planning-agent.md
@@ -23,7 +23,7 @@ Focus only on the system being built and the parts it directly touches. If somet
 
 1. Understand what the user wants to build. Ask clarifying questions until the scope is clear enough to diagram.
 2. If the system touches existing code you don't understand, invoke the `investigation-agent` to research it. Use its output as context.
-3. Create a new plan file in `docs/plans/<yyyy-mm-dd>-<what-it-updates>.md` using `templates/plan-template.md` as the scaffold.
+3. Create a new plan file in `docs/plans/<yyyy-mm-dd>-<what-it-updates>.md` using `agents/featurework/planning/templates/plan-template.md` as the scaffold.
 4. Walk the user through each stage in order. Do not advance to the next stage without explicit user approval.
 
 ## Stages

--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -22,7 +22,7 @@ If neither is provided, look at the git diff and any relevant `docs/bugs/` or `d
 
 ## Your task
 
-1. Build the PR body using `flows/pr/templates/pr-template.md`:
+1. Build the PR body using `agents/pr/templates/pr-template.md`:
    - **Description**: paste the full raw contents of the input file (or the matching `docs/bugs/` or `docs/plans/` file) verbatim into the Description section. Do not summarise, paraphrase, or abbreviate.
    - **Test Plan**: run the project's test suite. If tests exist and ran, paste the output. If no tests exist, omit the section entirely.
 2. Follow the instructions in `create-pr` to open the PR with the completed body.
@@ -51,7 +51,7 @@ If neither is provided, look at the git diff and any relevant `docs/bugs/` or `d
 
 - The fix is already applied to the working tree when you are spawned. Do not re-apply it.
 - Always stage with `git add --all` before committing — never stage individual files, so nothing is missed.
-- Always use `flows/pr/templates/pr-template.md` as the PR body structure. Never free-form the body.
+- Always use `agents/pr/templates/pr-template.md` as the PR body structure. Never free-form the body.
 - Always write the PR body to `/tmp/pr-body.md` and open the PR with `gh pr create --body-file /tmp/pr-body.md`. Never use `--body` with inline content — large bodies cause a "Parser aborted" interactive prompt.
 - Do not merge if CI is failing (unless the only failures are credits/quota exhaustion).
 - Do not merge if there are unresolved review threads.


### PR DESCRIPTION
## Summary

- `agents/pr/agents/pr-agent.md`: corrected template path from `flows/pr/templates/pr-template.md` to `agents/pr/templates/pr-template.md`
- `agents/featurework/planning/agents/planning-agent.md`: corrected template path from `templates/plan-template.md` to `agents/featurework/planning/templates/plan-template.md`

Both references were stale and pointed to paths that no longer exist after the directory restructuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
