### PR TITLE
docs(dark_factory): init dark factory documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,6 @@
-# Dark Factory
+# dark_factory
+
+A fully autonomous coding plugin for Claude Code that builds features, fixes bugs, and repairs broken integration flows end-to-end — from planning through code review, PR, and merge — with no manual intervention.
 
 This project is documented in `docs/`. See:
 

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -1,0 +1,8 @@
+# Documentation Index
+
+| Document | Description |
+|---|---|
+| [agents.md](./agents.md) | All orchestration agents — their responsibilities, invocation order, front-matter conventions, and inter-agent relationships |
+| [skills.md](./skills.md) | Reusable skill files used by agents — both project-level and agent-local skills, formats, and inventory |
+| [commands.md](./commands.md) | The three developer-facing slash commands (manufacture, init, update) and how they delegate to agents |
+| [tests.md](./tests.md) | Regression test suite — currently guards PushNotification front-matter declaration across all agents |

--- a/docs/docs/agents.md
+++ b/docs/docs/agents.md
@@ -1,0 +1,141 @@
+# Agents
+
+## Overview
+
+The `agents/` directory contains all orchestration logic for Dark Factory. Agents are markdown files with YAML front-matter that Claude Code loads as sub-agents. Each agent has a narrowly-scoped responsibility and delegates all writing/editing to other agents or skills.
+
+## Agent Inventory
+
+### dark-factory (top-level orchestrator)
+
+**File:** `agents/dark-factory/agents/dark-factory-agent.md`
+
+The root orchestrator invoked by `/dark-factory:manufacture`. It:
+
+1. Runs `agents/dark-factory/scripts/prep-feature-dir.sh <taskName>` to create an isolated working directory (`dark_factory-<taskName>/`).
+2. Classifies the task and routes to the correct worker:
+   - New feature → `feature-agent`
+   - Broken integration / end-to-end failure → `fix-flow-orchestrator`
+   - Bug / crash / unexpected behavior → `debugger-agent`
+3. Runs `code-review-orchestrator-agent` on the result.
+4. Runs `update-documentation-agent` (must complete before the PR step).
+5. Runs `skill-update-agent` (non-fatal — failure only logs a warning).
+6. Invokes `pr-agent` to open, CI-watch, resolve comments, and merge.
+7. Cleans up the isolated work directory.
+
+The agent never writes, edits, or scaffolds code itself — it delegates entirely.
+
+**Classification rules:**
+
+| Signal | Worker |
+|---|---|
+| "add", "build", "create", "implement", "new feature" | `feature-agent` |
+| "broken flow", "integration failing", "end-to-end", "pipeline" | `fix-flow-orchestrator` |
+| "bug", "crash", "error", "fix", "broken", "not working", "debug" | `debugger-agent` |
+| Ambiguous | Sends a PushNotification, then asks a single clarifying question |
+
+---
+
+### featurework
+
+**Directory:** `agents/featurework/`
+
+Handles end-to-end feature implementation through three layers:
+
+- **`feature-agent`** (`agents/featurework/agents/feature-agent.md`) — orchestrates planning → approval gate → execution. Invokes `planning-agent`, presents the plan to the developer, loops on feedback, then invokes `execution-agent` after approval. Sends a PushNotification before requesting approval. Never opens a PR itself.
+- **`planning-agent`** (`agents/featurework/planning/agents/planning-agent.md`) — reads the codebase and writes a plan file under `docs/plans/`.
+- **`execution-agent`** (`agents/featurework/execution/agents/execution-agent.md`) — implements the approved plan. Has sub-agents: `implementation-agent`, `skeleton-agent`, `testing-agent`.
+
+---
+
+### debugger
+
+**File:** `agents/debugger/agents/debugger-agent.md`
+
+Runs systematic debugging on non-obvious, state-dependent, or intermittent bugs. Steps:
+
+1. Confirms the bug warrants systematic debugging.
+2. Creates or reuses a `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` audit log.
+3. Reads all relevant logs and stack traces before touching code.
+4. Follows the debug checklist: write failing test → confirm failure → identify root cause → fix → confirm pass → optionally revert and re-confirm failure.
+5. Records root cause, fix summary, and verification in the bug file.
+
+---
+
+### fix-flow
+
+**Directory:** `agents/fix-flow/`
+
+Autonomously drives a failing integration flow to green. Three phases:
+
+1. **Phase 1 — Understand System**: spawns `investigation-agent` to document the named flow, writes `docs/plans/system-diagram.md`.
+2. **Phase 2 — Setup**: spawns `setup-wizard` to generate trigger/fetch-logs/wait-for-completion/deploy scripts.
+3. **Phase 3 — Fix and Push**: spawns `ralph-fix-and-push` which loops: trigger → debug → PR → deploy until the flow passes.
+
+---
+
+### code-review
+
+**Directory:** `agents/code-review/`
+
+Orchestrates automated code review. Entry point: `code-review-orchestrator-agent`.
+
+1. Creates `tmp/issues.md`.
+2. Spawns `high-level-review-agent` and `low-level-review-agent` in parallel.
+3. Enters a resolver loop: spawns `resolver-agent` repeatedly until `anyRemaining` is false (max 10 iterations).
+4. Deletes `tmp/issues.md` and returns `{ status: "complete" }`.
+
+---
+
+### documentation
+
+**Directory:** `agents/documentation/`
+
+Three agents handle documentation lifecycle:
+
+- **`investigation-agent`** — explores the codebase for a named system, validates or creates `docs/docs/<system-name>.md`. Uses `skills/investigate`, `skills/documentation`, and `skills/detect-drift`.
+- **`update-documentation-agent`** — after a plan is implemented, identifies affected flows, locates relevant `docs/docs/` files, and updates or creates them in three phases (identify flows → identify affected docs → update docs). Requires a plan path; sends PushNotification if missing.
+- **`detect-drift-agent`** — audits parity between `docs/` and the actual implementation.
+
+---
+
+### initialization
+
+**Directory:** `agents/initialization/`
+
+- **`init-orchestrator-agent`** — entry point for `/dark-factory:init`. Runs `agents/initialization/scripts/init.sh`, sets `bypassPermissions` in `~/.claude/settings.json`, invokes `init-docs-agent`, and opens an "init: dark factory" PR via `pr-agent`.
+- **`init-docs-agent`** — discovers major systems in the project, invokes `investigation-agent` for each, writes `docs/docs/` files, `docs/docs/README.md`, and `CLAUDE.md`.
+
+---
+
+### pr
+
+**Directory:** `agents/pr/`
+
+- **`pr-agent`** — stages all changes (`git add --all`), writes PR body from `agents/pr/templates/pr-template.md` to `/tmp/pr-body.md`, opens PR, waits for CI, spawns `resolve-pr-issue` for failures or unresolved review threads, squash-merges, deletes the branch, and returns `{ pr_url, merged: true }`.
+- **`resolve-pr-issue`** — resolves a single CI failure or review thread.
+
+---
+
+### skill-update
+
+**File:** `agents/skill-update/agents/skill-update-agent.md`
+
+After a manufacture run completes, reviews the completed work (plan file + git diff), identifies non-obvious patterns likely to recur, and writes or updates `skills/<slug>/SKILL.md` files. Returns `{ skillsWritten: [] }` when no qualifying patterns are found. Never modifies agent files or files outside `skills/`.
+
+## Front-matter conventions
+
+Every agent file has a YAML front-matter block:
+
+| Field | Purpose |
+|---|---|
+| `name` | Agent identifier |
+| `user-invocable` | Whether the agent can be invoked directly by the developer |
+| `description` | One-line summary |
+| `tools` | Comma-separated list of Claude tools the agent may use |
+| `model` | Model to use (typically `sonnet`) |
+| `skills` | Skill files the agent references |
+| `allowed-tools` | Fine-grained bash command allowlist |
+| `scripts` | Shell scripts the agent is permitted to run |
+
+Agents that call `PushNotification` in their body must declare it in `tools:` — the Claude Code runtime silently skips notifications for agents missing this declaration (see `docs/bugs/`).

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -1,0 +1,51 @@
+# Commands
+
+## Overview
+
+The `commands/` directory contains the three Claude Code slash commands that Dark Factory exposes to the developer. Each command file is a minimal markdown stub that delegates all logic to the corresponding orchestrator agent.
+
+## Command Files
+
+### manufacture
+
+**File:** `commands/manufacture.md`
+
+```
+/dark-factory:manufacture <task description>
+```
+
+Delegates to `agents/dark-factory/agents/dark-factory-agent.md`.
+
+Full end-to-end orchestration: classifies the task, routes to the appropriate worker (feature, debugger, or fix-flow), runs code review and documentation update, opens and merges a PR, and cleans up. Accepts a free-text task description as input (e.g. "add OAuth login", "fix the login crash", "pipeline is failing").
+
+---
+
+### init
+
+**File:** `commands/init.md`
+
+```
+/dark-factory:init [github_url]
+```
+
+Delegates to `agents/initialization/agents/init-orchestrator-agent.md`.
+
+Onboards a project onto Dark Factory. Optionally accepts a GitHub URL; if omitted, treats the current working directory as the project to initialize. Sets up `docs/docs/`, `docs/plans/`, `docs/bugs/` directories, generates `CLAUDE.md`, and opens an "init: dark factory" PR.
+
+---
+
+### update
+
+**File:** `commands/update.md`
+
+```
+/dark-factory:update
+```
+
+Updates the Dark Factory plugin to the latest version via `git pull` and `claude plugin update dark-factory`. Takes no arguments.
+
+## Relationship to Agents
+
+Commands are thin wrappers. Their front-matter carries a `description` for display in Claude Code's command picker, and their body contains a single line: `Follow the instructions in <agent-path> exactly.`
+
+All orchestration logic lives in `agents/`, not in `commands/`.

