### PR TITLE
fix(install): move install script to skills/install/

### DIFF
--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: true
 From anywhere inside the cloned repo:
 
 ```bash
-bash agents/initialization/scripts/install-plugin.sh
+bash skills/install/install-plugin.sh
 ```
 
 This script auto-detects the repo location — works for any user on any machine.

--- a/skills/install/install-plugin.sh
+++ b/skills/install/install-plugin.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Resolve the repo root (the directory containing this script's grandparent).
+# Resolve the repo root (two levels up from this script's directory).
 # Works regardless of where the repo was cloned.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 echo "Registering dark-factory marketplace from: $PLUGIN_ROOT"
 claude plugin marketplace add "$PLUGIN_ROOT"


### PR DESCRIPTION
## Summary

- Moved `install-plugin.sh` from `agents/initialization/scripts/` to `skills/install/` where it logically belongs alongside the install skill.
- Updated path reference in `skills/install/SKILL.md` to reflect the new location.

## Changes

- `agents/initialization/scripts/install-plugin.sh` — deleted (moved)
- `skills/install/install-plugin.sh` — added (same script, corrected path depth)
- `skills/install/SKILL.md` — updated path reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
