### PR TITLE
feat(agents): add PushNotification before every user-input request

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,3 +16,228 @@ hooks
 
 Maybe:
 security
+
+
+----
+
+
+● Bash(cd dark_factory && git status && git log --oneline -5)          
+  ⎿  Running…
+                                                                                
+────────────────────────────────────────────────────────────────────────────────
+ Bash command                                                                   
+                  
+   cd dark_factory && git status && git log --oneline -5
+   Check git status and recent log in dark_factory
+
+ This command changes directory before running git, which can execute untrusted
+  hooks from the target directory. Approve only if you trust it.
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. No
+
+ng…                                                                   
+                                                                                
+────────────────────────────────────────────────────────────────────────────────
+ Bash command                                                                   
+                                                                                
+   cd dark_factory && git checkout main && git pull origin main 2>&1            
+   Switch to main and pull latest                                               
+                                                                                
+ This command changes directory before running git, which can execute untrusted 
+  hooks from the target directory. Approve only if you trust it.                
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. No
+
+
+ checkout main && git pull origin main 2>&1)                          
+  ⎿  Switched to branch 'main'                                                  
+     Your branch is behind 'origin/main' by 1 commit, and can be fast-forwa     
+     rded.                                                                      
+     … +11 lines (ctrl+o to expand)                                             
+                                                                                
+● Bash(bash dark_factory/agents/dark-factory/scripts/prep-feature-dir.sh        
+      open-plan-in-vscode 2>&1)                                                 
+  ⎿  Error: Exit code 127                                                       
+     bash: dark_factory/agents/dark-factory/scripts/prep-feature-dir.sh: No such
+      file or directory                                                         
+                                                                                
+  Listed 2 directories (ctrl+o to expand)                                       
+                                  
+                                                                          
+────────────────────────────────────────────────────────────────────────────────
+ Bash command                                                                   
+                                                                                
+   mkdir -p /home/lewibs/github/dark_factory/dark_factory-open-plan-in-vscode   
+   /skills/open-in-vscode                                                       
+   Run shell command                                                            
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and always allow access to skills/ from this project
+   3. No
+
+ Esc to cancel · Tab to amend · ctrl+e to explain
+
++23 tool uses (ctrl+o to expand)                                         
+     (ctrl+b to run in background)                                              
+                                                                                
+────────────────────────────────────────────────────────────────────────────────
+ Bash command                                                                   
+                                                                                
+   diff <(ls /home/lewibs/github/dark_factory/dark_factory/skills/) <(ls
+   /home/lewibs/github/dark_factory/dark_factory-open-plan-in-vscode/skills/)   
+   Compare skills directories
+
+ Contains process_substitution
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. No
+
+ Esc to cancel · Tab to amend · ctrl+
+
+
+trl+o to expand)                                         
+     (ctrl+b to run in background)                                              
+                                                                                
+────────────────────────────────────────────────────────────────────────────────
+ Bash command                                                                   
+                                                                                
+   cd /home/lewibs/github/dark_factory/dark_factory-skill-update-agent && git   
+    status                                                                      
+   Check git status of working tree                                             
+                                                                                
+ This command changes directory before running git, which can execute untrusted 
+  hooks from the target directory. Approve only if you trust it.                
+
+ Do you want to proceed?                                                        
+ ❯ 1. Yes
+   2. No
+
+ Esc to cancel · Tab to amend · ctrl+e to explain
+
+
+────────────────────────────────────────────────────────────────────────────────
+ Bash command                                                                  
+                                                             
+   cd /home/lewibs/github/dark_factory/dark_factory-skill-update-agent && git
+    log --oneline -5                                                            
+   Show recent git log
+                                                                                
+ This command changes directory before running git, which can execute untrusted
+  hooks from the target directory. Approve only if you trust it.              
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. No
+
+ Esc to cancel · Tab to amend · ctrl+e to explain
+
+✻ Julienn3ng… (7m 40s · ↓ 5.7k tokens)                                          
+  ⎿  Tip: Create skills by adding .md files to .claude/skills/ in your project 
+     or ~/.claude/skills/ for skills that work in any project
+────────────────────────────────────────────────────────────────────────────────
+ Bash command                                                                  ─
+❯                                                            
+───cd─/home/lewibs/github/dark_factory/dark_factory-skill-update-agent─&&─git───
+    diff agents/dark-factory/agents/dark-factory-agent.md                       
+   Show changes to dark-factory-agent.md                    ◐ medium · /effort
+                                                                                
+ This command changes directory before running git, which can execute untrusted 
+  hooks from the target directory. Approve only if you trust it.                
+                                                                                
+ Do you want to proceed?                                                        
+ ❯ 1. Yes                                                                       
+   2. No
+
+ Esc to cancel · Tab to amend · ctrl+e to explain
+
+
+ses (ctrl+o to expand)at work in any project
+ ─   (ctrl+b to run in background)                                    ─  ─   ───
+                                                                               ─
+────────────────────────────────────────────────────────────────────────────────
+ Bash command                                                                  ─
+                                                                                
+   cd /home/lewibs/github/dark_factory/dark_factory-skill-update-agent &&fgitt  
+    diff TODO.md                                                                
+   Show TODO.md diff                                                            
+                                                                                
+ This command changes directory before running git, which can execute untrusted 
+  hooks from the target directory. Approve only if you trust it.                
+                                                                                
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. No
+
+ Esc to cancel · Tab to amend · ctrl+e to explain
+
+ erun in background)     iles to .claude/skills/ in your project 
+────────────────────────────────────────────────────────────────────────────────
+ Bash command                                                                  
+  ⎿                                                          / in your project ─
+   cat > /tmp/pr-body.md << 'PREOF'  that work in  ny project                   
+   ## Description                                                               
+  ───                                                        ───────────────────
+   # skill-update-agent                                                         
+                                                                                
+   ## Plan Metadata                                                             
+                                                                                
+   - Plan type: `plan`                                                          
+   - Parent plan: `docs/plans/2026-04-25-dark-factory-agent.md`
+   - Depends on: N/A
+   - Status: `approved`
+
+   ## System Intent
+
+   - What is being built: A `skill-update-agent` that runs near the end of
+   the `dark-factory-agent` manufacture loop (after code review and doc
+   updates, before the PR step). It reviews the work that was just completed,
+    identifies any non-obvious patterns or workarounds that were encountered
+   during the task, and — only when those patterns are likely to recur —
+   writes or updates skill files in the target project's `skills/` directory
+   so future manufacture runs benefit from that knowledge.
+   - Primary consumer(s): `dark-factory-agent` (invokes it as Step 4c,
+   between `detect-drift-agent` and `pr-agent`). Indirectly benefits future
+   invocations of any agent that reads project skills.
+   - Boundary (black-box scope only): Accepts the completed work context
+   (plan file path, work dir, and a summary of what was done). Produces zero
+   or more new/updated skill files in `<workDir>/skills/`. Returns a list of
+   skills written (may be empty). Does not open PRs, does not modify agent
+   files, does not edit plans.
+
+   ## Flows
+
+   ### Flow: `skillUpdateAgent`
+
+   New agent file: `agents/skill-update/agents/skill-update-agent.md`
+
+   Reads plan + git diff, identifies non-obvious recurring patterns, applies
+   recurrence filter, writes/updates `skills/<slug>/SKILL.md` files, returns
+   `skillsWritten` list.
+
+   ### Flow: `darkFactoryAgentIntegration`
+
+   Updated: `agents/dark-factory/agents/dark-factory-agent.md`
+
+   Adds Step 4c (skill-update-agent invocation) between detect-drift and PR
+   steps. Non-fatal: if skill-update-agent errors, dark-factory-agent logs a
+   warning and continues to PR.
+
+   ---
+   🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
+   PREOF
+   Write PR body to /tmp/pr-body.md
+
+ Do you want to proceed?
+   1. Yes
+ ❯ 2. Yes, and always allow access to tmp/ from this project
+   3. No
+
+ Esc to cancel · ctrl+e to explain               
+
+

