### PR TITLE
feat(skill-update-agent): integrate skill-update-agent into dark-factory loop

### DIFF
--- a/agents/code-review/agents/code-review-orchestrator-agent.md
+++ b/agents/code-review/agents/code-review-orchestrator-agent.md
@@ -47,7 +47,7 @@ StandardError {
 3. Wait for both to complete.
    - If either returns an error: surface the error and halt. Do not start the resolver.
 4. Enter the resolver loop:
-   - Spawn `agents/code-review/agents/resolver-agent.md` with `issuesFilePath: "tmp/issues.md"`.
+   - Spawn `agents/code-review/agents/resolver-agent.md` with `issuesFilePath` set to the absolute path of `tmp/issues.md` (i.e. `<codePath>/tmp/issues.md`).
    - Wait for it to return.
    - If it returns an error: surface the error and halt.
    - If `anyRemaining` is false: exit the loop.

--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -82,12 +82,14 @@ dark-factory-agent(taskDescription, taskName):
     STOP
 
   # Step 4c — skill update (non-fatal)
+  skillsWritten = []
   try:
     skillResult = invoke skill-update-agent with:
       planFilePath = planFilePath
       workDir      = WORK_DIR
       taskSummary  = taskDescription
-    log "Skills written: " + skillResult.skillsWritten
+    skillsWritten = skillResult.skillsWritten
+    log "Skills written: " + skillsWritten
   catch error:
     warn developer: "skill-update-agent failed: <error>. Continuing to PR."
 
@@ -105,7 +107,7 @@ dark-factory-agent(taskDescription, taskName):
   cleanup(WORK_DIR)
   /clear
 
-  Report: "Done. PR: <prUrl>. Work dir <WORK_DIR> removed. Skills written: <skillResult.skillsWritten>."
+  Report: "Done. PR: <prUrl>. Work dir <WORK_DIR> removed. Skills written: <skillsWritten>."
   STOP
 ```
 

--- a/docs/docs/dark-factory-agent.md
+++ b/docs/docs/dark-factory-agent.md
@@ -1,0 +1,149 @@
+# dark-factory-agent
+
+## Metadata
+
+- System type: `agent`
+
+## System Intent
+
+- What this is: The top-level dark-factory orchestrator. It preps an isolated work directory, routes to the correct worker agent (feature/debug/fix-flow), runs code review and documentation housekeeping, invokes the skill-update-agent to capture recurring patterns, opens a PR, and removes the work directory. It does not write or modify code itself — it delegates entirely.
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  User["Developer"]
+  DAF["dark-factory-agent"]
+  Prep["prep-feature-dir.sh"]
+  Worker["Worker agent\n(feature / fix-flow / debugger)"]
+  CR["code-review-orchestrator-agent"]
+  Docs["update-documentation-agent"]
+  Drift["detect-drift-agent"]
+  SUA["skill-update-agent"]
+  PR["pr-agent"]
+  Skills["skills/ in workDir"]
+
+  User -->|"taskDescription, taskName"| DAF
+  DAF -->|"taskName"| Prep
+  Prep -->|"WORK_DIR"| DAF
+  DAF -->|"taskDescription"| Worker
+  Worker -->|"planFilePath"| DAF
+  DAF --> CR
+  DAF --> Docs
+  DAF --> Drift
+  DAF -->|"planFilePath, workDir, taskSummary"| SUA
+  SUA -->|"skillsWritten"| DAF
+  SUA --> Skills
+  DAF --> PR
+  PR -->|"prUrl"| DAF
+  DAF -->|"prUrl, skillsWritten"| User
+```
+
+## Flows
+
+### Flow: `darkFactoryAgentOrchestration`
+
+- Test files: N/A (agent instruction file, no automated tests)
+- Core files:
+  - `agents/dark-factory/agents/dark-factory-agent.md`
+  - `agents/dark-factory/scripts/prep-feature-dir.sh`
+
+#### Types
+
+```txt
+DarkFactoryInput {
+  taskDescription: string  (verbatim user request)
+  taskName:        string  (optional — short slug; derived from taskDescription if omitted)
+}
+
+DarkFactoryOutput {
+  prUrl:         string
+  merged:        true
+  workDir:       string
+  skillsWritten: SkillFile[]   (may be empty)
+}
+
+SkillFile {
+  path:    string  (relative path within workDir)
+  action:  "created" | "updated"
+}
+
+StandardError {
+  message: string
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `darkFactoryAgent.success` | `DarkFactoryInput` | `DarkFactoryOutput` | happy path | Full manufacture loop completes; PR merged; work dir removed |
+| `darkFactoryAgent.noSkills` | `DarkFactoryInput` | `DarkFactoryOutput { skillsWritten: [] }` | happy path | skill-update-agent ran, found nothing; manufacture continues normally |
+| `darkFactoryAgent.skillsAdded` | `DarkFactoryInput` | `DarkFactoryOutput` | happy path | skill-update-agent wrote skills; they are included in the PR diff |
+| `darkFactoryAgent.prepFailure` | `DarkFactoryInput` | `StandardError` | error | prep-feature-dir.sh fails; agent stops immediately (no cleanup needed) |
+| `darkFactoryAgent.workerError` | `DarkFactoryInput` | `StandardError` | error | Worker agent errors; cleanup runs; agent stops |
+| `darkFactoryAgent.codeReviewError` | `DarkFactoryInput` | `StandardError` | error | Code review errors; cleanup runs; agent stops |
+| `darkFactoryAgent.driftUnresolved` | `DarkFactoryInput` | `StandardError` | error | detect-drift-agent surfaces items requiring developer input; cleanup runs; agent stops |
+| `darkFactoryAgent.skillUpdateError` | `DarkFactoryInput` | `DarkFactoryOutput` | error (non-fatal) | skill-update-agent errors; dark-factory-agent logs warning and continues to pr-agent |
+| `darkFactoryAgent.prError` | `DarkFactoryInput` | `StandardError` | error | pr-agent errors or cannot merge; cleanup runs; agent stops |
+
+#### Pseudocode
+
+```
+dark-factory-agent(taskDescription, taskName):
+
+  # Step 1 — prep isolated work dir
+  bash agents/dark-factory/scripts/prep-feature-dir.sh <taskName>
+  Capture WORK_DIR from stdout
+  If script fails: report error and STOP
+
+  # Step 2 — route to worker agent
+  cd into WORK_DIR
+  Classify taskDescription and invoke the appropriate worker
+  If worker errors: cleanup(WORK_DIR), /clear, report error, STOP
+  planFilePath = path the worker wrote its plan to (null if no plan produced)
+
+  # Step 3 — code review
+  invoke code-review-orchestrator-agent with planFilePath, WORK_DIR
+  If error: cleanup(WORK_DIR), /clear, report error, STOP
+
+  # Step 4 — update docs and detect drift
+  invoke update-documentation-agent with planFilePath
+  invoke detect-drift-agent scoped to WORK_DIR/docs/docs/
+  If detect-drift-agent surfaces unresolvable items:
+    report to developer, cleanup(WORK_DIR), /clear, STOP
+
+  # Step 4c — skill update (non-fatal)
+  try:
+    skillResult = invoke skill-update-agent with planFilePath, workDir, taskSummary=taskDescription
+    skillsWritten = skillResult.skillsWritten
+    log "Skills written: " + skillsWritten
+  catch error:
+    warn developer: "skill-update-agent failed: <error>. Continuing to PR."
+
+  # Step 5 — PR
+  invoke pr-agent with planFilePath ?? taskDescription
+  If pr-agent errors or cannot merge: cleanup(WORK_DIR), /clear, report error, STOP
+  prUrl = result from pr-agent
+
+  # Step 6 — cleanup
+  cleanup(WORK_DIR)
+  /clear
+  Report: "Done. PR: <prUrl>. Work dir <WORK_DIR> removed. Skills written: <skillsWritten>."
+```
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| dark-factory-agent stdout | terminal / caller stdout |
+| skill-update-agent (Step 4c) | terminal / caller stdout |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment step — agent is a markdown file checked into the repo.
+  ```
+- Notes: All steps except Step 4c (skill-update-agent) are fatal on error — they trigger cleanup and halt. Step 4c is non-fatal: errors are logged as warnings and the loop continues to the PR step.

--- a/docs/docs/skill-update-agent.md
+++ b/docs/docs/skill-update-agent.md
@@ -1,0 +1,129 @@
+# skill-update-agent
+
+## Metadata
+
+- System type: `agent`
+
+## System Intent
+
+- What this is: An agent that runs near the end of the `dark-factory-agent` manufacture loop (after code review and doc updates, before the PR step). It reviews the work that was just completed, identifies non-obvious patterns or workarounds encountered during the task, and — only when those patterns are likely to recur — writes or updates skill files in the target project's `skills/` directory so future manufacture runs benefit from that knowledge. It is non-fatal: if it errors, the manufacture loop continues to the PR step.
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  DAF["dark-factory-agent"]
+  subgraph SUA["skill-update-agent"]
+    SUA1["Step 1 — Read plan + git diff"]
+    SUA2["Step 2 — Identify non-obvious patterns"]
+    SUA3["Step 3 — Recurrence filter"]
+    SUA4["Step 4 — Write or update skill files"]
+    SUA5["Step 5 — Return skills written"]
+  end
+  Skills["skills/ directory in workDir"]
+
+  DAF -->|"planFilePath, workDir, taskSummary"| SUA1
+  SUA1 --> SUA2
+  SUA2 --> SUA3
+  SUA3 --> SUA4
+  SUA4 --> Skills
+  SUA4 --> SUA5
+  SUA5 -->|"skillsWritten: SkillFile[]"| DAF
+```
+
+## Flows
+
+### Flow: `skillUpdateAgent`
+
+- Test files: N/A (agent instruction file, no automated tests)
+- Core files:
+  - `agents/skill-update/agents/skill-update-agent.md` (agent instruction file)
+
+#### Types
+
+```txt
+SkillUpdateInput {
+  planFilePath:  string | null  (path to the approved plan file, or null)
+  workDir:       string         (absolute path to the isolated work dir)
+  taskSummary:   string         (brief human-readable description of what was accomplished)
+}
+
+SkillUpdateOutput {
+  skillsWritten: SkillFile[]   (may be empty — agent wrote zero skills if nothing qualified)
+}
+
+SkillFile {
+  path:    string  (relative path within workDir, e.g. "skills/handle-git-conflicts/SKILL.md")
+  action:  "created" | "updated"
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `skillUpdateAgent.noSkillsNeeded` | `SkillUpdateInput` | `SkillUpdateOutput { skillsWritten: [] }` | happy path | Agent determines no non-obvious recurring patterns exist; returns empty list |
+| `skillUpdateAgent.skillsWritten` | `SkillUpdateInput` | `SkillUpdateOutput` | happy path | One or more skill files written/updated in `skills/`; list returned |
+| `skillUpdateAgent.readError` | `SkillUpdateInput` | `StandardError` | error | Cannot read plan file or git diff; agent reports error; caller logs a warning and continues to PR (non-fatal) |
+
+#### Pseudocode
+
+```
+skill-update-agent(planFilePath, workDir, taskSummary):
+
+  # Step 1 — gather context
+  if planFilePath is not null:
+    read planFilePath to understand what flows were built and why
+  run git diff HEAD~1 or git log --oneline -5 in workDir to see what changed
+
+  # Step 2 — identify candidate patterns
+  For each non-obvious thing encountered during the task
+  (detected by: comments like "NOTE", "WORKAROUND", "HACK", "non-obvious",
+   repeated lookups in the plan pseudocode, deviations that were resolved,
+   things the agent had to figure out that aren't documented anywhere):
+    add to candidatePatterns list
+
+  # Step 3 — recurrence filter
+  For each candidate in candidatePatterns:
+    Ask: "Is this specific to this one task, or would a future agent hit the same wall?"
+    If task-specific only (e.g. a one-off data migration quirk): discard
+    If general and likely to recur (e.g. "how to do X in this codebase"): keep
+
+  if filteredPatterns is empty:
+    return { skillsWritten: [] }
+
+  # Step 4 — write/update skill files
+  For each pattern in filteredPatterns:
+    slug = kebab-case name for the pattern
+    skillPath = "skills/<slug>/SKILL.md"
+
+    if skillPath already exists in workDir:
+      read existing skill, merge new knowledge, write updated file
+      record { path: skillPath, action: "updated" }
+    else:
+      write new SKILL.md using the skill template
+      record { path: skillPath, action: "created" }
+
+  # Step 5 — return
+  return { skillsWritten: [recorded SkillFile entries] }
+```
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| skill-update-agent stdout | terminal / caller stdout |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment step — agent is a markdown file checked into the repo.
+  # Invoked automatically by dark-factory-agent as Step 4c.
+  ```
+- Notes: Non-fatal. If it errors, `dark-factory-agent` logs a warning and continues to the PR step. The manufacture loop is never blocked by skill-writing failures.

--- a/docs/plans/2026-04-25-dark-factory-agent.md
+++ b/docs/plans/2026-04-25-dark-factory-agent.md
@@ -39,6 +39,7 @@ graph TD
     S3["Step 3 — code-review-orchestrator-agent"]:::created
     S4a["Step 4a — update-documentation-agent"]:::created
     S4b["Step 4b — detect-drift-agent"]:::created
+    S4c["Step 4c — skill-update-agent\n(non-fatal)"]:::created
     S5["Step 5 — pr-agent"]:::created
     S6["Step 6 — Cleanup\nrm -rf dark_factory-&lt;task-name&gt;"]:::created
   end
@@ -59,7 +60,8 @@ graph TD
   WC -->|"planFilePath (if any)"| S3
   S3 -->|"status: complete"| S4a
   S4a -->|"docs updated"| S4b
-  S4b -->|"drift report"| S5
+  S4b -->|"drift report"| S4c
+  S4c -->|"skillsWritten (non-fatal)"| S5
   S5 -->|"pr_url, merged: true"| S6
   S6 -->|"PR URL + cleanup confirmation"| User
 
@@ -365,9 +367,10 @@ DarkFactoryInput {
 }
 
 DarkFactoryOutput {
-  prUrl:   string
-  merged:  true
-  workDir: string  (already deleted; reported for auditability)
+  prUrl:         string
+  merged:        true
+  workDir:       string     (already deleted; reported for auditability)
+  skillsWritten: SkillFile[]  (may be empty; list of skill files created or updated by skill-update-agent)
 }
 ```
 
@@ -407,6 +410,14 @@ dark-factory-agent(taskDescription, taskName):
   docsResult = updateDocsAndDrift(planFilePath, workDir)
   if error: cleanup(workDir); STOP
 
+  # Step 4c — skill update (non-fatal)
+  skillsWritten = []
+  try:
+    skillResult = invoke skill-update-agent with (planFilePath, workDir, taskDescription)
+    skillsWritten = skillResult.skillsWritten
+  catch error:
+    warn developer: "skill-update-agent failed: <error>. Continuing to PR."
+
   # Step 5 — open PR
   prResult = openPR(planFilePath, taskDescription)
   if error: cleanup(workDir); STOP
@@ -414,7 +425,7 @@ dark-factory-agent(taskDescription, taskName):
   # Step 6 — cleanup
   cleanup(workDir)
 
-  return { prUrl: prResult.prUrl, merged: true, workDir }
+  return { prUrl: prResult.prUrl, merged: true, workDir, skillsWritten }
 ```
 
 ## Logs


### PR DESCRIPTION
## Description

# skill-update-agent

## Plan Metadata

- Plan type: `plan`
- Parent plan: `docs/plans/2026-04-25-dark-factory-agent.md`
- Depends on: N/A
- Status: `approved`

Status semantics:
- `draft`: Plan is being created or updated and is not final.
- `approved`: Plan is approved but not yet applied in code.
- `documentation`: Code currently exists and matches the plan contract.

Update rule:
- When an existing plan is edited, set status to `draft` until re-approved.

## System Intent

- What is being built: A `skill-update-agent` that runs near the end of the `dark-factory-agent` manufacture loop (after code review and doc updates, before the PR step). It reviews the work that was just completed, identifies any non-obvious patterns or workarounds that were encountered during the task, and — only when those patterns are likely to recur — writes or updates skill files in the target project's `skills/` directory so future manufacture runs benefit from that knowledge.
- Primary consumer(s): `dark-factory-agent` (invokes it as Step 4c, between `detect-drift-agent` and `pr-agent`). Indirectly benefits future invocations of any agent that reads project skills.
- Boundary (black-box scope only): Accepts the completed work context (plan file path, work dir, and a summary of what was done). Produces zero or more new/updated skill files in `<workDir>/skills/`. Returns a list of skills written (may be empty). Does not open PRs, does not modify agent files, does not edit plans.

## Stage Gate Tracker

- [ ] Stage 1 Mermaid approved
- [ ] Stage 2 Flows approved
- [ ] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

See plan file for full diagram.

## Flows

### Flow: `skillUpdateAgent`

- Test files: N/A (agent instruction file, no automated tests)
- Core files:
  - `agents/skill-update/agents/skill-update-agent.md` (new — the agent instruction file)

### Flow: `darkFactoryAgentIntegration`

- Test files: N/A (orchestration change to existing agent)
- Core files:
  - `agents/dark-factory/agents/dark-factory-agent.md` (updated — adds Step 4c)

## Deployment

- Mechanism: `local only`
- Notes: The skill-update-agent is non-fatal. If it errors, dark-factory-agent logs a warning and continues to the PR step.

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
