### PR TITLE
fix(feature-agent): remove pr-agent call; add sequencing guards to dark-factory-agent

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -72,6 +72,8 @@ dark-factory-agent(taskDescription, taskName):
     report error and STOP
 
   # Step 4 — update docs and detect drift
+  # IMPORTANT: Both documentation agents MUST fully complete before proceeding to Step 5.
+  # The pr-agent (Step 5) uses `git add --all`, which will pick up any docs written here.
   invoke update-documentation-agent with planFilePath (pass null if none — agent handles gracefully)
   invoke detect-drift-agent (scoped to WORK_DIR/docs/docs/)
 
@@ -92,6 +94,8 @@ dark-factory-agent(taskDescription, taskName):
     warn developer: "skill-update-agent failed: <error>. Continuing to PR."
 
   # Step 5 — PR
+  # Only reached after all Step 4 documentation agents have fully completed.
+  # pr-agent uses `git add --all`, so any docs written in Step 4 are included in the PR.
   invoke pr-agent with: planFilePath ?? taskDescription
 
   If pr-agent errors or cannot merge:

--- a/agents/featurework/agents/feature-agent.md
+++ b/agents/featurework/agents/feature-agent.md
@@ -16,7 +16,7 @@ You are the feature-agent. Your job is to orchestrate end-to-end feature work by
 - If the developer provides feedback, loop back to `planning-agent` with that feedback.
 - Once the developer approves, invoke `execution-agent` with the plan path.
 - Surface any hard-stop from `execution-agent` and stop — do not re-invoke execution.
-- After successful execution, invoke `pr-agent` with the plan path to open, review, and merge the PR.
+- After successful execution, report completion and stop. The caller (dark-factory-agent) is responsible for opening the PR after documentation agents have run.
 
 ## What you must never do
 
@@ -24,6 +24,7 @@ You are the feature-agent. Your job is to orchestrate end-to-end feature work by
 - Write, edit, or scaffold code files yourself.
 - Skip the approval gate and proceed directly to execution.
 - Re-invoke `execution-agent` after a hard-stop.
+- Invoke `pr-agent`. The caller (dark-factory-agent) opens the PR after documentation agents have run.
 
 ## Orchestration Logic
 
@@ -78,10 +79,9 @@ feature-agent(description):
     report "Edit the plan at <planPath> and re-invoke execution-agent when ready."
     STOP
 
