### PR TITLE
feat(planning-agent): auto-open plan file in VS Code after writing

### DIFF
--- a/agents/featurework/planning/agents/planning-agent.md
+++ b/agents/featurework/planning/agents/planning-agent.md
@@ -3,7 +3,7 @@ name: planning-agent
 user-invocable: false
 description: "High-level planning agent. Works with the user to design architecture for a new feature or system before any code is written. Produces a plan in docs/plans/ using staged gates: Mermaid diagram, black-box I/O contracts, acceptance criteria, and optional pseudocode."
 tools: Read, Grep, Glob, Bash, Write, Edit, Agent
-skills: create-mermaid-diagram
+skills: create-mermaid-diagram, open-in-vscode
 model: sonnet
 allowed-tools: "Bash(find *), Bash(grep -r *), Bash(ls *)"
 ---
@@ -44,3 +44,5 @@ Invoke the `investigation-agent` when you need to understand an existing system 
 ## Output
 
 Use the Write tool to save the plan directly to `docs/plans/<yyyy-mm-dd>-<what-it-updates>.md`. Do not return the plan content to the caller and expect them to save it — write the file yourself. Set status to `approved` after all stages pass and update the stage gate tracker.
+
+After writing the plan file, invoke the `open-in-vscode` skill with the absolute path to the plan file so the developer can review it immediately in their editor.

--- a/skills/open-in-vscode/SKILL.md
+++ b/skills/open-in-vscode/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: open-in-vscode
+description: "Opens a file in VS Code. Use after writing a plan file so the developer sees it immediately."
+user-invocable: false
+---
+
+# Open in VS Code
+
+Opens a file in the user's VS Code editor using the `code` CLI.
+
+## Usage
+
+Call this skill with the absolute path to the file you want to open.
+
+## Steps
+
+1. Run the following command, substituting `<file_path>` with the absolute path to the file:
+
+```bash
+code "<file_path>"
+```
+
+2. If the `code` command is not found (exit code 127), report to the caller:
+   > "VS Code CLI (`code`) is not available. The plan was written to `<file_path>`."
+   Do not treat this as a fatal error — the file was already written successfully.
+
+## Notes
+
+- This skill does not open a new VS Code window if one is already running; it reuses the existing instance.
+- Only use this after the file has been fully written to disk.


### PR DESCRIPTION
## Description

Add a new `open-in-vscode` skill that opens a file in VS Code using the `code` CLI, and update the `planning-agent` to use it after writing a plan file so developers see the plan immediately in their editor.

### Changes

**New skill: `skills/open-in-vscode/SKILL.md`**
- Accepts an absolute file path and runs `code "<file_path>"`
- Gracefully handles missing `code` CLI (exit 127) — reports the path without failing
- Only opens files after they are fully written to disk

**Updated: `agents/featurework/planning/agents/planning-agent.md`**
- Added `open-in-vscode` to the `skills:` frontmatter list
- Added instruction in the Output section to invoke `open-in-vscode` with the absolute path after writing the plan file

## Test Plan

No automated tests exist for skill/agent markdown files. Manual verification: invoke the planning-agent, approve a plan, and confirm VS Code opens the written plan file.

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
