### PR TITLE
feat(skills): add install skill

### DIFF
--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: install
+description: Install or update the dark-factory plugin in Claude Code.
+user-invocable: true
+---
+
+## Install (one-time)
+
+```bash
+# 1. Register the local repo as a marketplace
+claude plugin marketplace add /home/lewibs/github/dark_factory/dark_factory
+
+# 2. Install the plugin
+claude plugin install dark-factory
+```
+
+## Update (after pulling new changes)
+
+```bash
+git -C /home/lewibs/github/dark_factory/dark_factory pull
+claude plugin update dark-factory
+```
+
+## Verify
+
+```bash
+claude plugin list
+```
+
+## Available commands after install
+
+| Command | Description |
+|---|---|
+| `/dark-factory:dark-factory` | Full orchestration — feature, debug, or fix-flow end-to-end |
+| `/dark-factory:init` | Initialize a new project with dark factory |


### PR DESCRIPTION
## Summary

- Adds `skills/install/SKILL.md`, a user-invocable skill documenting how to install and update the dark-factory Claude Code plugin.
- Covers one-time install via `claude plugin marketplace add` + `claude plugin install`, update workflow after pulling, verification, and a table of available commands post-install.

## Test plan

- [ ] Invoke `/install` in a Claude Code session and verify the skill renders the correct install/update instructions.
- [ ] Follow the install steps in a clean environment and confirm `claude plugin list` shows `dark-factory`.

Generated with [Claude Code](https://claude.com/claude-code)