--- a/docs/docs/skills.md
+++ b/docs/docs/skills.md
@@ -1,0 +1,134 @@
+# Skills
+
+## Overview
+
+The `skills/` directory contains reusable skill files that agents reference during execution. Skills are markdown documents (`SKILL.md`) that describe a concrete, repeatable procedure. They are not agents — they do not have their own invocation lifecycle. An agent reads a skill file and follows its steps.
+
+There are two categories of skills:
+
+1. **Project-level skills** (`skills/`) — general-purpose skills applicable to any project using Dark Factory.
+2. **Agent-local skills** (`agents/<agent-name>/skills/`) — skills scoped to a specific agent's workflows.
+
+## Project-Level Skills
+
+### install
+
+**File:** `skills/install/SKILL.md`
+
+Instructions for installing or updating the Dark Factory plugin in Claude Code via `claude plugin marketplace add` and `claude plugin install dark-factory`.
+
+---
+
+### install-plugin
+
+**File:** `skills/install-plugin/SKILL.md`
+
+Instructions for installing a Claude Code plugin from a local path.
+
+---
+
+### logging
+
+**File:** `skills/logging/SKILL.md`
+
+Instruments code flows with structured log statements. Log format: `log<flow><step><data>`. Steps:
+
+1. Accept a path to a plan, bug, or doc file.
+2. Extract every flow and write a checklist to `tmp/logging-checklist.md` using `skills/logging/templates/logging-checklist-template.md`.
+3. Add a log at each meaningful step (entry, branch, error, exit) in the implementation file.
+4. Delete `tmp/logging-checklist.md` after all flows are instrumented.
+
+Does not introduce new dependencies — uses the project's existing logger (`console.log`, `logger.info`, Python `logging`, etc.).
+
+---
+
+### create-mermaid-diagram
+
+**File:** `skills/create-mermaid-diagram/SKILL.md`
+
+Produces a Mermaid diagram from a codebase or plan. Used to visualize flows.
+
+---
+
+### find-dead-code
+
+**File:** `skills/find-dead-code/SKILL.md`
+
+Scans the codebase for dead code: exported symbols with no callers, unreachable branches, and unused imports.
+
+---
+
+### declare-tools-in-agent-frontmatter
+
+**File:** `skills/declare-tools-in-agent-frontmatter/SKILL.md`
+
+Procedure for ensuring all tools called in an agent body are also declared in its YAML front-matter `tools:` field, preventing silent runtime failures.
+
+---
+
+### handle-idempotent-setup-script
+
+**File:** `skills/handle-idempotent-setup-script/SKILL.md`
+
+Pattern for writing setup scripts that are safe to run more than once (idempotent). Guards against re-creating directories or resources that already exist.
+
+---
+
+### open-in-vscode
+
+**File:** `skills/open-in-vscode/SKILL.md`
+
+Opens a file or directory in VS Code from within an agent context.
+
+## Agent-Local Skills
+
+Agent-local skills live under `agents/<agent-name>/skills/` and are referenced in the agent's front-matter `skills:` field.
+
+### documentation (agents/documentation/skills/)
+
+| Skill | File | Purpose |
+|---|---|---|
+| `investigate` | `skills/investigate/SKILL.md` | Explore an unknown codebase — entry points, data flow, log sources, failure modes, deployment discovery |
+| `documentation` | `skills/documentation/SKILL.md` | Write or update a `docs/docs/` file using the documentation template |
+| `detect-drift` | `skills/detect-drift/SKILL.md` | Audit parity between `docs/plans/` or `docs/docs/` and actual implementation |
+
+### debugger (agents/debugger/skills/)
+
+| Skill | File | Purpose |
+|---|---|---|
+| `debug` | `skills/debug/SKILL.md` | Step-by-step systematic debugging checklist with bug audit log template |
+
+### fix-flow (agents/fix-flow/skills/)
+
+| Skill | File | Purpose |
+|---|---|---|
+| `generate-fetch-logs` | `skills/generate-fetch-logs/SKILL.md` | Generates a script to fetch logs from a running integration flow |
+| `generate-wait-for-completion` | `skills/generate-wait-for-completion/SKILL.md` | Generates a polling script that waits for a flow to complete |
+| `generate-trigger` | `skills/generate-trigger/SKILL.md` | Generates a script to trigger an integration flow |
+| `generate-deploy` | `skills/generate-deploy/SKILL.md` | Generates a deploy script for a flow |
+
+### pr (agents/pr/skills/)
+
+| Skill | File | Purpose |
+|---|---|---|
+| `create-pr` | `skills/create-pr/SKILL.md` | Scripts and procedures for opening, watching, and merging a GitHub PR via `gh` |
+
+## Skill File Format
+
+```
+---
+name: <slug>
+description: "<one sentence: what this skill does and when to use it>"
+user-invocable: false
+---
+## When to use
+<condition>
+
+## Steps
+<numbered steps>
+
+## Notes
+<caveats or gotchas>
+```
+
+Skills written by `skill-update-agent` follow this template exactly. Existing skills are merged (never overwritten) when the agent identifies the same pattern recurs.

