### PR TITLE
fix(install): use $(pwd) for marketplace add

### DIFF
--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: true
 ```bash
 git clone https://github.com/lewibs/dark-factory
 cd dark-factory
-claude plugin marketplace add .
+claude plugin marketplace add "$(pwd)"
 claude plugin install dark-factory
 ```
 


### PR DESCRIPTION
## Summary

- Fixed `claude plugin marketplace add .` to `claude plugin marketplace add "$(pwd)"` in `skills/install/SKILL.md`
- The Claude CLI requires an absolute path when adding a plugin via the marketplace; passing `.` (a relative path) fails at runtime
- Using `"$(pwd)"` ensures the correct absolute path is always passed regardless of the calling context

## Test plan
- [ ] Verify `claude plugin marketplace add "$(pwd)"` works from the skill's install directory
- [ ] Confirm the install documentation reflects the corrected command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
