### PR TITLE
fix: skip init.sh when directory already exists and proceed to docs phase

### DIFF
--- a/agents/initialization/agents/init-orchestrator-agent.md
+++ b/agents/initialization/agents/init-orchestrator-agent.md
@@ -24,12 +24,21 @@ init-orchestrator-agent(github_url?):
 
   If github_url is provided:
     run: bash <SCRIPT> <github_url>
+    REPO_NAME = basename(github_url, ".git")
+    DERIVED_PROJECT_PATH = REPO_NAME/REPO_NAME
   Else:
     run: bash <SCRIPT>
+    DIRNAME = basename(CWD)
+    DERIVED_PROJECT_PATH = DIRNAME/DIRNAME
 
-  Capture PROJECT_PATH from the script's stdout line: `PROJECT_PATH=<value>`
+  If the script succeeds:
+    Capture PROJECT_PATH from the script's stdout line: `PROJECT_PATH=<value>`
 
-  If the script fails, report the error and STOP.
+  If the script fails with an "already exists" error:
+    Log: "Directory already exists — skipping init.sh, proceeding to documentation phase."
+    PROJECT_PATH = DERIVED_PROJECT_PATH
+
+  If the script fails for any other reason: report the error and STOP.
 
   # Step 2: generate CLAUDE.md for the project
   invoke init-docs-agent with: project_path = PROJECT_PATH
@@ -47,4 +56,4 @@ init-orchestrator-agent(github_url?):
 
 - Never modify init.sh or init-docs-agent.
 - Do not create or edit any files yourself — delegate entirely to the script and agents.
-- If init.sh fails because the target directory already exists, report that to the user and stop — do not attempt to recover.
+- If init.sh fails because the target directory already exists, derive PROJECT_PATH and proceed directly to Step 2 — do not stop.


### PR DESCRIPTION
## Summary

- Previously, when `init.sh` failed with an "already exists" error, `init-orchestrator-agent` reported the error to the user and stopped — no further work was done.
- This change updates the orchestration logic so the agent derives `PROJECT_PATH` from context (using `DERIVED_PROJECT_PATH`, which is computed from the `github_url` basename or the current directory name) and proceeds directly to Step 2 (the documentation phase via `init-docs-agent`).
- The final Rules section is updated to match: "If init.sh fails because the target directory already exists, derive PROJECT_PATH and proceed directly to Step 2 — do not stop."

## Why

When a project directory already exists (e.g., the user re-runs init on a partially-initialized project), stopping was unnecessarily disruptive. The `init.sh` failure is benign in this case — the directory is already in the expected state — so the agent should continue onboarding rather than requiring manual intervention.

## Test plan

- [ ] Run `/dark-factory:init` on a project whose directory already exists; confirm the agent logs the skip message and proceeds to generate `CLAUDE.md`.
- [ ] Run `/dark-factory:init` on a fresh project; confirm the existing happy path (PROJECT_PATH captured from stdout) still works.
- [ ] Run `/dark-factory:init` with a bad `github_url` that causes a non-"already exists" failure; confirm the agent still stops and reports the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)