### PR TITLE
fix(plugin): fix validation errors and add marketplace for local install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+"name": "dark-factory",
+  "owner": {
+    "name": "lewibs"
+  },
+  "plugins": [
+    {
+      "name": "dark-factory",
+      "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/lewibs/dark-factory.git"
+      }
+    }
+  ]
+}
+

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,18 +8,7 @@
   },
   "repository": "https://github.com/lewibs/dark-factory",
   "license": "MIT",
-  "agents": [
-    "./agents/dark-factory/agents/",
-    "./agents/code-review/agents/",
-    "./agents/debugger/agents/",
-    "./agents/documentation/agents/",
-    "./agents/featurework/agents/",
-    "./agents/featurework/execution/agents/",
-    "./agents/featurework/planning/agents/",
-    "./agents/fix-flow/agents/",
-    "./agents/initialization/agents/",
-    "./agents/pr/agents/"
-  ],
+  "commands": "./commands/",
   "skills": [
     "./skills/",
     "./agents/debugger/skills/",

--- a/agents/featurework/planning/agents/planning-agent.md
+++ b/agents/featurework/planning/agents/planning-agent.md
@@ -1,11 +1,11 @@
 ---
 name: planning-agent
 user-invocable: false
-description: High-level planning agent. Works with the user to design architecture for a new feature or system before any code is written. Produces a plan in docs/plans/ using staged gates: Mermaid diagram, black-box I/O contracts, acceptance criteria, and optional pseudocode.
+description: "High-level planning agent. Works with the user to design architecture for a new feature or system before any code is written. Produces a plan in docs/plans/ using staged gates: Mermaid diagram, black-box I/O contracts, acceptance criteria, and optional pseudocode."
 tools: Read, Grep, Glob, Bash, Write, Edit, Agent
 skills: create-mermaid-diagram
 model: sonnet
-allowed-tools: Bash(find *), Bash(grep -r *), Bash(ls *)
+allowed-tools: "Bash(find *), Bash(grep -r *), Bash(ls *)"
 ---
 
 You are the planning-agent. Your job is to work with the user at a high level to produce an architecture plan before implementation begins. You do not write code, fix bugs, or open PRs. You only plan.

--- a/agents/fix-flow/agents/fix-flow-orchestrator.md
+++ b/agents/fix-flow/agents/fix-flow-orchestrator.md
@@ -1,10 +1,10 @@
 ---
 name: fix-flow-orchestrator
 user-invocable: false
-description: Autonomously drives a failing integration flow to green. Given a required flow name argument, it understands the system, generates test/log/deploy scripts, then loops: trigger → debug → PR → deploy until the flow passes. Use when you want to fix a broken integration flow end-to-end without manual iteration.
+description: "Autonomously drives a failing integration flow to green. Generates test/log/deploy scripts, then loops: trigger, debug, PR, deploy until the flow passes."
 tools: Read, Bash
 model: sonnet
-allowed-tools: Bash(find *), Bash(grep -r *)
+allowed-tools: "Bash(find *), Bash(grep -r *)"
 ---
 
 # fix-flow-orchestrator

--- a/agents/initialization/agents/init-orchestrator-agent.md
+++ b/agents/initialization/agents/init-orchestrator-agent.md
@@ -1,11 +1,11 @@
 ---
 name: init-orchestrator-agent
 user-invocable: true
-description: Sets up a project to use dark factory. Runs init.sh, generates CLAUDE.md via init-docs-agent, then opens a PR titled "init: dark factory".
+description: 'Sets up a project to use dark factory. Runs init.sh, generates CLAUDE.md via init-docs-agent, then opens a PR titled "init: dark factory".'
 tools: Bash, Agent
 model: sonnet
 scripts: agents/initialization/scripts/init.sh
-allowed-tools: Bash(bash agents/initialization/scripts/init.sh *), Bash(find *)
+allowed-tools: "Bash(bash agents/initialization/scripts/init.sh *), Bash(find *)"
 ---
 
 You are the init-orchestrator-agent. Your job is to set up a project to use dark factory end-to-end.

--- a/agents/pr/skills/create-pr/SKILL.md
+++ b/agents/pr/skills/create-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pr
-description: Opens a pull request on GitHub using a fix already applied to the working tree. Provides all scripts needed to manage the full PR lifecycle: open, CI checks, comment resolution, and merge.
+description: "Opens a pull request on GitHub using a fix already applied to the working tree. Provides all scripts needed to manage the full PR lifecycle: open, CI checks, comment resolution, and merge."
 user-invocable: false
 ---
 

--- a/commands/dark-factory.md
+++ b/commands/dark-factory.md
@@ -1,0 +1,5 @@
+---
+description: "Top-level dark-factory orchestrator. Preps an isolated work dir, routes to the right worker agent (feature/debug/fix-flow), runs code review and doc housekeeping, opens a PR, then removes the work dir."
+---
+
+Follow the instructions in `agents/dark-factory/agents/dark-factory-agent.md` exactly.

--- a/commands/init.md
+++ b/commands/init.md
@@ -1,0 +1,5 @@
+---
+description: "Sets up a project to use dark factory. Run from the project root. Optionally pass a GitHub URL to clone and initialize a new repo."
+---
+
+Follow the instructions in `agents/initialization/agents/init-orchestrator-agent.md` exactly.

--- a/skills/logging/SKILL.md
+++ b/skills/logging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: logging
-description: Instruments code flows with structured logs. Given a plan/bug/doc file, adds a log statement at each step of every flow using the format: flow | step | data. Use when adding observability to a feature, debugging a flow, or setting up structured logging.
+description: "Instruments code flows with structured logs. Adds a log statement at each step of every flow using the format: flow | step | data."
 user-invocable: true
 ---
 


### PR DESCRIPTION
## Summary

- Removed `agents` array from `.claude-plugin/plugin.json` and pointed to `commands/` directory instead
- Created `.claude-plugin/marketplace.json` with correct format for local plugin install
- Added `commands/dark-factory.md` and `commands/init.md` as user-facing command entry points
- Fixed YAML parse errors caused by unquoted descriptions containing colons in:
  - `skills/logging/SKILL.md`
  - `agents/pr/skills/create-pr/SKILL.md`
  - `agents/initialization/agents/init-orchestrator-agent.md`
  - `agents/fix-flow/agents/fix-flow-orchestrator.md`
  - `agents/featurework/planning/agents/planning-agent.md`

These changes make the plugin installable via the Claude Code marketplace local install flow.
