### PR TITLE
docs: add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+```
+██████╗  █████╗ ██████╗ ██╗  ██╗    ███████╗ █████╗  ██████╗████████╗ ██████╗ ██████╗ ██╗   ██╗
+██╔══██╗██╔══██╗██╔══██╗██║ ██╔╝    ██╔════╝██╔══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔══██╗╚██╗ ██╔╝
+██║  ██║███████║██████╔╝█████╔╝     █████╗  ███████║██║        ██║   ██║   ██║██████╔╝ ╚████╔╝ 
+██║  ██║██╔══██║██╔══██╗██╔═██╗     ██╔══╝  ██╔══██║██║        ██║   ██║   ██║██╔══██╗  ╚██╔╝  
+██████╔╝██║  ██║██║  ██║██║  ██╗    ██║     ██║  ██║╚██████╗   ██║   ╚██████╔╝██║  ██║   ██║   
+╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝    ╚═╝     ╚═╝  ╚═╝ ╚═════╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝   ╚═╝  
+```
+
+Dark Factory is a fully autonomous coding plugin for [Claude Code](https://claude.ai/code). Give it a plan file and it outputs working features — end-to-end. No hand-holding, no back-and-forth. Dark Factory handles the implementation, debugging, code review, and PR from start to finish.
+
+---
+
+## Install
+
+```bash
+git clone https://github.com/lewibs/dark-factory
+cd dark-factory
+claude plugin marketplace add "$(pwd)"
+claude plugin install dark-factory
+```
+
+### Verify
+
+```bash
+claude plugin list
+```
+
+---
+
+## Commands
+
+| Command | Input | Description |
+|---|---|---|
+| `/dark-factory:manufacture` | Task description (e.g. "add OAuth login") | Full orchestration — routes to the right agent (feature, debug, or fix-flow) end-to-end, runs code review, opens a PR, and cleans up |
+| `/dark-factory:init` | Optional GitHub URL | Onboard a project onto dark factory — sets up the structure for infinite autonomous changes and generates a `CLAUDE.md` |
+| `/dark-factory:update` | None | Update the plugin to the latest version |


### PR DESCRIPTION
## Summary
- Adds README.md with ASCII art DARK FACTORY header
- Describes dark factory as a fully autonomous coding plugin
- Includes install commands and a commands table with input column

🤖 Generated with [Claude Code](https://claude.com/claude-code)