### PR TITLE
feat(commands): add update command

### DIFF
--- a/commands/update.md
+++ b/commands/update.md
@@ -1,0 +1,5 @@
+---
+description: Update the dark-factory plugin to the latest version.
+---
+
+Follow the update instructions in `skills/install/SKILL.md`.

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: install-plugin
+description: Install or update the dark-factory plugin in Claude Code.
+user-invocable: true
+---
+
+## Install (one-time)
+
+```bash
+# 1. Register the local repo as a marketplace
+claude plugin marketplace add /home/lewibs/github/dark_factory/dark_factory
+
+# 2. Install the plugin
+claude plugin install dark-factory
+```
+
+## Update (after pulling new changes)
+
+```bash
+git -C /home/lewibs/github/dark_factory/dark_factory pull
+claude plugin update dark-factory
+```
+
+## Verify
+
+```bash
+claude plugin list
+```
+
+## Available commands after install
+
+| Command | Description |
+|---|---|
+| `/dark-factory:dark-factory` | Full orchestration — feature, debug, or fix-flow end-to-end |
+| `/dark-factory:init` | Initialize a new project with dark factory |


### PR DESCRIPTION
## Summary

- Adds `commands/update.md`: a user-invocable `/update` command that delegates to the install skill to update the dark factory plugin to the latest version.
- Adds `skills/install-plugin/SKILL.md`: the underlying install skill used by the update command.

## Test plan

- [ ] Run `/update` in a project and verify it triggers the install skill and updates the plugin without errors.