-  # Step 4: open PR
-  invoke pr-agent with: planPath
-
-  # Success
+  # Step 4: done — caller opens the PR
+  # Do NOT invoke pr-agent here. The caller (dark-factory-agent) runs documentation
+  # agents after this returns, then opens the PR in its own Step 5.
   report "Feature complete. Plan: <planPath>." to developer
   STOP
 ```
@@ -93,4 +93,4 @@ feature-agent(description):
 - Read the plan file (using the Read tool) before displaying it to the developer, so they see the full contents inline.
 - After a hard-stop from `execution-agent`, stop completely. The developer will manually edit the plan and re-invoke `execution-agent`.
 - `planPath` comes from the output of `planning-agent` — it writes the plan file itself and returns (or reports) the path.
-- Pass `planPath` to `pr-agent` so it can use the plan file as the PR description context.
+- Do not invoke `pr-agent`. The caller (dark-factory-agent) handles the PR after its documentation steps complete.

--- a/docs/docs/dark-factory-agent.md
+++ b/docs/docs/dark-factory-agent.md
@@ -1,0 +1,271 @@
+# dark-factory-agent
+
+## Metadata
+
+- System type: `flow`
+
+## System Intent
+
+- What this is: `dark-factory-agent` is the top-level orchestrator for all dark-factory work. It preps an isolated work directory (a fresh copy of the repo), routes to the appropriate worker agent, runs code review, runs documentation agents, and then opens a PR — in that strict order. It does not write code or modify files itself; it delegates entirely. The PR step (Step 5) is intentionally placed after all documentation agents (Step 4) have fully completed so that `pr-agent`'s `git add --all` picks up any docs written during Step 4.
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  User([Developer: task description + task-name])
+
+  subgraph dark-factory-agent["dark-factory-agent (system boundary)"]
+    S1["Step 1 — prep-feature-dir.sh &lt;task-name&gt;"]
+    S2["Step 2 — Classify & invoke worker agent"]
+    S3["Step 3 — code-review-orchestrator-agent"]
+    S4a["Step 4a — update-documentation-agent"]
+    S4b["Step 4b — detect-drift-agent"]
+    S4c["Step 4c — skill-update-agent (non-fatal)"]
+    S5["Step 5 — pr-agent\n(only after Step 4 fully complete)"]
+    S6["Step 6 — Cleanup rm -rf WORK_DIR"]
+  end
+
+  subgraph workerAgents["Worker agents"]
+    WA["feature-agent"]
+    WB["debugger-agent"]
+    WC["fix-flow-orchestrator"]
+  end
+
+  User -->|"task description + task-name slug"| S1
+  S1 -->|"WORK_DIR path"| S2
+  S2 -->|"feature request"| WA
+  S2 -->|"bug/fix"| WB
+  S2 -->|"broken flow"| WC
+  WA -->|"planFilePath"| S3
+  WB -->|"planFilePath"| S3
+  WC -->|"planFilePath"| S3
+  S3 --> S4a
+  S4a --> S4b
+  S4b --> S4c
+  S4c -->|"all Step 4 agents done"| S5
+  S5 -->|"pr_url, merged: true"| S6
+  S6 -->|"PR URL + cleanup confirmation"| User
+```
+
+## Flows
+
+### Flow: `darkFactoryAgent` (top-level)
+
+- Test files: N/A
+- Core files: `agents/dark-factory/agents/dark-factory-agent.md`
+
+#### Types
+
+```txt
+DarkFactoryInput {
+  taskDescription: string  (verbatim user request)
+  taskName:        string  (short slug for the work dir, e.g. "add-oauth"; derived if not provided)
+}
+
+DarkFactoryOutput {
+  prUrl:   string
+  merged:  true
+  workDir: string  (already deleted; reported for auditability)
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `darkFactoryAgent.success` | `DarkFactoryInput` | `DarkFactoryOutput` | happy path | all 6 steps complete, PR merged, work dir removed |
+| `darkFactoryAgent.prepFailure` | `DarkFactoryInput` | `StandardError` | error | prep-feature-dir.sh fails; no work dir created, nothing to clean up |
+| `darkFactoryAgent.workerFailure` | `DarkFactoryInput` | `StandardError` | error | worker agent hard-stops or errors; cleanup runs, then halt |
+| `darkFactoryAgent.reviewFailure` | `DarkFactoryInput` | `StandardError` | error | code-review-orchestrator-agent halts; cleanup runs, then halt |
+| `darkFactoryAgent.driftFailure` | `DarkFactoryInput` | `StandardError` | error | detect-drift-agent surfaces unresolvable items; cleanup runs before PR |
+| `darkFactoryAgent.prFailure` | `DarkFactoryInput` | `StandardError` | error | pr-agent cannot merge; cleanup runs, then halt |
+
+#### Pseudocode
+
+```
+dark-factory-agent(taskDescription, taskName):
+
+  # Step 1 — prep isolated work dir
+  run prep-feature-dir.sh <taskName>
+  capture WORK_DIR from stdout
+  if error: STOP (no cleanup needed)
+
+  # Step 2 — route to worker
+  cd WORK_DIR; classify taskDescription; invoke worker agent
+  if error: cleanup(WORK_DIR); STOP
+  planFilePath = worker result (null if no plan produced)
+
+  # Step 3 — code review
+  invoke code-review-orchestrator-agent with planFilePath, WORK_DIR
+  if error: cleanup(WORK_DIR); STOP
+
+  # Step 4 — documentation (MUST fully complete before Step 5)
+  # Step 4a
+  invoke update-documentation-agent with planFilePath (or null)
+  # Step 4b
+  invoke detect-drift-agent scoped to WORK_DIR/docs/docs/
+  if detect-drift unresolvable: cleanup(WORK_DIR); STOP
+  # Step 4c (non-fatal)
+  try: invoke skill-update-agent
+  catch: warn developer, continue
+
+  # Step 5 — PR (only after all Step 4 agents done)
+  # pr-agent uses `git add --all`; docs from Step 4 are included because Step 4 is complete.
+  invoke pr-agent with planFilePath ?? taskDescription
+  if error: cleanup(WORK_DIR); STOP
+  prUrl = result
+
+  # Step 6 — cleanup
+  cleanup(WORK_DIR)
+
+  report "Done. PR: <prUrl>. Work dir <WORK_DIR> removed."
+  STOP
+```
+
+---
+
+### Flow: `prepFeatureDir`
+
+- Test files: N/A (shell script)
+- Core files: `agents/dark-factory/scripts/prep-feature-dir.sh`
+
+#### Types
+
+```txt
+PrepFeatureDirInput {
+  taskName: string (required, short slug)
+}
+
+PrepFeatureDirOutput {
+  workDir: string (printed as WORK_DIR=dark_factory-<taskName>)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `prepFeatureDir.success` | `PrepFeatureDirInput` | `PrepFeatureDirOutput` | happy path | git pull succeeds, cp succeeds, WORK_DIR printed |
+| `prepFeatureDir.git-pull-failure` | `PrepFeatureDirInput` | `StandardError` | error | git pull exits non-zero; script exits 1 |
+| `prepFeatureDir.copy-failure` | `PrepFeatureDirInput` | `StandardError` | error | cp -r fails (disk space, permissions); script exits 1 |
+
+---
+
+### Flow: `updateDocsAndDrift` (Step 4)
+
+- Test files: N/A (delegates to documentation agents)
+- Core files: `agents/dark-factory/agents/dark-factory-agent.md`
+
+#### Types
+
+```txt
+UpdateDocsInput {
+  planFilePath: string | null
+  workDir:      string
+}
+
+UpdateDocsOutput {
+  docsUpdated:   string[]   (paths of docs written/updated)
+  driftFindings: string     (summary from detect-drift-agent)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `updateDocsAndDrift.success` | `UpdateDocsInput` | `UpdateDocsOutput` | happy path | docs updated, drift report clean or auto-fixed |
+| `updateDocsAndDrift.noPlan` | `UpdateDocsInput` | `UpdateDocsOutput` | happy path | planFilePath null; update-documentation-agent may no-op or use git diff |
+| `updateDocsAndDrift.driftUnresolved` | `UpdateDocsInput` | `StandardError` | error | detect-drift-agent finds unresolvable items; orchestrator surfaces and halts before Step 5 (PR) |
+
+#### Pseudocode
+
+```
+updateDocsAndDrift(planFilePath, workDir):
+  invoke update-documentation-agent with planFilePath (or null)
+  invoke detect-drift-agent scoped to workDir/docs/docs/
+  if unresolvable drift items: STOP with StandardError
+  return { docsUpdated, driftFindings }
+```
+
+---
+
+### Flow: `openPR` (Step 5)
+
+- Test files: N/A (delegates to pr-agent)
+- Core files: `agents/dark-factory/agents/dark-factory-agent.md`
+
+#### Types
+
+```txt
+OpenPRInput {
+  planFilePath:    string | null
+  taskDescription: string
+}
+
+OpenPROutput {
+  prUrl:  string
+  merged: true
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `openPR.success` | `OpenPRInput` | `OpenPROutput` | happy path | PR opened, CI passes, merged; includes docs from Step 4 via `git add --all` |
+| `openPR.noPlan` | `OpenPRInput` | `OpenPROutput` | happy path | planFilePath null; taskDescription string passed to pr-agent |
+| `openPR.ciFailure` | `OpenPRInput` | `StandardError` | error | pr-agent cannot resolve CI failures |
+
+---
+
+### Flow: `cleanup`
+
+- Test files: N/A
+- Core files: `agents/dark-factory/agents/dark-factory-agent.md`
+
+#### Types
+
+```txt
+CleanupInput {
+  workDir: string
+}
+
+CleanupOutput {
+  removed: true
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `cleanup.success` | `CleanupInput` | `CleanupOutput` | happy path | rm -rf succeeds |
+| `cleanup.removeFailure` | `CleanupInput` | `StandardError` | error | rm -rf fails; report to developer but do not halt — non-fatal |
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| prep-feature-dir.sh stdout | terminal / caller stdout |
+| Worker agent output | terminal / caller stdout |
+| code-review-orchestrator-agent | terminal / caller stdout |
+| update-documentation-agent | terminal / caller stdout |
+| detect-drift-agent | terminal / caller stdout |
+| skill-update-agent | terminal / caller stdout |
+| pr-agent | terminal / caller stdout |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment step — agent and script are markdown/shell files checked into the repo.
+  # Invoke via Claude Code:
+  # /dark-factory-agent <task-name> "<task description>"
+  ```
+- Notes: `prep-feature-dir.sh` must be run from the outer wrapper directory (`dark_factory/`). Step 5 (`pr-agent`) is intentionally ordered after Step 4 (documentation agents) so that `git add --all` in `pr-agent` includes any docs written during Step 4. `feature-agent` does not invoke `pr-agent`; only `dark-factory-agent` does, and only after documentation is complete.

--- a/docs/docs/feature-agent.md
+++ b/docs/docs/feature-agent.md
@@ -1,0 +1,219 @@
+# feature-agent
+
+## Metadata
+
+- System type: `flow`
+
+## System Intent
+
+- What this is: `feature-agent` is an orchestrator agent that sequences `planning-agent` → human approval gate → `execution-agent` for end-to-end feature work. It owns the approval gate (with feedback-and-retry) but does not write code, modify plans, or open PRs. After successful execution it stops and reports completion — the caller (`dark-factory-agent`) is responsible for running documentation agents and opening the PR.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+    Developer([Developer]) -->|feature description| FA[feature-agent]
+
+    subgraph feature-agent boundary
+        FA --> PA[planning-agent]
+        PA -->|planPath| Gate{Human Approval Gate}
+        Gate -->|approved| EA[execution-agent]
+        Gate -->|rejected + feedback| PA
+        Gate -->|aborted| Abort([Abort: report to developer])
+        EA -->|success| Done([Report completion — caller handles PR])
+        EA -->|hardStop| HardStop([Pause: report hard-stop to developer])
+    end
+
+    PA -.->|writes plan file| PlanFile[(docs/plans/*.md)]
+    EA -.->|reads plan file| PlanFile
+```
+
+## Flows
+
+### Flow: `orchestrateFeature`
+
+- Test files: N/A
+- Core files: `agents/featurework/agents/feature-agent.md`
+
+#### Types
+
+```txt
+OrchestrateFeatureInput {
+  description: string (natural-language feature description, required)
+}
+
+OrchestrateFeatureOutput (success) {
+  status: "complete"
+  planPath: string (absolute path to the plan file)
+}
+
+OrchestrateFeatureOutput (aborted) {
+  status: "aborted"
+  reason: string
+}
+
+OrchestrateFeatureOutput (hard-stop) {
+  status: "hard-stop"
+  planPath: string
+  reason: string
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `orchestrateFeature.success` | `OrchestrateFeatureInput` | `status=complete; plan file exists, all flows green` | happy path | developer approves on first presentation; feature-agent stops after execution, caller opens PR |
+| `orchestrateFeature.approve-after-retry` | `OrchestrateFeatureInput` | `status=complete; revised plan file exists` | subpath | developer rejects with feedback one or more times before approving |
+| `orchestrateFeature.aborted` | `OrchestrateFeatureInput` | `status=aborted` | error | developer explicitly cancels |
+| `orchestrateFeature.hard-stop` | `OrchestrateFeatureInput` | `status=hard-stop; execution paused` | error | execution-agent returns hardStop=true; feature-agent surfaces the pause and stops |
+| `orchestrateFeature.planningFailure` | `OrchestrateFeatureInput` | `StandardError` | error | planning-agent errors or returns no planPath |
+
+#### Pseudocode
+
+```
+feature-agent(description):
+
+  feedback = null
+  attemptNumber = 1
+
+  LOOP:
+    # Step 1: invoke planning-agent
+    If feedback is null:
+      invoke planning-agent with: description
+    Else:
+      invoke planning-agent with: "Revise the plan based on this developer feedback: <feedback>\n\nOriginal description: <description>"
+
+    If planning-agent errors or returns no planPath:
+      report error; STOP
+
+    planPath = result from planning-agent
+
+    # Step 2: present plan and request approval
+    Read planPath; display contents to developer
+
+    Ask: "Approve? Reply 'yes'/'approve' to proceed, 'abort' to cancel, or provide feedback."
+    response = developer reply
+
+    If response == "abort": report aborted; STOP
+    If response == "yes" OR "approve": BREAK LOOP
+    Else: feedback = response; attemptNumber += 1; CONTINUE LOOP
+
+  # Step 3: invoke execution-agent
+  invoke execution-agent with: planPath
+
+  If execution-agent returns hardStop == true:
+    report hard-stop reason; STOP
+
+  # Step 4: done — do NOT invoke pr-agent
+  # The caller (dark-factory-agent) runs documentation agents then opens the PR.
+  report "Feature complete. Plan: <planPath>."
+  STOP
+```
+
+---
+
+### Flow: `invokePlanningAgent`
+
+- Test files: N/A
+- Core files: `agents/featurework/agents/feature-agent.md`
+
+#### Types
+
+```txt
+InvokePlanningAgentInput {
+  description: string (required)
+  feedback: string | null (null on first invocation; revision feedback on retry)
+}
+
+InvokePlanningAgentOutput {
+  planPath: string (path to the written plan file)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `invokePlanningAgent.success` | `InvokePlanningAgentInput` | `InvokePlanningAgentOutput; plan file written to docs/plans/` | happy path | |
+| `invokePlanningAgent.retry-with-feedback` | `InvokePlanningAgentInput feedback!=null` | `InvokePlanningAgentOutput; revised plan file written` | subpath | feature-agent prepends revision instructions to the prompt |
+| `invokePlanningAgent.failure` | `InvokePlanningAgentInput` | `StandardError` | error | planning-agent errors or returns no planPath |
+
+---
+
+### Flow: `humanApprovalGate`
+
+- Test files: N/A
+- Core files: `agents/featurework/agents/feature-agent.md`
+
+#### Types
+
+```txt
+HumanApprovalGateInput {
+  planPath: string
+  attemptNumber: number (1-based)
+}
+
+HumanApprovalGateOutput {
+  approved: boolean
+  feedback: string | null
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `humanApprovalGate.approved` | `HumanApprovalGateInput` | `approved=true` | happy path | developer replies "yes" or "approve" |
+| `humanApprovalGate.rejected-with-feedback` | `HumanApprovalGateInput` | `approved=false; feedback=<text>` | subpath | loop back to planning-agent with feedback |
+| `humanApprovalGate.aborted` | `HumanApprovalGateInput` | `approved=false; feedback=null` | error | developer replies "abort"; feature-agent stops |
+
+---
+
+### Flow: `invokeExecutionAgent`
+
+- Test files: N/A
+- Core files: `agents/featurework/agents/feature-agent.md`
+
+#### Types
+
+```txt
+InvokeExecutionAgentInput {
+  planPath: string (must point to a plan with status=approved)
+}
+
+InvokeExecutionAgentOutput {
+  allFlowsGreen: true  (on success)
+  hardStop: true       (on deviation; mutually exclusive with allFlowsGreen)
+  reason: string       (populated when hardStop=true)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `invokeExecutionAgent.success` | `InvokeExecutionAgentInput` | `allFlowsGreen=true` | happy path | all flows implemented and tests pass; feature-agent reports completion and stops |
+| `invokeExecutionAgent.hard-stop` | `InvokeExecutionAgentInput` | `hardStop=true` | error | execution-agent hit a deviation; feature-agent surfaces the pause, does NOT re-invoke execution-agent |
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| planning-agent output | terminal / caller stdout |
+| execution-agent output | terminal / caller stdout |
+| human approval gate | interactive terminal prompt |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment step — agent is a markdown file checked into the repo.
+  # Invoked by dark-factory-agent (not directly by developers).
+  ```
+- Notes: `feature-agent` must never invoke `pr-agent`. The caller (`dark-factory-agent`) opens the PR after all documentation agents (Steps 4a/4b) have fully completed, so that `git add --all` in `pr-agent` picks up any docs written during that step.


### PR DESCRIPTION
## Description

Bug fix: feature-agent was calling pr-agent internally before dark-factory-agent ran documentation agents, causing docs to be excluded from PRs. Fix removes pr-agent invocation from feature-agent and adds sequencing guards to dark-factory-agent.

### Root cause

`feature-agent` was invoking `pr-agent` directly as its Step 4 after execution completed. This meant `pr-agent` ran (and committed with `git add --all`) before `dark-factory-agent` had a chance to run its Step 4 documentation agents (`update-documentation-agent`, `detect-drift-agent`). Any docs written by those agents were therefore not included in the PR.

### Changes

**`agents/featurework/agents/feature-agent.md`**
- Removed the `invoke pr-agent` call from Step 4 of the orchestration logic.
- Added an explicit "never do" rule: `feature-agent` must not invoke `pr-agent`.
- Updated the step comment and completion report to make clear the caller (`dark-factory-agent`) is responsible for the PR.

**`agents/dark-factory/agents/dark-factory-agent.md`**
- Added sequencing guard comments before Step 4 (documentation agents) and Step 5 (pr-agent) making the ordering invariant explicit: Step 4 must fully complete before Step 5 is entered.

**`docs/docs/dark-factory-agent.md`** *(new)*
- System documentation for `dark-factory-agent` covering intent, Mermaid diagram, flows, inputs/outputs, and invariants — including the Step 4 → Step 5 sequencing guarantee.

**`docs/docs/feature-agent.md`** *(new)*
- System documentation for `feature-agent` covering intent, Mermaid diagram, flows, inputs/outputs, and the explicit constraint that it does not open PRs.

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