--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -114,7 +114,7 @@ If rm fails: warn developer but do not halt — this is non-fatal.
 | "add", "build", "create", "implement", "new feature" | `feature-agent` |
 | "broken flow", "integration failing", "end-to-end", "pipeline" | `fix-flow-orchestrator` |
 | "bug", "crash", "error", "fix", "broken", "not working", "debug" | `debugger-agent` |
-| Ambiguous | Ask the developer one clarifying question before routing |
+| Ambiguous | Before asking the developer a clarifying question about an ambiguous task, call PushNotification with title: "Clarification Required" and message: "The dark-factory agent needs one clarification before it can route your request." Then ask the developer one clarifying question before routing |
 
 ## Rules
 

--- a/agents/documentation/agents/detect-drift-agent.md
+++ b/agents/documentation/agents/detect-drift-agent.md
@@ -29,7 +29,7 @@ None required. Runs against all files in `docs/docs/` by default. Optionally acc
 2. After the skill produces its findings report:
    - Fix any `extra` or `different` items that are straightforward (broken file paths, stale references, renamed files).
    - For `missing` items (implemented behavior not documented), add a brief section to the relevant doc or create a new doc in `docs/docs/`.
-   - For `wrong` items, note them in the report and ask the developer how to proceed.
+   - For `wrong` items, note them in the report; before asking the developer how to proceed on unresolvable drift items, call PushNotification with title: "Documentation Drift — Input Required" and message: "The detect-drift agent found items it cannot resolve automatically and needs your guidance." Then ask the developer how to proceed.
 
 3. Return:
    - A summary of findings (counts per severity bucket).

