### PR TITLE
feat(skill-update-agent): add skill-update-agent to dark-factory manufacture loop

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -31,6 +31,7 @@ All paths are relative to the inner project dir (`dark_factory/dark_factory/` fr
 | `code-review-orchestrator-agent` | `agents/code-review/agents/code-review-orchestrator-agent.md` |
 | `update-documentation-agent` | `agents/documentation/agents/update-documentation-agent.md` |
 | `detect-drift-agent` | `agents/documentation/agents/detect-drift-agent.md` |
+| `skill-update-agent` | `agents/skill-update/agents/skill-update-agent.md` |
 | `pr-agent` | `agents/pr/agents/pr-agent.md` |
 
 ## Orchestration
@@ -77,6 +78,16 @@ dark-factory-agent(taskDescription, taskName):
     run cleanup(WORK_DIR)
     STOP
 
+  # Step 4c — skill update (non-fatal)
+  try:
+    skillResult = invoke skill-update-agent with:
+      planFilePath = planFilePath
+      workDir      = WORK_DIR
+      taskSummary  = taskDescription
+    log "Skills written: " + skillResult.skillsWritten
+  catch error:
+    warn developer: "skill-update-agent failed: <error>. Continuing to PR."
+
   # Step 5 — PR
   invoke pr-agent with: planFilePath ?? taskDescription
 
@@ -89,7 +100,7 @@ dark-factory-agent(taskDescription, taskName):
   # Step 6 — cleanup
   cleanup(WORK_DIR)
 
-  Report: "Done. PR: <prUrl>. Work dir <WORK_DIR> removed."
+  Report: "Done. PR: <prUrl>. Work dir <WORK_DIR> removed. Skills written: <skillResult.skillsWritten>."
   STOP
 ```
 

--- a/agents/skill-update/agents/skill-update-agent.md
+++ b/agents/skill-update/agents/skill-update-agent.md
@@ -1,0 +1,103 @@
+---
+name: skill-update-agent
+user-invocable: false
+description: Reviews completed work, identifies non-obvious recurring patterns, and writes or updates skill files in the target project's skills/ directory so future manufacture runs benefit from that knowledge.
+tools: Read, Write, Edit, Bash
+model: sonnet
+---
+
+You are the skill-update-agent. Your job is to review the work that was just completed in a dark-factory manufacture run, identify non-obvious patterns or workarounds that were encountered, and — only when those patterns are likely to recur — write or update skill files in the target project's `skills/` directory.
+
+## Input
+
+You will be invoked with:
+- `planFilePath` — path to the approved plan file for the completed task, or `null`
+- `workDir` — absolute path to the isolated work dir
+- `taskSummary` — brief human-readable description of what was accomplished
+
+## Output
+
+```
+SkillUpdateOutput {
+  skillsWritten: SkillFile[]   (may be empty — agent wrote zero skills if nothing qualified)
+}
+```
+
+where:
+
+```
+SkillFile {
+  path:   string  (relative path within workDir, e.g. "skills/handle-git-conflicts/SKILL.md")
+  action: "created" | "updated"
+}
+```
+
+## Orchestration
+
+```
+skill-update-agent(planFilePath, workDir, taskSummary):
+
+  # Step 1 — gather context
+  if planFilePath is not null:
+    read planFilePath to understand what flows were built and why
+  run git diff HEAD~1 or git log --oneline -5 in workDir to see what changed
+
+  # Step 2 — identify candidate patterns
+  For each non-obvious thing encountered during the task
+  (detected by: comments like "NOTE", "WORKAROUND", "HACK", "non-obvious",
+   repeated lookups in the plan pseudocode, deviations that were resolved,
+   things the agent had to figure out that aren't documented anywhere):
+    add to candidatePatterns list
+
+  # Step 3 — recurrence filter
+  For each candidate in candidatePatterns:
+    Ask: "Is this specific to this one task, or would a future agent hit the same wall?"
+    If task-specific only (e.g. a one-off data migration quirk): discard
+    If general and likely to recur (e.g. "how to do X in this codebase"): keep
+
+  if filteredPatterns is empty:
+    return { skillsWritten: [] }
+
+  # Step 4 — write/update skill files
+  For each pattern in filteredPatterns:
+    slug = kebab-case name for the pattern (e.g. "handle-git-conflicts")
+    skillPath = "skills/<slug>/SKILL.md"
+
+    if skillPath already exists in workDir:
+      read existing skill, merge new knowledge, write updated file
+      record { path: skillPath, action: "updated" }
+    else:
+      write new SKILL.md using the skill template below
+      record { path: skillPath, action: "created" }
+
+  # Step 5 — return
+  return { skillsWritten: [recorded SkillFile entries] }
+```
+
+## Skill Template
+
+When creating a new skill file, use this format:
+
+```
+---
+name: <slug>
+description: "<one sentence: what this skill does and when to use it>"
+user-invocable: false
+---
+## When to use
+<condition that triggers this skill>
+
+## Steps
+<numbered steps describing what to do>
+
+## Notes
+<any caveats or gotchas>
+```
+
+## Rules
+
+- Only write a skill when a pattern is genuinely non-obvious AND likely to recur in future manufacture runs. Prefer returning an empty list over writing noise.
+- Never modify agent files, plan files, or any file outside `skills/` in `workDir`.
+- If you cannot read `planFilePath` or run `git` in `workDir`, report the error to the caller. This is non-fatal — the caller (dark-factory-agent) will log a warning and continue to the PR step.
+- A skill file path is always `skills/<slug>/SKILL.md` relative to `workDir`.
+- When updating an existing skill, preserve all existing content and merge new knowledge in — do not overwrite.

--- a/docs/plans/2026-04-25-skill-update-agent.md
+++ b/docs/plans/2026-04-25-skill-update-agent.md
@@ -1,0 +1,244 @@
+# skill-update-agent
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: `docs/plans/2026-04-25-dark-factory-agent.md`
+- Depends on: N/A
+- Status: `approved`
+
+Status semantics:
+- `draft`: Plan is being created or updated and is not final.
+- `approved`: Plan is approved but not yet applied in code.
+- `documentation`: Code currently exists and matches the plan contract.
+
+Update rule:
+- When an existing plan is edited, set status to `draft` until re-approved.
+
+## System Intent
+
+- What is being built: A `skill-update-agent` that runs near the end of the `dark-factory-agent` manufacture loop (after code review and doc updates, before the PR step). It reviews the work that was just completed, identifies any non-obvious patterns or workarounds that were encountered during the task, and — only when those patterns are likely to recur — writes or updates skill files in the target project's `skills/` directory so future manufacture runs benefit from that knowledge.
+- Primary consumer(s): `dark-factory-agent` (invokes it as Step 4c, between `detect-drift-agent` and `pr-agent`). Indirectly benefits future invocations of any agent that reads project skills.
+- Boundary (black-box scope only): Accepts the completed work context (plan file path, work dir, and a summary of what was done). Produces zero or more new/updated skill files in `<workDir>/skills/`. Returns a list of skills written (may be empty). Does not open PRs, does not modify agent files, does not edit plans.
+
+## Stage Gate Tracker
+
+- [ ] Stage 1 Mermaid approved
+- [ ] Stage 2 Flows approved
+- [ ] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  DAF["dark-factory-agent"]:::unchanged
+  CR["code-review-orchestrator-agent"]:::unchanged
+  DD["detect-drift-agent"]:::unchanged
+
+  subgraph SUA["skill-update-agent (system boundary)"]
+    SUA1["Step 1 — Read plan + git diff\nto understand what was done"]:::created
+    SUA2["Step 2 — Identify non-obvious patterns\n(was anything unclear or worked-around?)"]:::created
+    SUA3["Step 3 — Filter: will this recur?\n(low-signal patterns discarded)"]:::created
+    SUA4["Step 4 — Write or update skill files\nin skills/ (only if filter passes)"]:::created
+    SUA5["Step 5 — Return skills written\n(empty list is valid)"]:::created
+  end
+
+  PR["pr-agent"]:::unchanged
+  Skills["skills/ directory in workDir"]:::created
+
+  DAF -->|"planFilePath, workDir, taskSummary"| SUA1
+  CR -->|"code review complete"| DAF
+  DD -->|"drift report clean"| DAF
+  SUA1 -->|"context loaded"| SUA2
+  SUA2 -->|"candidate patterns"| SUA3
+  SUA3 -->|"patterns that pass recurrence filter"| SUA4
+  SUA4 -->|"skill files written"| Skills
+  SUA4 -->|"skillsWritten list"| SUA5
+  SUA5 -->|"skillsWritten: string[]"| DAF
+  DAF -->|"planFilePath"| PR
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Flows
+
+- Flow naming rule: ``### Flow: `<flowname>` ``
+- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+
+SkillFile {
+  path:    string  (relative path within workDir, e.g. "skills/handle-git-conflicts/SKILL.md")
+  action:  "created" | "updated"
+}
+```
+
+### Flow: `skillUpdateAgent`
+
+- Test files: N/A (agent instruction file, no automated tests)
+- Core files:
+  - `agents/skill-update/agents/skill-update-agent.md` (new — the agent instruction file)
+
+#### Types
+
+```txt
+SkillUpdateInput {
+  planFilePath:  string | null  (path to the approved plan file for the completed task, or null)
+  workDir:       string         (absolute path to the isolated work dir)
+  taskSummary:   string         (brief human-readable description of what was accomplished)
+}
+
+SkillUpdateOutput {
+  skillsWritten: SkillFile[]   (may be empty — agent wrote zero skills if nothing qualified)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `skillUpdateAgent.noSkillsNeeded` | `SkillUpdateInput` | `SkillUpdateOutput { skillsWritten: [] }` | happy path | Agent determines no non-obvious recurring patterns exist; returns empty list | |
+| `skillUpdateAgent.skillsWritten` | `SkillUpdateInput` | `SkillUpdateOutput` | happy path | One or more skill files written/updated in `skills/`; list returned | |
+| `skillUpdateAgent.readError` | `SkillUpdateInput` | `StandardError` | error | Cannot read plan file or git diff; agent reports error; dark-factory-agent surfaces it but continues to PR (non-fatal) | |
+
+#### Pseudocode
+
+```
+skill-update-agent(planFilePath, workDir, taskSummary):
+
+  # Step 1 — gather context
+  if planFilePath is not null:
+    read planFilePath to understand what flows were built and why
+  run git diff HEAD~1 or git log --oneline -5 in workDir to see what changed
+
+  # Step 2 — identify candidate patterns
+  For each non-obvious thing encountered during the task
+  (detected by: comments like "NOTE", "WORKAROUND", "HACK", "non-obvious",
+   repeated lookups in the plan pseudocode, deviations that were resolved,
+   things the agent had to figure out that aren't documented anywhere):
+    add to candidatePatterns list
+
+  # Step 3 — recurrence filter
+  For each candidate in candidatePatterns:
+    Ask: "Is this specific to this one task, or would a future agent hit the same wall?"
+    If task-specific only (e.g. a one-off data migration quirk): discard
+    If general and likely to recur (e.g. "how to do X in this codebase"): keep
+
+  if filteredPatterns is empty:
+    return { skillsWritten: [] }
+
+  # Step 4 — write/update skill files
+  For each pattern in filteredPatterns:
+    slug = kebab-case name for the pattern (e.g. "handle-git-conflicts")
+    skillPath = "skills/<slug>/SKILL.md"
+
+    if skillPath already exists in workDir:
+      read existing skill, merge new knowledge, write updated file
+    else:
+      write new SKILL.md using the skill template:
+        ---
+        name: <slug>
+        description: "<one sentence: what this skill does and when to use it>"
+        user-invocable: false
+        ---
+        ## When to use
+        <condition that triggers this skill>
+
+        ## Steps
+        <numbered steps describing what to do>
+
+        ## Notes
+        <any caveats or gotchas>
+
+    record { path: skillPath, action: "created" | "updated" }
+
+  # Step 5 — return
+  return { skillsWritten: [recorded SkillFile entries] }
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+---
+
+### Flow: `darkFactoryAgentIntegration`
+
+- Test files: N/A (orchestration change to existing agent)
+- Core files:
+  - `agents/dark-factory/agents/dark-factory-agent.md` (updated — adds Step 4c)
+
+#### Types
+
+```txt
+(reuses DarkFactoryInput / DarkFactoryOutput from parent plan)
+
+DarkFactoryOutput updated to include:
+DarkFactoryOutput {
+  prUrl:         string
+  merged:        true
+  workDir:       string
+  skillsWritten: SkillFile[]   (added — may be empty)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `darkFactoryAgentIntegration.noSkills` | `DarkFactoryInput` | `DarkFactoryOutput { skillsWritten: [] }` | happy path | skill-update-agent ran, found nothing, manufacture continues normally | |
+| `darkFactoryAgentIntegration.skillsAdded` | `DarkFactoryInput` | `DarkFactoryOutput` | happy path | skill-update-agent wrote skills; they are included in the PR diff | |
+| `darkFactoryAgentIntegration.skillUpdateError` | `DarkFactoryInput` | `DarkFactoryOutput` | error (non-fatal) | skill-update-agent errors; dark-factory-agent logs warning and continues to pr-agent | |
+
+#### Pseudocode
+
+```
+dark-factory-agent (updated step ordering):
+
+  # Steps 1–4b unchanged (prep, route, code-review, update-docs, detect-drift)
+
+  # Step 4c — NEW: skill update
+  try:
+    skillResult = invoke skill-update-agent with:
+      planFilePath = planFilePath
+      workDir      = workDir
+      taskSummary  = taskDescription
+    log "Skills written: " + skillResult.skillsWritten
+  catch error:
+    warn developer: "skill-update-agent failed: <error>. Continuing to PR."
+
+  # Step 5 — PR (unchanged; any new skill files are already staged in workDir)
+  prResult = openPR(planFilePath, taskDescription)
+  ...
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| skill-update-agent stdout | terminal / caller stdout |
+| dark-factory-agent (Step 4c) | terminal / caller stdout |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment step — agent is a markdown file checked into the repo.
+  # It is invoked automatically by dark-factory-agent as Step 4c.
+  ```
+- Notes: The skill-update-agent is non-fatal. If it errors, dark-factory-agent logs a warning and continues to the PR step. This ensures the manufacture loop is never blocked by skill-writing failures.
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Handoff to Related Plan Reconciliation
+
+After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans.


### PR DESCRIPTION
## Description

# skill-update-agent

## Plan Metadata

- Plan type: `plan`
- Parent plan: `docs/plans/2026-04-25-dark-factory-agent.md`
- Depends on: N/A
- Status: `approved`

## System Intent

- What is being built: A `skill-update-agent` that runs near the end of the `dark-factory-agent` manufacture loop (after code review and doc updates, before the PR step). It reviews the work that was just completed, identifies any non-obvious patterns or workarounds that were encountered during the task, and — only when those patterns are likely to recur — writes or updates skill files in the target project's `skills/` directory so future manufacture runs benefit from that knowledge.
- Primary consumer(s): `dark-factory-agent` (invokes it as Step 4c, between `detect-drift-agent` and `pr-agent`). Indirectly benefits future invocations of any agent that reads project skills.
- Boundary (black-box scope only): Accepts the completed work context (plan file path, work dir, and a summary of what was done). Produces zero or more new/updated skill files in `<workDir>/skills/`. Returns a list of skills written (may be empty). Does not open PRs, does not modify agent files, does not edit plans.

## Flows

### Flow: `skillUpdateAgent`

New agent file: `agents/skill-update/agents/skill-update-agent.md`

Reads plan + git diff, identifies non-obvious recurring patterns, applies recurrence filter, writes/updates `skills/<slug>/SKILL.md` files, returns `skillsWritten` list.

### Flow: `darkFactoryAgentIntegration`

Updated: `agents/dark-factory/agents/dark-factory-agent.md`

Adds Step 4c (skill-update-agent invocation) between detect-drift and PR steps. Non-fatal: if skill-update-agent errors, dark-factory-agent logs a warning and continues to PR.

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