--- a/docs/docs/tests.md
+++ b/docs/docs/tests.md
@@ -1,0 +1,43 @@
+# Tests
+
+## Overview
+
+The `tests/` directory contains regression tests that guard against known failure modes discovered during development. Tests are written in Python and run with `pytest`.
+
+## Test Files
+
+### test_push_notification_declared.py
+
+**File:** `tests/test_push_notification_declared.py`
+
+**Purpose:** Ensures that every agent which calls `PushNotification` in its body also declares `PushNotification` in its YAML front-matter `tools:` field. The Claude Code runtime silently skips tool calls for tools not listed in `tools:`, so a missing declaration causes notifications to be dropped without any error.
+
+**What it tests:** Each of the 8 agents known to use `PushNotification`:
+
+- `agents/featurework/agents/feature-agent.md`
+- `agents/featurework/planning/agents/planning-agent.md`
+- `agents/featurework/execution/agents/execution-agent.md`
+- `agents/fix-flow/agents/fix-flow-orchestrator.md`
+- `agents/fix-flow/agents/ralph-fix-and-push.md`
+- `agents/dark-factory/agents/dark-factory-agent.md`
+- `agents/documentation/agents/detect-drift-agent.md`
+- `agents/documentation/agents/update-documentation-agent.md`
+
+**For each agent the test:**
+
+1. Asserts the agent file exists.
+2. Parses the YAML front-matter block (`---` delimiters) and extracts the `tools:` value.
+3. Asserts the agent body (after front-matter) references `PushNotification` — to catch stale entries in the test list.
+4. Asserts `PushNotification` appears in the parsed tools list.
+
+**Parametrized with:** `@pytest.mark.parametrize` — one test case per agent path.
+
+## Running Tests
+
+```bash
+pytest tests/
+```
+
+## Background
+
+These tests were added after the bug documented in `docs/bugs/2026-04-25-push-notification-missing-from-tools.md`, where `PushNotification` calls were silently dropped because agents did not declare the tool in their front-matter.


### PR DESCRIPTION
## Description

init: dark factory

Adds docs/docs/ and CLAUDE.md to dark_factory/dark_factory to bootstrap dark factory integration.

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