--- a/agents/documentation/agents/update-documentation-agent.md
+++ b/agents/documentation/agents/update-documentation-agent.md
@@ -14,7 +14,7 @@ Updates project documentation after a plan has been implemented. Runs three phas
 
 ## Required argument
 
-The plan path is required. If not provided, stop and ask the developer before doing anything else.
+The plan path is required. If not provided, before asking the developer for the required plan path, call PushNotification with title: "Input Required" and message: "The update-documentation agent needs a plan path to proceed." Then stop and ask the developer before doing anything else.
 
 ```
 /update-documentation-agent <plan-path>

--- a/agents/featurework/agents/feature-agent.md
+++ b/agents/featurework/agents/feature-agent.md
@@ -51,6 +51,8 @@ feature-agent(description):
     Display: "Plan written to <planPath>. Please review."
     Display the full contents of the plan file to the developer.
 
+    Before asking the developer for plan approval, call PushNotification with title: "Plan Approval Required" and message: "A plan is ready for your review and requires approval to proceed."
+
     Ask the developer:
       "Approve this plan? Reply 'yes' or 'approve' to proceed to implementation,
        'abort' to cancel, or provide feedback text to request a revision."

--- a/agents/featurework/execution/agents/execution-agent.md
+++ b/agents/featurework/execution/agents/execution-agent.md
@@ -32,6 +32,7 @@ You will be invoked with a `planPath` — a path to a `docs/plans/*.md` file.
 ## Planning Mode
 
 When a hard-stop is returned from `implementation-agent`:
+- Before informing the developer of a hard-stop and waiting for them to resume, call PushNotification with title: "Execution Paused — Input Required" and message: "Plan execution has been paused due to a hard-stop. Review the plan and reply when ready to resume."
 - Inform the developer that execution is paused and the plan has been marked `draft`.
 - Do not spawn any agents.
 - Wait. When the developer tells you the plan is ready to resume, re-read the plan, confirm its status is `approved`, and resume from step 5 (re-spawn `implementation-agent`).

--- a/agents/featurework/execution/skills/deviation-protocol/SKILL.md
+++ b/agents/featurework/execution/skills/deviation-protocol/SKILL.md
@@ -12,7 +12,9 @@ You must follow this skill exactly when invoked. Do not write any code from the 
 
 1. **Stop writing code immediately.** Do not edit any files until a developer decision is received.
 
-2. **Ask the developer how to proceed.** Present clearly:
+2. Before asking the developer how to proceed on a plan conflict, call PushNotification with title: "Developer Decision Required" and message: "A plan conflict was encountered and requires your decision to continue."
+
+   **Ask the developer how to proceed.** Present clearly:
    - What flow was being implemented.
    - What the conflict or ambiguity is (be specific — quote the plan section if helpful).
    - Your proposed resolution, if you have one.

--- a/agents/featurework/planning/agents/planning-agent.md
+++ b/agents/featurework/planning/agents/planning-agent.md
@@ -28,6 +28,8 @@ Focus only on the system being built and the parts it directly touches. If somet
 
 ## Stages
 
+Before presenting each stage gate and asking for approval, call PushNotification with title: "Plan Review Required" and message: "A planning stage is ready for your review and approval."
+
 | Stage | What to produce | Gate |
 |---|---|---|
 | 1 | Mermaid diagram — use the `create-mermaid-diagram` skill; nodes, boundaries, labeled data flows | User approval required |

--- a/agents/fix-flow/agents/fix-flow-orchestrator.md
+++ b/agents/fix-flow/agents/fix-flow-orchestrator.md
@@ -13,7 +13,7 @@ Runs three phases in strict sequence. Never proceed to the next phase until the 
 
 ## Required argument
 
-The flow name is required. If not provided, stop and ask the developer before doing anything else. 
+The flow name is required. If not provided, before asking the developer for the required flow name, call PushNotification with title: "Input Required" and message: "The fix-flow orchestrator needs a flow name to proceed." Then stop and ask the developer before doing anything else.
 
 ```
 /fix-flow-orchestrator <flow-name>

--- a/agents/fix-flow/agents/ralph-fix-and-push.md
+++ b/agents/fix-flow/agents/ralph-fix-and-push.md
@@ -38,7 +38,7 @@ loop:
 ## Stopping conditions
 
 - Flow passes (exit_code 0 from debugger-agent) → return all-green
-- Debugger-agent is stuck (same root cause appears in the new bug-explanation as in a previous one, with no new progress) → ask the developer how to proceed rather than stopping; do not re-attempt the same fix
+- Debugger-agent is stuck (same root cause appears in the new bug-explanation as in a previous one, with no new progress) → before asking the developer how to proceed when the debugger-agent is stuck, call PushNotification with title: "Debugging Stuck — Input Required" and message: "The debugger-agent is stuck on a repeated root cause and needs your guidance to proceed." Then ask the developer how to proceed rather than stopping; do not re-attempt the same fix
 
 ## Bug explanation files
 

--- a/docs/docs/desktop-notification-user-input.md
+++ b/docs/docs/desktop-notification-user-input.md
@@ -1,0 +1,97 @@
+# Desktop Notification Before User Input
+
+## Metadata
+
+- System type: `flow`
+
+## System Intent
+
+- What this is: A cross-cutting instrumentation pattern applied to every dark-factory agent that requests developer input. Whenever an agent is about to block on a developer reply, it first calls the `PushNotification` tool so the developer receives an OS-level desktop notification.
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  Agent[Dark-factory Agent]:::modified -->|"needs input"| PN[PushNotification tool]:::created
+  PN -->|"notification sent"| AUQ[AskUserQuestion / conversational prompt]:::unchanged
+  AUQ -->|"developer reply"| Agent
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+classDef modified fill:#aec6e8,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+### Flow: `notifyThenAsk`
+
+- Core files: all 9 agent instruction files listed in the Application Sites table below
+
+#### Types
+
+```txt
+PushNotificationPayload {
+  title: string  (short label, e.g. "Input Required")
+  message: string (one sentence describing what the agent needs)
+}
+
+NotifyThenAskInput {
+  context: string  (what the agent was doing when it needs input)
+  question: string (the exact question being asked of the developer)
+}
+
+NotifyThenAskOutput {
+  developerReply: string
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `notifyThenAsk.success` | `NotifyThenAskInput` | `NotifyThenAskOutput` | happy path | PushNotification fires, developer replies |
+| `notifyThenAsk.notificationIgnored` | `NotifyThenAskInput` | `NotifyThenAskOutput` | happy path | Developer misses notification but still replies — behavior is identical |
+
+#### Pseudocode
+
+```
+function notifyThenAsk(title, message, question):
+  PushNotification(title=title, message=message)
+  reply = ask(question)   // conversational or AskUserQuestion tool
+  return reply
+```
+
+## Application Sites
+
+Every location where the pattern is applied:
+
+| Agent file | Trigger condition | PushNotification title | PushNotification message |
+|---|---|---|---|
+| `agents/featurework/agents/feature-agent.md` | Before plan-approval prompt | `"Plan Approval Required"` | `"A plan is ready for your review and requires approval to proceed."` |
+| `agents/featurework/planning/agents/planning-agent.md` | Before each stage-gate approval | `"Plan Review Required"` | `"A planning stage is ready for your review and approval."` |
+| `agents/featurework/execution/skills/deviation-protocol/SKILL.md` | Before conflict-decision prompt | `"Developer Decision Required"` | `"A plan conflict was encountered and requires your decision to continue."` |
+| `agents/featurework/execution/agents/execution-agent.md` | Before hard-stop wait | `"Execution Paused — Input Required"` | `"Plan execution has been paused due to a hard-stop. Review the plan and reply when ready to resume."` |
+| `agents/fix-flow/agents/fix-flow-orchestrator.md` | Missing flow-name argument | `"Input Required"` | `"The fix-flow orchestrator needs a flow name to proceed."` |
+| `agents/fix-flow/agents/ralph-fix-and-push.md` | Debugger-agent stuck on repeated root cause | `"Debugging Stuck — Input Required"` | `"The debugger-agent is stuck on a repeated root cause and needs your guidance to proceed."` |
+| `agents/dark-factory/agents/dark-factory-agent.md` | Ambiguous task classification | `"Clarification Required"` | `"The dark-factory agent needs one clarification before it can route your request."` |
+| `agents/documentation/agents/detect-drift-agent.md` | Unresolvable `wrong` drift items | `"Documentation Drift — Input Required"` | `"The detect-drift agent found items it cannot resolve automatically and needs your guidance."` |
+| `agents/documentation/agents/update-documentation-agent.md` | Missing plan-path argument | `"Input Required"` | `"The update-documentation agent needs a plan path to proceed."` |
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| N/A | No log sinks — all changes are agent instruction text only |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment needed — changes are .md instruction files only
+  ```
+- Notes: All changes are to agent instruction `.md` files. No code is compiled or deployed. Changes take effect immediately when an agent reads its updated instructions.

--- a/docs/plans/2026-04-25-desktop-notification-user-input.md
+++ b/docs/plans/2026-04-25-desktop-notification-user-input.md
@@ -1,0 +1,225 @@
+# Desktop Notification Before User Input
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: N/A
+- Depends on: N/A
+- Status: `approved`
+
+## System Intent
+
+- What is being built: Instrumentation of every dark-factory agent that asks the user/developer for input, so that a `PushNotification` tool call is issued immediately before the user-input request.
+- Primary consumer(s): Dark-factory agents running autonomously in the background; the developer who needs to be notified when their input is required.
+- Boundary (black-box scope only): The `PushNotification` tool is a built-in Claude Code capability — its internals are out of scope. The agents themselves are the only files being modified.
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 Flows approved
+- [x] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  Agent[Dark-factory Agent]:::modified -->|"needs input"| PN[PushNotification tool]:::created
+  PN -->|"notification sent"| AUQ[AskUserQuestion / conversational prompt]:::unchanged
+  AUQ -->|"developer reply"| Agent
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+classDef modified fill:#aec6e8,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+
+PushNotificationPayload {
+  title: string  (short label, e.g. "Input Required")
+  message: string (one sentence describing what the agent needs)
+}
+```
+
+---
+
+### Flow: `notifyThenAsk`
+
+This is the single pattern applied in every location below. Before any user-input request the agent must:
+1. Call `PushNotification` with a title and message that describes what input is needed.
+2. Immediately issue the user-input request (conversational prompt or `AskUserQuestion`).
+
+#### Types
+
+```txt
+NotifyThenAskInput {
+  context: string  (what the agent was doing when it needs input)
+  question: string (the exact question being asked of the developer)
+}
+
+NotifyThenAskOutput {
+  developerReply: string
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `notifyThenAsk.success` | `NotifyThenAskInput` | `NotifyThenAskOutput` | happy path | PushNotification fires, developer replies | |
+| `notifyThenAsk.notificationIgnored` | `NotifyThenAskInput` | `NotifyThenAskOutput` | happy path | Developer misses notification but still replies — no change in behavior | |
+
+#### Pseudocode
+
+```
+function notifyThenAsk(title, message, question):
+  PushNotification(title=title, message=message)
+  reply = ask(question)   // conversational or AskUserQuestion tool
+  return reply
+```
+
+---
+
+## Files to Update
+
+Each entry below identifies the exact file, the location of the user-input request, and the instruction text to add.
+
+---
+
+### 1. `agents/featurework/agents/feature-agent.md`
+
+**Location:** The plan-approval gate section (around line 54-56).
+
+**Current behavior:** Asks the developer: *"Approve this plan? Reply 'yes' or 'approve' to proceed…"*
+
+**Instruction to add (immediately before the approval prompt):**
+> Before asking the developer for plan approval, call `PushNotification` with:
+> - title: `"Plan Approval Required"`
+> - message: `"A plan is ready for your review and requires approval to proceed."`
+
+---
+
+### 2. `agents/featurework/planning/agents/planning-agent.md`
+
+**Location:** Stage gate — "User approval required" after Mermaid diagram; "One approval per flow" after each flow.
+
+**Current behavior:** At each stage gate the agent waits for the developer to approve before advancing.
+
+**Instruction to add (before each stage-gate approval prompt):**
+> Before presenting each stage gate and asking for approval, call `PushNotification` with:
+> - title: `"Plan Review Required"`
+> - message: `"A planning stage is ready for your review and approval."`
+
+---
+
+### 3. `agents/featurework/execution/skills/deviation-protocol/SKILL.md`
+
+**Location:** Lines 15-21 — asks developer how to proceed when a plan conflict is encountered.
+
+**Current behavior:** Presents the conflict and asks: *"How would you like to proceed? Options: (1) course-correct … or (2) hard-stop …"*
+
+**Instruction to add (immediately before presenting the conflict and asking):**
+> Before asking the developer how to proceed on a plan conflict, call `PushNotification` with:
+> - title: `"Developer Decision Required"`
+> - message: `"A plan conflict was encountered and requires your decision to continue."`
+
+---
+
+### 4. `agents/featurework/execution/agents/execution-agent.md`
+
+**Location:** Hard-stop handling section (around lines 34-37) — agent informs the developer that execution is paused and waits for them to say the plan is ready to resume.
+
+**Current behavior:** Informs the developer that execution is paused, then waits for a reply.
+
+**Instruction to add (before informing the developer and waiting):**
+> Before informing the developer of a hard-stop and waiting for them to resume, call `PushNotification` with:
+> - title: `"Execution Paused — Input Required"`
+> - message: `"Plan execution has been paused due to a hard-stop. Review the plan and reply when ready to resume."`
+
+---
+
+### 5. `agents/fix-flow/agents/fix-flow-orchestrator.md`
+
+**Location:** Line 16 — if the flow name is not provided, stop and ask the developer.
+
+**Current behavior:** Stops and asks the developer for the missing flow name.
+
+**Instruction to add (before asking for the flow name):**
+> Before asking the developer for the required flow name, call `PushNotification` with:
+> - title: `"Input Required"`
+> - message: `"The fix-flow orchestrator needs a flow name to proceed."`
+
+---
+
+### 6. `agents/fix-flow/agents/ralph-fix-and-push.md`
+
+**Location:** Lines 38-41 — asks the developer how to proceed when the debugger-agent is stuck.
+
+**Current behavior:** Asks the developer for guidance when the same root cause repeats with no new progress.
+
+**Instruction to add (before asking the developer for guidance):**
+> Before asking the developer how to proceed when the debugger-agent is stuck, call `PushNotification` with:
+> - title: `"Debugging Stuck — Input Required"`
+> - message: `"The debugger-agent is stuck on a repeated root cause and needs your guidance to proceed."`
+
+---
+
+### 7. `agents/dark-factory/agents/dark-factory-agent.md`
+
+**Location:** Line 117 — asks one clarifying question when task classification is ambiguous.
+
+**Current behavior:** Asks the developer one clarifying question before routing.
+
+**Instruction to add (before asking the clarifying question):**
+> Before asking the developer a clarifying question about an ambiguous task, call `PushNotification` with:
+> - title: `"Clarification Required"`
+> - message: `"The dark-factory agent needs one clarification before it can route your request."`
+
+---
+
+### 8. `agents/documentation/agents/detect-drift-agent.md`
+
+**Location:** Line 32 — asks the developer how to proceed on `wrong` drift items.
+
+**Current behavior:** Notes `wrong` items in the report and asks the developer how to proceed.
+
+**Instruction to add (before asking the developer):**
+> Before asking the developer how to proceed on unresolvable drift items, call `PushNotification` with:
+> - title: `"Documentation Drift — Input Required"`
+> - message: `"The detect-drift agent found items it cannot resolve automatically and needs your guidance."`
+
+---
+
+### 9. `agents/documentation/agents/update-documentation-agent.md`
+
+**Location:** Line 17 — if the required plan argument is not provided, stop and ask the developer.
+
+**Current behavior:** Stops and asks the developer for the missing plan path.
+
+**Instruction to add (before asking for the plan path):**
+> Before asking the developer for the required plan path, call `PushNotification` with:
+> - title: `"Input Required"`
+> - message: `"The update-documentation agent needs a plan path to proceed."`
+
+---
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| N/A | No log sinks — all changes are agent instruction text only |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment needed — changes are .md instruction files only
+  ```
+- Notes: All changes are to agent instruction `.md` files. No code is compiled or deployed. Changes take effect immediately when an agent reads its updated instructions.

--- a/tmp/update-docs-flows.md
+++ b/tmp/update-docs-flows.md
@@ -1,0 +1,25 @@
+# Flows Checklist
+
+- [x] notifyThenAsk — created (new pattern applied across 9 agents)
+- [x] feature-agent — modified (PushNotification before plan-approval prompt)
+- [x] planning-agent — modified (PushNotification before each stage-gate approval)
+- [x] deviation-protocol SKILL — modified (PushNotification before conflict-decision prompt)
+- [x] execution-agent — modified (PushNotification before hard-stop wait)
+- [x] fix-flow-orchestrator — modified (PushNotification before missing flow-name ask)
+- [x] ralph-fix-and-push — modified (PushNotification before stuck-debugger guidance ask)
+- [x] dark-factory-agent — modified (PushNotification before clarifying-question)
+- [x] detect-drift-agent — modified (PushNotification before wrong-drift-item ask)
+- [x] update-documentation-agent — modified (PushNotification before missing plan-path ask)
+
+# Affected Docs Checklist
+
+- [x] NEW — notifyThenAsk has no existing doc → created docs/docs/desktop-notification-user-input.md
+- [x] NEW — feature-agent has no existing doc → documented in docs/docs/desktop-notification-user-input.md
+- [x] NEW — planning-agent has no existing doc → documented in docs/docs/desktop-notification-user-input.md
+- [x] NEW — deviation-protocol SKILL has no existing doc → documented in docs/docs/desktop-notification-user-input.md
+- [x] NEW — execution-agent has no existing doc → documented in docs/docs/desktop-notification-user-input.md
+- [x] NEW — fix-flow-orchestrator has no existing doc → documented in docs/docs/desktop-notification-user-input.md
+- [x] NEW — ralph-fix-and-push has no existing doc → documented in docs/docs/desktop-notification-user-input.md
+- [x] NEW — dark-factory-agent has no existing doc → documented in docs/docs/desktop-notification-user-input.md
+- [x] NEW — detect-drift-agent has no existing doc → documented in docs/docs/desktop-notification-user-input.md
+- [x] NEW — update-documentation-agent has no existing doc → documented in docs/docs/desktop-notification-user-input.md


### PR DESCRIPTION
## Description

# Desktop Notification Before User Input

## Plan Metadata

- Plan type: `plan`
- Parent plan: N/A
- Depends on: N/A
- Status: `approved`

## System Intent

- What is being built: Instrumentation of every dark-factory agent that asks the user/developer for input, so that a `PushNotification` tool call is issued immediately before the user-input request.
- Primary consumer(s): Dark-factory agents running autonomously in the background; the developer who needs to be notified when their input is required.
- Boundary (black-box scope only): The `PushNotification` tool is a built-in Claude Code capability -- its internals are out of scope. The agents themselves are the only files being modified.

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [x] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

See plan file for full diagram.

## Flows

### Flow: notifyThenAsk

This is the single pattern applied in every location below. Before any user-input request the agent must:
1. Call PushNotification with a title and message that describes what input is needed.
2. Immediately issue the user-input request (conversational prompt or AskUserQuestion).

## Files Updated

9 agent instruction files were updated to add PushNotification calls before every user-input request:

1. agents/featurework/agents/feature-agent.md - Plan approval gate
2. agents/featurework/planning/agents/planning-agent.md - Stage gate approvals
3. agents/featurework/execution/skills/deviation-protocol/SKILL.md - Plan conflict decision
4. agents/featurework/execution/agents/execution-agent.md - Hard-stop handling
5. agents/fix-flow/agents/fix-flow-orchestrator.md - Missing flow name
6. agents/fix-flow/agents/ralph-fix-and-push.md - Debugger stuck
7. agents/dark-factory/agents/dark-factory-agent.md - Clarifying question
8. agents/documentation/agents/detect-drift-agent.md - Drift items
9. agents/documentation/agents/update-documentation-agent.md - Missing plan path

## Deployment

- Mechanism: local only
- Notes: All changes are to agent instruction .md files. No code is compiled or deployed. Changes take effect immediately when an agent reads its updated instructions.

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
