### PR TITLE
fix(docs): rewrite docs/docs/ files to follow documentation template and fix skill path references

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,3 @@
-
-/clear at the end of the manufacture loop
-
 hooks
 * execution logs
 * debugging logs

--- a/agents/documentation/agents/investigation-agent.md
+++ b/agents/documentation/agents/investigation-agent.md
@@ -30,9 +30,9 @@ You are the investigation-agent. Your job is to investigate a system and produce
 
 | Skill | When to use |
 |---|---|
-| `skills/investigate/SKILL.md` | Exploring an unknown codebase — entry points, data flow, log sources, failure modes, deployment discovery |
-| `skills/documentation/SKILL.md` | Writing or updating a `docs/docs/` file using the documentation template |
-| `skills/detect-drift/SKILL.md` | Auditing parity between docs/plans and actual implementation — works for both `docs/docs/` system documents and `docs/plans/` plan files |
+| `agents/documentation/skills/investigate/SKILL.md` | Exploring an unknown codebase — entry points, data flow, log sources, failure modes, deployment discovery |
+| `agents/documentation/skills/documentation/SKILL.md` | Writing or updating a `docs/docs/` file using the documentation template |
+| `agents/documentation/skills/detect-drift/SKILL.md` | Auditing parity between docs/plans and actual implementation — works for both `docs/docs/` system documents and `docs/plans/` plan files |
 
 ## Drift detection
 

--- a/agents/documentation/skills/documentation/SKILL.md
+++ b/agents/documentation/skills/documentation/SKILL.md
@@ -21,4 +21,4 @@ Use this skill whenever a system needs to be documented in `docs/docs/`.
 
 ## Template
 
-Use `templates/documentation-template.md` as the required scaffold for all documentation files.
+Use `agents/documentation/skills/documentation/templates/documentation-template.md` as the required scaffold for all documentation files.

--- a/docs/docs/agents.md
+++ b/docs/docs/agents.md
@@ -1,129 +1,264 @@
 # Agents
 
-## Overview
+## Metadata
 
-The `agents/` directory contains all orchestration logic for Dark Factory. Agents are markdown files with YAML front-matter that Claude Code loads as sub-agents. Each agent has a narrowly-scoped responsibility and delegates all writing/editing to other agents or skills.
+- System type: `library`
+- Owner: dark-factory plugin
+- Source directory: `agents/`
+- Agent count: 24 agent markdown files across 9 subsystems
 
-## Agent Inventory
+## System Intent
 
-### dark-factory (top-level orchestrator)
+- What this is: The `agents/` directory contains all orchestration logic for Dark Factory. Agents are markdown files with YAML front-matter that Claude Code loads as sub-agents. Each agent has a narrowly-scoped responsibility and delegates all writing/editing to other agents or skills. No agent writes code directly — they orchestrate.
+- Primary consumer(s): Claude Code runtime (loads agents via front-matter), `/dark-factory:manufacture` command (entry point).
+- Boundary: Only agent `.md` files. No Python, no shell scripts (except via `allowed-tools`).
 
-**File:** `agents/dark-factory/agents/dark-factory-agent.md`
+## Mermaid Diagram
 
-The root orchestrator invoked by `/dark-factory:manufacture`. It:
+```mermaid
+flowchart TD
+  User([Developer]) -->|/dark-factory:manufacture| DFA[dark-factory-agent]
 
-1. Runs `agents/dark-factory/scripts/prep-feature-dir.sh <taskName>` to create an isolated working directory (`dark_factory-<taskName>/`).
-2. Classifies the task and routes to the correct worker:
-   - New feature → `feature-agent`
-   - Broken integration / end-to-end failure → `fix-flow-orchestrator`
-   - Bug / crash / unexpected behavior → `debugger-agent`
-3. Runs `code-review-orchestrator-agent` on the result.
-4. Runs `update-documentation-agent` (must complete before the PR step).
-5. Runs `skill-update-agent` (non-fatal — failure only logs a warning).
-6. Invokes `pr-agent` to open, CI-watch, resolve comments, and merge.
-7. Cleans up the isolated work directory.
+  DFA -->|new feature| FA[feature-agent]
+  DFA -->|broken flow| FFO[fix-flow-orchestrator]
+  DFA -->|bug / crash| DA[debugger-agent]
+  DFA -->|ambiguous| PN[PushNotification → clarify]
 
-The agent never writes, edits, or scaffolds code itself — it delegates entirely.
+  FA --> PA[planning-agent]
+  PA --> EA[execution-agent]
+  EA --> SkelA[skeleton-agent]
+  EA --> TA[testing-agent]
+  EA --> IA[implementation-agent]
 
-**Classification rules:**
+  FFO --> IVA[investigation-agent]
+  FFO --> SW[setup-wizard]
+  FFO --> RFP[ralph-fix-and-push]
+  RFP --> DFA2[debug-flow-agent]
+  DFA2 --> DA
 
-| Signal | Worker |
-|---|---|
-| "add", "build", "create", "implement", "new feature" | `feature-agent` |
-| "broken flow", "integration failing", "end-to-end", "pipeline" | `fix-flow-orchestrator` |
-| "bug", "crash", "error", "fix", "broken", "not working", "debug" | `debugger-agent` |
-| Ambiguous | Sends a PushNotification, then asks a single clarifying question |
+  DFA -->|after worker| CRO[code-review-orchestrator-agent]
+  CRO --> HLR[high-level-review-agent]
+  CRO --> LLR[low-level-review-agent]
+  CRO --> RA[resolver-agent]
 
----
+  DFA -->|after code review| UDA[update-documentation-agent]
+  DFA -->|after docs| SUA[skill-update-agent]
+  DFA -->|after skills| PRA[pr-agent]
+  PRA --> RPI[resolve-pr-issue]
 
-### featurework
+  DFA -->|init path| IOA[init-orchestrator-agent]
+  IOA --> IDA[init-docs-agent]
+```
 
-**Directory:** `agents/featurework/`
+## Flows
 
-Handles end-to-end feature implementation through three layers:
+### Flow: `manufacture`
 
-- **`feature-agent`** (`agents/featurework/agents/feature-agent.md`) — orchestrates planning → approval gate → execution. Invokes `planning-agent`, presents the plan to the developer, loops on feedback, then invokes `execution-agent` after approval. Sends a PushNotification before requesting approval. Never opens a PR itself.
-- **`planning-agent`** (`agents/featurework/planning/agents/planning-agent.md`) — reads the codebase and writes a plan file under `docs/plans/`.
-- **`execution-agent`** (`agents/featurework/execution/agents/execution-agent.md`) — implements the approved plan. Has sub-agents: `implementation-agent`, `skeleton-agent`, `testing-agent`.
+- Core files: `agents/dark-factory/agents/dark-factory-agent.md`
 
----
+#### Types
 
-### debugger
+```txt
+TaskInput {
+  taskDescription: string (verbatim user request)
+  taskName: string (optional short slug; derived from taskDescription if omitted)
+}
 
-**File:** `agents/debugger/agents/debugger-agent.md`
+WorkerResult {
+  planFilePath: string | null (path written by worker; null if debugger-agent)
+}
 
-Runs systematic debugging on non-obvious, state-dependent, or intermittent bugs. Steps:
+ManufactureOutput {
+  prUrl: string
+  merged: boolean
+  skillsWritten: string[]
+}
 
-1. Confirms the bug warrants systematic debugging.
-2. Creates or reuses a `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` audit log.
-3. Reads all relevant logs and stack traces before touching code.
-4. Follows the debug checklist: write failing test → confirm failure → identify root cause → fix → confirm pass → optionally revert and re-confirm failure.
-5. Records root cause, fix summary, and verification in the bug file.
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
 
----
+#### Paths
 
-### fix-flow
-
-**Directory:** `agents/fix-flow/`
-
-Autonomously drives a failing integration flow to green. Three phases:
-
-1. **Phase 1 — Understand System**: spawns `investigation-agent` to document the named flow, writes `docs/plans/system-diagram.md`.
-2. **Phase 2 — Setup**: spawns `setup-wizard` to generate trigger/fetch-logs/wait-for-completion/deploy scripts.
-3. **Phase 3 — Fix and Push**: spawns `ralph-fix-and-push` which loops: trigger → debug → PR → deploy until the flow passes.
-
----
-
-### code-review
-
-**Directory:** `agents/code-review/`
-
-Orchestrates automated code review. Entry point: `code-review-orchestrator-agent`.
-
-1. Creates `tmp/issues.md`.
-2. Spawns `high-level-review-agent` and `low-level-review-agent` in parallel.
-3. Enters a resolver loop: spawns `resolver-agent` repeatedly until `anyRemaining` is false (max 10 iterations).
-4. Deletes `tmp/issues.md` and returns `{ status: "complete" }`.
-
----
-
-### documentation
-
-**Directory:** `agents/documentation/`
-
-Three agents handle documentation lifecycle:
-
-- **`investigation-agent`** — explores the codebase for a named system, validates or creates `docs/docs/<system-name>.md`. Uses `skills/investigate`, `skills/documentation`, and `skills/detect-drift`.
-- **`update-documentation-agent`** — after a plan is implemented, identifies affected flows, locates relevant `docs/docs/` files, and updates or creates them in three phases (identify flows → identify affected docs → update docs). Requires a plan path; sends PushNotification if missing.
-- **`detect-drift-agent`** — audits parity between `docs/` and the actual implementation.
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `manufacture.feature` | `TaskInput` | `ManufactureOutput` | `happy path` | Routes to feature-agent; runs code-review, docs, skills, PR, cleanup |
+| `manufacture.fixFlow` | `TaskInput` | `ManufactureOutput` | `happy path` | Routes to fix-flow-orchestrator |
+| `manufacture.debug` | `TaskInput` | `ManufactureOutput` | `happy path` | Routes to debugger-agent; planFilePath is null |
+| `manufacture.ambiguous` | `TaskInput` | PushNotification + clarifying question | `branch` | Sends PushNotification before asking developer |
+| `manufacture.workerError` | `TaskInput` | `StandardError` | `error` | Worker returns error or hard-stop; cleanup runs before halt |
+| `manufacture.prepFailure` | `TaskInput` | `StandardError` | `error` | prep-feature-dir.sh fails; no cleanup needed |
 
 ---
 
-### initialization
+### Flow: `featurework`
 
-**Directory:** `agents/initialization/`
+- Core files: `agents/featurework/agents/feature-agent.md`, `agents/featurework/planning/agents/planning-agent.md`, `agents/featurework/execution/agents/execution-agent.md`, `agents/featurework/execution/agents/skeleton-agent.md`, `agents/featurework/execution/agents/testing-agent.md`, `agents/featurework/execution/agents/implementation-agent.md`
 
-- **`init-orchestrator-agent`** — entry point for `/dark-factory:init`. Runs `agents/initialization/scripts/init.sh`, sets `bypassPermissions` in `~/.claude/settings.json`, invokes `init-docs-agent`, and opens an "init: dark factory" PR via `pr-agent`.
-- **`init-docs-agent`** — discovers major systems in the project, invokes `investigation-agent` for each, writes `docs/docs/` files, `docs/docs/README.md`, and `CLAUDE.md`.
+#### Types
+
+```txt
+FeatureInput {
+  taskDescription: string
+}
+
+PlanFile {
+  path: string (docs/plans/<date>-<slug>.md)
+  approved: boolean
+}
+
+FeatureOutput {
+  planFilePath: string
+  testsGreen: boolean
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `featurework.approved` | `FeatureInput` | `FeatureOutput` | `happy path` | planning-agent writes plan; developer approves; execution-agent implements |
+| `featurework.feedbackLoop` | `FeatureInput` | PushNotification + revised plan | `branch` | Developer rejects plan; planning-agent revises; loop repeats |
+| `featurework.hardStop` | `FeatureInput` | `StandardError` | `error` | implementation-agent triggers deviation-protocol and cannot self-resolve |
 
 ---
 
-### pr
+### Flow: `fixFlow`
 
-**Directory:** `agents/pr/`
+- Core files: `agents/fix-flow/agents/fix-flow-orchestrator.md`, `agents/fix-flow/agents/setup-wizard.md`, `agents/fix-flow/agents/ralph-fix-and-push.md`, `agents/fix-flow/agents/debug-flow-agent.md`
 
-- **`pr-agent`** — stages all changes (`git add --all`), writes PR body from `agents/pr/templates/pr-template.md` to `/tmp/pr-body.md`, opens PR, waits for CI, spawns `resolve-pr-issue` for failures or unresolved review threads, squash-merges, deletes the branch, and returns `{ pr_url, merged: true }`.
-- **`resolve-pr-issue`** — resolves a single CI failure or review thread.
+#### Types
+
+```txt
+FixFlowInput {
+  flowName: string (name of the failing integration flow)
+}
+
+DebugFlowInput {
+  triggerScriptPath: string
+  waitScriptPath: string
+  fetchLogsScriptPath: string
+}
+
+DebugFlowOutput {
+  bugFilePath: string (docs/bugs/bug-explanation-<N>.md)
+  exitCode: number (0 = flow passed, 1 = flow failed)
+}
+
+FixFlowOutput {
+  prUrls: string[]
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `fixFlow.success` | `FixFlowInput` | `FixFlowOutput` | `happy path` | investigation → setup → ralph-fix-and-push loop until flow green; debug-flow-agent triggers + fetches logs per iteration |
+| `fixFlow.flowPassed` | `DebugFlowInput` | `DebugFlowOutput{exitCode=0}` | `happy path` | debug-flow-agent runs trigger.sh + wait-for-completion.sh; flow succeeds; no logging or debug needed |
+| `fixFlow.flowFailed` | `DebugFlowInput` | `DebugFlowOutput{exitCode=1}` | `branch` | flow fails; debug-flow-agent fetches logs and delegates to debugger-agent for fix |
+| `fixFlow.missingFlowName` | `FixFlowInput{flowName=null}` | PushNotification + halt | `error` | fix-flow-orchestrator sends PushNotification before asking developer for flow name |
 
 ---
 
-### skill-update
+### Flow: `codeReview`
 
-**File:** `agents/skill-update/agents/skill-update-agent.md`
+- Core files: `agents/code-review/agents/code-review-orchestrator-agent.md`, `agents/code-review/agents/high-level-review-agent.md`, `agents/code-review/agents/low-level-review-agent.md`, `agents/code-review/agents/resolver-agent.md`
 
-After a manufacture run completes, reviews the completed work (plan file + git diff), identifies non-obvious patterns likely to recur, and writes or updates `skills/<slug>/SKILL.md` files. Returns `{ skillsWritten: [] }` when no qualifying patterns are found. Never modifies agent files or files outside `skills/`.
+#### Types
 
-## Front-matter conventions
+```txt
+ReviewInput {
+  planFilePath: string | "Task: <description>"
+  codePath: string
+}
+
+ReviewOutput {
+  status: "complete"
+  anyRemaining: boolean (false when all issues are resolved; true if max iterations hit)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `codeReview.clean` | `ReviewInput` | `ReviewOutput{anyRemaining=false}` | `happy path` | No issues found; resolver loop exits immediately |
+| `codeReview.issuesFound` | `ReviewInput` | `ReviewOutput{anyRemaining=false}` | `happy path` | Resolver loop runs up to 10 iterations until all issues checked off |
+| `codeReview.maxIterations` | `ReviewInput` | `StandardError` | `error` | Resolver loop exceeds 10 iterations without clearing all items; orchestrator halts with stuck-items description |
+
+---
+
+### Flow: `documentation`
+
+- Core files: `agents/documentation/agents/investigation-agent.md`, `agents/documentation/agents/update-documentation-agent.md`, `agents/documentation/agents/detect-drift-agent.md`
+
+#### Types
+
+```txt
+DocUpdateInput {
+  planFilePath: string | null
+}
+
+DocUpdateOutput {
+  filesUpdated: string[]
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `documentation.update` | `DocUpdateInput` | `DocUpdateOutput` | `happy path` | update-documentation-agent identifies affected flows and updates docs/docs/ files |
+| `documentation.missingPlan` | `DocUpdateInput{planFilePath=null}` | PushNotification + error | `error` | update-documentation-agent sends PushNotification before halting |
+| `documentation.driftDetected` | DetectDriftInput | drift report | `branch` | detect-drift-agent flags stale docs; fixes straightforward drift in place |
+
+---
+
+### Flow: `pr`
+
+- Core files: `agents/pr/agents/pr-agent.md`, `agents/pr/agents/resolve-pr-issue.md`
+
+#### Types
+
+```txt
+PRInput {
+  planFilePath: string | taskDescription
+}
+
+PROutput {
+  pr_url: string
+  merged: boolean
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `pr.merged` | `PRInput` | `PROutput{merged=true}` | `happy path` | PR opens, CI passes, squash-merge succeeds |
+| `pr.ciFailure` | `PRInput` | spawn `resolve-pr-issue` | `branch` | CI red; resolve-pr-issue fixes and pushes |
+| `pr.reviewComment` | `PRInput` | spawn `resolve-pr-issue` | `branch` | Unresolved review thread; resolve-pr-issue addresses and resolves |
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| N/A | Agents are markdown instruction files; they produce no structured runtime log output. All observable output is Claude Code session text. |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # Agents are loaded by the Claude Code runtime from the plugin directory.
+  # No deployment step — install the plugin with:
+  claude plugin install dark-factory
+  ```
+- Notes: Agents run inside Claude Code sessions on the developer's local machine. There is no remote runtime or server.
+
+## Front-matter Conventions
 
 Every agent file has a YAML front-matter block:
 
@@ -131,11 +266,11 @@ Every agent file has a YAML front-matter block:
 |---|---|
 | `name` | Agent identifier |
 | `user-invocable` | Whether the agent can be invoked directly by the developer |
-| `description` | One-line summary |
+| `description` | One-line summary shown in Claude Code |
 | `tools` | Comma-separated list of Claude tools the agent may use |
 | `model` | Model to use (typically `sonnet`) |
 | `skills` | Skill files the agent references |
 | `allowed-tools` | Fine-grained bash command allowlist |
 | `scripts` | Shell scripts the agent is permitted to run |
 
-Agents that call `PushNotification` in their body must declare it in `tools:` — the Claude Code runtime silently skips notifications for agents missing this declaration (see `docs/bugs/`).
+Agents that call `PushNotification` in their body must declare it in `tools:` — the Claude Code runtime silently skips notifications for agents missing this declaration (see `docs/bugs/2026-04-25-push-notification-missing-from-tools.md`).

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -1,51 +1,123 @@
 # Commands
 
-## Overview
+## Metadata
 
-The `commands/` directory contains the three Claude Code slash commands that Dark Factory exposes to the developer. Each command file is a minimal markdown stub that delegates all logic to the corresponding orchestrator agent.
+- System type: `library`
+- Owner: dark-factory plugin
+- Source directory: `commands/`
+- Command count: 3 slash commands
 
-## Command Files
+## System Intent
 
-### manufacture
+- What this is: The `commands/` directory contains the three Claude Code slash commands that Dark Factory exposes to the developer. Each command file is a minimal markdown stub that delegates all logic to the corresponding orchestrator agent. Commands carry a `description` field for the Claude Code command picker and a single delegation line in the body.
+- Primary consumer(s): Developers invoking slash commands from the Claude Code interface.
+- Boundary: Commands only contain front-matter and a delegation line. All orchestration logic lives in `agents/`.
 
-**File:** `commands/manufacture.md`
+## Mermaid Diagram
 
+```mermaid
+flowchart TD
+  Dev([Developer]) -->|/dark-factory:manufacture task| CMD_M[commands/manufacture.md]
+  Dev -->|/dark-factory:init github_url?| CMD_I[commands/init.md]
+  Dev -->|/dark-factory:update| CMD_U[commands/update.md]
+
+  CMD_M -->|delegates to| DFA[agents/dark-factory/agents/dark-factory-agent.md]
+  CMD_I -->|delegates to| IOA[agents/initialization/agents/init-orchestrator-agent.md]
+  CMD_U -->|runs directly| GIT[git pull + claude plugin update]
 ```
-/dark-factory:manufacture <task description>
+
+## Flows
+
+### Flow: `manufacture`
+
+- Core files: `commands/manufacture.md`, `agents/dark-factory/agents/dark-factory-agent.md`
+
+#### Types
+
+```txt
+ManufactureInput {
+  taskDescription: string (free-text, e.g. "add OAuth login", "fix login crash")
+}
+
+ManufactureOutput {
+  prUrl: string
+  merged: boolean
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
 ```
 
-Delegates to `agents/dark-factory/agents/dark-factory-agent.md`.
+#### Paths
 
-Full end-to-end orchestration: classifies the task, routes to the appropriate worker (feature, debugger, or fix-flow), runs code review and documentation update, opens and merges a PR, and cleans up. Accepts a free-text task description as input (e.g. "add OAuth login", "fix the login crash", "pipeline is failing").
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `manufacture.success` | `ManufactureInput` | `ManufactureOutput` | `happy path` | Delegates to dark-factory-agent; routes feature/debug/fix-flow, reviews, opens PR |
+| `manufacture.error` | `ManufactureInput` | `StandardError` | `error` | Worker agent returns error or hard-stop; cleanup runs |
 
 ---
 
-### init
+### Flow: `init`
 
-**File:** `commands/init.md`
+- Core files: `commands/init.md`, `agents/initialization/agents/init-orchestrator-agent.md`
 
+#### Types
+
+```txt
+InitInput {
+  githubUrl: string | void (optional GitHub repo URL to clone; omit to use CWD)
+}
+
+InitOutput {
+  prUrl: string (the "init: dark factory" PR)
+}
 ```
-/dark-factory:init [github_url]
-```
 
-Delegates to `agents/initialization/agents/init-orchestrator-agent.md`.
+#### Paths
 
-Onboards a project onto Dark Factory. Optionally accepts a GitHub URL; if omitted, treats the current working directory as the project to initialize. Sets up `docs/docs/`, `docs/plans/`, `docs/bugs/` directories, generates `CLAUDE.md`, and opens an "init: dark factory" PR.
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `init.newRepo` | `InitInput{githubUrl}` | `InitOutput` | `happy path` | Clones repo, runs init.sh, generates docs, opens PR |
+| `init.existingCWD` | `InitInput{void}` | `InitOutput` | `happy path` | Treats CWD as target; runs init.sh, generates docs, opens PR |
 
 ---
 
-### update
+### Flow: `update`
 
-**File:** `commands/update.md`
+- Core files: `commands/update.md`
 
+#### Types
+
+```txt
+UpdateInput {
+  void (no arguments)
+}
+
+UpdateOutput {
+  void (outputs plugin version info to terminal)
+}
 ```
-/dark-factory:update
-```
 
-Updates the Dark Factory plugin to the latest version via `git pull` and `claude plugin update dark-factory`. Takes no arguments.
+#### Paths
 
-## Relationship to Agents
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `update.success` | `UpdateInput` | `UpdateOutput` | `happy path` | Runs `git pull` then `claude plugin update "dark-factory@dark-factory"` |
 
-Commands are thin wrappers. Their front-matter carries a `description` for display in Claude Code's command picker, and their body contains a single line: `Follow the instructions in <agent-path> exactly.`
+## Logs
 
-All orchestration logic lives in `agents/`, not in `commands/`.
+| Source | Location |
+|--------|----------|
+| N/A | Commands are thin stubs; they produce no structured log output. Terminal output from `git pull` and `claude plugin update` is the only observable output for the update command. |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # Commands become available after installing the plugin:
+  claude plugin install dark-factory
+  # Commands are then accessible as /dark-factory:<name> in the Claude Code interface.
+  ```
+- Notes: Commands are loaded by the Claude Code runtime from the plugin's `commands/` directory. No deployment step beyond plugin installation.

--- a/docs/docs/skills.md
+++ b/docs/docs/skills.md
@@ -1,117 +1,239 @@
 # Skills
 
-## Overview
+## Metadata
 
-The `skills/` directory contains reusable skill files that agents reference during execution. Skills are markdown documents (`SKILL.md`) that describe a concrete, repeatable procedure. They are not agents — they do not have their own invocation lifecycle. An agent reads a skill file and follows its steps.
+- System type: `library`
+- Owner: dark-factory plugin
+- Source directories: `skills/` (project-level), `agents/*/skills/` (agent-local)
+- Skill count: 8 project-level + 10 agent-local = 18 skills total
 
-There are two categories of skills:
+## System Intent
 
-1. **Project-level skills** (`skills/`) — general-purpose skills applicable to any project using Dark Factory.
-2. **Agent-local skills** (`agents/<agent-name>/skills/`) — skills scoped to a specific agent's workflows.
+- What this is: Skills are markdown procedure files (`SKILL.md`) that agents read and follow during execution. They are not agents — they have no invocation lifecycle of their own. An agent reads a skill file and executes its steps. Skills encode non-obvious, reusable procedures that would otherwise be duplicated across agents.
+- Primary consumer(s): Dark Factory agents (referenced in agent front-matter `skills:` field). Some skills are also user-invocable as slash commands.
+- Boundary: Skill files are read-only inputs to agents. Skills do not write files, call tools, or produce outputs directly — the consuming agent does.
 
-## Project-Level Skills
+## Mermaid Diagram
 
-### install
+```mermaid
+flowchart TD
+  Agent([Consuming Agent]) -->|reads SKILL.md| Skill[Skill File]
+  Skill -->|step-by-step procedure| Agent
+  Agent -->|executes steps| Output([Skill Output])
 
-**File:** `skills/install/SKILL.md`
+  subgraph ProjectLevel["Project-Level Skills (skills/)"]
+    S1[install]
+    S2[install-plugin]
+    S3[logging]
+    S4[create-mermaid-diagram]
+    S5[find-dead-code]
+    S6[declare-tools-in-agent-frontmatter]
+    S7[handle-idempotent-setup-script]
+    S8[open-in-vscode]
+  end
 
-Instructions for installing or updating the Dark Factory plugin in Claude Code via `claude plugin marketplace add` and `claude plugin install dark-factory`.
+  subgraph AgentLocal["Agent-Local Skills (agents/*/skills/)"]
+    AL1[investigate]
+    AL2[documentation]
+    AL3[detect-drift]
+    AL4[debug]
+    AL5[generate-fetch-logs]
+    AL6[generate-wait-for-completion]
+    AL7[generate-trigger]
+    AL8[generate-deploy]
+    AL9[create-pr]
+    AL10[deviation-protocol]
+  end
+```
+
+## Flows
+
+### Flow: `projectLevelSkills`
+
+- Core files: `skills/install/SKILL.md`, `skills/install-plugin/SKILL.md`, `skills/logging/SKILL.md`, `skills/create-mermaid-diagram/SKILL.md`, `skills/find-dead-code/SKILL.md`, `skills/declare-tools-in-agent-frontmatter/SKILL.md`, `skills/handle-idempotent-setup-script/SKILL.md`, `skills/open-in-vscode/SKILL.md`
+
+#### Types
+
+```txt
+SkillInput {
+  agentContext: string (the task description or file path provided by the consuming agent)
+}
+
+SkillOutput {
+  result: string (what the consuming agent produces after following skill steps)
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `install.pluginMarketplace` | `SkillInput{marketplace install}` | `SkillOutput` | `happy path` | Installs via `claude plugin marketplace add` then `claude plugin install dark-factory` |
+| `install-plugin.localPath` | `SkillInput{local plugin path}` | `SkillOutput` | `happy path` | Installs a Claude Code plugin from a local directory path |
+| `logging.instrumentFlow` | `SkillInput{plan/bug/doc path}` | `SkillOutput{logging-checklist checked}` | `happy path` | Extracts flows, adds structured log statements at entry/branch/error/exit |
+| `create-mermaid-diagram.fromPlan` | `SkillInput{plan or codebase}` | `SkillOutput{mermaid diagram}` | `happy path` | Produces a Mermaid flowchart from a plan file or codebase exploration |
+| `find-dead-code.scan` | `SkillInput{codebase}` | `SkillOutput{dead code report}` | `happy path` | Finds exported symbols with no callers, unreachable branches, unused imports |
+| `declare-tools-in-agent-frontmatter.fix` | `SkillInput{agent file}` | `SkillOutput{front-matter updated}` | `happy path` | Adds missing tool declarations to agent YAML front-matter |
+| `handle-idempotent-setup-script.guard` | `SkillInput{setup script}` | `SkillOutput{script is idempotent}` | `happy path` | Adds existence checks so script is safe to run more than once |
+| `open-in-vscode.open` | `SkillInput{file/dir path}` | `SkillOutput{VS Code opened}` | `happy path` | Opens a file or directory in VS Code from an agent context |
 
 ---
 
-### install-plugin
+### Flow: `documentationSkills`
 
-**File:** `skills/install-plugin/SKILL.md`
+- Core files: `agents/documentation/skills/investigate/SKILL.md`, `agents/documentation/skills/documentation/SKILL.md`, `agents/documentation/skills/detect-drift/SKILL.md`
 
-Instructions for installing a Claude Code plugin from a local path.
+#### Types
 
----
+```txt
+InvestigateInput {
+  systemName: string (name of system to document)
+}
 
-### logging
+DocumentationInput {
+  systemName: string
+  findings: object (from investigate skill)
+}
 
-**File:** `skills/logging/SKILL.md`
+DriftInput {
+  docPath: string (docs/docs/ file to audit)
+}
+```
 
-Instruments code flows with structured log statements. Log format: `log<flow><step><data>`. Steps:
+#### Paths
 
-1. Accept a path to a plan, bug, or doc file.
-2. Extract every flow and write a checklist to `tmp/logging-checklist.md` using `skills/logging/templates/logging-checklist-template.md`.
-3. Add a log at each meaningful step (entry, branch, error, exit) in the implementation file.
-4. Delete `tmp/logging-checklist.md` after all flows are instrumented.
-
-Does not introduce new dependencies — uses the project's existing logger (`console.log`, `logger.info`, Python `logging`, etc.).
-
----
-
-### create-mermaid-diagram
-
-**File:** `skills/create-mermaid-diagram/SKILL.md`
-
-Produces a Mermaid diagram from a codebase or plan. Used to visualize flows.
-
----
-
-### find-dead-code
-
-**File:** `skills/find-dead-code/SKILL.md`
-
-Scans the codebase for dead code: exported symbols with no callers, unreachable branches, and unused imports.
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `investigate.success` | `InvestigateInput` | system intent, flows, logs, deployment findings | `happy path` | Explores codebase via grep/glob to fill documentation template sections |
+| `documentation.write` | `DocumentationInput` | `docs/docs/<system>.md` written | `happy path` | Writes or updates a docs/docs/ file using the documentation template |
+| `detect-drift.audit` | `DriftInput` | drift report with stale/missing items | `happy path` | Audits parity between docs/docs/ and actual implementation |
+| `detect-drift.fixInPlace` | `DriftInput` | `docs/docs/<system>.md` updated | `branch` | Fixes straightforward drift without escalating |
 
 ---
 
-### declare-tools-in-agent-frontmatter
+### Flow: `debuggerSkills`
 
-**File:** `skills/declare-tools-in-agent-frontmatter/SKILL.md`
+- Core files: `agents/debugger/skills/debug/SKILL.md`
 
-Procedure for ensuring all tools called in an agent body are also declared in its YAML front-matter `tools:` field, preventing silent runtime failures.
+#### Types
+
+```txt
+DebugInput {
+  bugDescription: string
+  logPath: string | null
+}
+
+DebugOutput {
+  bugFilePath: string (docs/bugs/<date>-<slug>.md)
+  rootCauseConfirmed: boolean
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `debug.systematicDebugging` | `DebugInput` | `DebugOutput` | `happy path` | Follows Lewibs bug template: failing test → root cause → fix → confirm pass |
 
 ---
 
-### handle-idempotent-setup-script
+### Flow: `fixFlowSkills`
 
-**File:** `skills/handle-idempotent-setup-script/SKILL.md`
+- Core files: `agents/fix-flow/skills/generate-fetch-logs/SKILL.md`, `agents/fix-flow/skills/generate-wait-for-completion/SKILL.md`, `agents/fix-flow/skills/generate-trigger/SKILL.md`, `agents/fix-flow/skills/generate-deploy/SKILL.md`
 
-Pattern for writing setup scripts that are safe to run more than once (idempotent). Guards against re-creating directories or resources that already exist.
+#### Types
+
+```txt
+ScriptGenInput {
+  systemDiagramPath: string (docs/plans/system-diagram.md)
+}
+
+ScriptOutput {
+  scriptPath: string (path to generated .sh file)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `generate-trigger.create` | `ScriptGenInput` | `ScriptOutput{trigger.sh}` | `happy path` | Generates a script to fire the integration flow |
+| `generate-wait-for-completion.create` | `ScriptGenInput` | `ScriptOutput{wait-for-completion.sh}` | `happy path` | Generates a polling script that waits for flow to reach terminal state |
+| `generate-fetch-logs.create` | `ScriptGenInput` | `ScriptOutput{fetch-logs.sh}` | `happy path` | Generates a script to pull all relevant logs |
+| `generate-deploy.create` | `ScriptGenInput` | `ScriptOutput{deploy.sh}` | `branch` | Optional; only generated when fixes cannot be tested locally |
 
 ---
 
-### open-in-vscode
+### Flow: `prSkills`
 
-**File:** `skills/open-in-vscode/SKILL.md`
+- Core files: `agents/pr/skills/create-pr/SKILL.md`
 
-Opens a file or directory in VS Code from within an agent context.
+#### Types
 
-## Agent-Local Skills
+```txt
+PRSkillInput {
+  branchName: string
+  prBodyPath: string
+}
 
-Agent-local skills live under `agents/<agent-name>/skills/` and are referenced in the agent's front-matter `skills:` field.
+PRSkillOutput {
+  prUrl: string
+  merged: boolean
+}
+```
 
-### documentation (agents/documentation/skills/)
+#### Paths
 
-| Skill | File | Purpose |
-|---|---|---|
-| `investigate` | `skills/investigate/SKILL.md` | Explore an unknown codebase — entry points, data flow, log sources, failure modes, deployment discovery |
-| `documentation` | `skills/documentation/SKILL.md` | Write or update a `docs/docs/` file using the documentation template |
-| `detect-drift` | `skills/detect-drift/SKILL.md` | Audit parity between `docs/plans/` or `docs/docs/` and actual implementation |
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `create-pr.open` | `PRSkillInput` | `PRSkillOutput` | `happy path` | Opens PR via `gh pr create`, watches CI, resolves comments, squash-merges |
 
-### debugger (agents/debugger/skills/)
+---
 
-| Skill | File | Purpose |
-|---|---|---|
-| `debug` | `skills/debug/SKILL.md` | Step-by-step systematic debugging checklist with bug audit log template |
+### Flow: `deviationProtocol`
 
-### fix-flow (agents/fix-flow/skills/)
+- Core files: `agents/featurework/execution/skills/deviation-protocol/SKILL.md`
 
-| Skill | File | Purpose |
-|---|---|---|
-| `generate-fetch-logs` | `skills/generate-fetch-logs/SKILL.md` | Generates a script to fetch logs from a running integration flow |
-| `generate-wait-for-completion` | `skills/generate-wait-for-completion/SKILL.md` | Generates a polling script that waits for a flow to complete |
-| `generate-trigger` | `skills/generate-trigger/SKILL.md` | Generates a script to trigger an integration flow |
-| `generate-deploy` | `skills/generate-deploy/SKILL.md` | Generates a deploy script for a flow |
+#### Types
 
-### pr (agents/pr/skills/)
+```txt
+DeviationInput {
+  conflictDescription: string (what in the plan cannot be resolved)
+}
 
-| Skill | File | Purpose |
-|---|---|---|
-| `create-pr` | `skills/create-pr/SKILL.md` | Scripts and procedures for opening, watching, and merging a GitHub PR via `gh` |
+DeviationOutput {
+  action: "course-correct" | "hard-stop"
+  instructions: string | null
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `deviation-protocol.courseCorrect` | `DeviationInput` | `DeviationOutput{action=course-correct}` | `happy path` | Developer provides updated instructions; implementation-agent resumes |
+| `deviation-protocol.hardStop` | `DeviationInput` | `DeviationOutput{action=hard-stop}` | `error` | Developer cannot resolve conflict; implementation halts |
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| N/A | Skills are markdown procedure files; they produce no structured runtime log output. The consuming agent's session text is the only observable output. |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # Skills are bundled with the plugin and loaded by agents at runtime.
+  # No deployment step — install the plugin with:
+  claude plugin install dark-factory
+  ```
+- Notes: Skills live in the plugin repository. They are read by agents during Claude Code sessions on the developer's local machine. There is no remote runtime.
 
 ## Skill File Format
 

--- a/docs/docs/tests.md
+++ b/docs/docs/tests.md
@@ -1,18 +1,91 @@
 # Tests
 
-## Overview
+## Metadata
 
-The `tests/` directory contains regression tests that guard against known failure modes discovered during development. Tests are written in Python and run with `pytest`.
+- System type: `library`
+- Owner: dark-factory plugin
+- Source directory: `tests/`
+- Test framework: `pytest`
+- Test file count: 2
 
-## Test Files
+## System Intent
 
-### test_push_notification_declared.py
+- What this is: The `tests/` directory contains regression tests that guard against known failure modes discovered during development. Tests are written in Python and run with `pytest`. Currently one test file guards against a silent runtime failure mode where agents omit `PushNotification` from their front-matter `tools:` field.
+- Primary consumer(s): CI systems and developers running `pytest tests/` locally before merging.
+- Boundary: Tests are read-only validators; they do not modify agent files.
 
-**File:** `tests/test_push_notification_declared.py`
+## Mermaid Diagram
 
-**Purpose:** Ensures that every agent which calls `PushNotification` in its body also declares `PushNotification` in its YAML front-matter `tools:` field. The Claude Code runtime silently skips tool calls for tools not listed in `tools:`, so a missing declaration causes notifications to be dropped without any error.
+```mermaid
+flowchart TD
+  Dev([Developer / CI]) -->|pytest tests/| PY[pytest runner]
 
-**What it tests:** Each of the 8 agents known to use `PushNotification`:
+  PY -->|parametrize 8 agent paths| TC[test_push_notification_in_tools_field]
+
+  TC -->|for each agent| AF[Agent .md file]
+  AF -->|assert file exists| E1{exists?}
+  E1 -->|no| FAIL1[AssertionError: file not found]
+  E1 -->|yes| FM[parse YAML front-matter]
+  FM -->|extract tools: field| TL[tools list]
+  TL -->|assert body contains PushNotification| B1{body refs PN?}
+  B1 -->|no| FAIL2[AssertionError: stale test list]
+  B1 -->|yes| TF{PN in tools?}
+  TF -->|no| FAIL3[AssertionError: PN missing from tools]
+  TF -->|yes| PASS[test passes]
+```
+
+## Flows
+
+### Flow: `pushNotificationDeclared`
+
+- Test files: `tests/test_push_notification_declared.py`
+- Core files: 8 agent `.md` files (see parametrize list below)
+
+#### Types
+
+```txt
+AgentFilePath {
+  path: string (relative path from project root, e.g. "agents/featurework/agents/feature-agent.md")
+}
+
+FrontMatter {
+  tools: string[] (comma-separated tool names parsed from YAML --- block)
+}
+
+TestResult {
+  passed: boolean
+  failedCases: string[] (agent paths that failed any assertion)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `pushNotificationDeclared.pass` | `AgentFilePath` | `TestResult{passed=true}` | `happy path` | File exists, body references PushNotification, tools: field includes PushNotification |
+| `pushNotificationDeclared.fileNotFound` | `AgentFilePath` | `TestResult{passed=false}` | `error` | Agent file missing from disk; assertion fails with "Agent file not found" |
+| `pushNotificationDeclared.staleTestList` | `AgentFilePath` | `TestResult{passed=false}` | `error` | Agent body no longer references PushNotification; test list may be outdated |
+| `pushNotificationDeclared.missingFromTools` | `AgentFilePath` | `TestResult{passed=false}` | `error` | Agent calls PushNotification in body but front-matter tools: field does not list it |
+
+#### Pseudocode
+
+```
+For each agent_path in AGENTS_USING_PUSH_NOTIFICATION:
+  abs_path = PROJECT_ROOT / agent_path
+  assert os.path.exists(abs_path)
+
+  content = read(abs_path)
+
+  # Strip front-matter so tools: declaration does not satisfy body check
+  fm_end = content.find("\n---", 4)
+  body = content[fm_end + 4:]
+  assert "PushNotification" in body  # guards against stale test list
+
+  tools = parse_front_matter_tools(content)
+  assert "PushNotification" in tools
+```
+
+**Parametrized agent paths (8 total):**
 
 - `agents/featurework/agents/feature-agent.md`
 - `agents/featurework/planning/agents/planning-agent.md`
@@ -23,21 +96,83 @@ The `tests/` directory contains regression tests that guard against known failur
 - `agents/documentation/agents/detect-drift-agent.md`
 - `agents/documentation/agents/update-documentation-agent.md`
 
-**For each agent the test:**
+---
 
-1. Asserts the agent file exists.
-2. Parses the YAML front-matter block (`---` delimiters) and extracts the `tools:` value.
-3. Asserts the agent body (after front-matter) references `PushNotification` — to catch stale entries in the test list.
-4. Asserts `PushNotification` appears in the parsed tools list.
+### Flow: `docsTemplateCompliance`
 
-**Parametrized with:** `@pytest.mark.parametrize` — one test case per agent path.
+- Test files: `tests/test_docs_template_compliance.py`
+- Core files: `docs/docs/agents.md`, `docs/docs/commands.md`, `docs/docs/skills.md`, `docs/docs/tests.md`
 
-## Running Tests
+#### Types
 
-```bash
-pytest tests/
+```txt
+DocFilePath {
+  path: string (absolute path to a docs/docs/ markdown file)
+}
+
+TemplateComplianceResult {
+  passed: boolean
+  failedDocs: string[] (paths of docs/docs/ files missing required sections)
+}
 ```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `docsTemplateCompliance.pass` | `DocFilePath` | `TemplateComplianceResult{passed=true}` | `happy path` | All required sections (Metadata, Mermaid Diagram, Flows, Logs, Deployment) present; Mermaid block exists; Types+Paths subsections present; Logs has Source table; Deployment has Mechanism field |
+| `docsTemplateCompliance.missingSection` | `DocFilePath` | `TemplateComplianceResult{passed=false}` | `error` | One or more of the 5 required top-level sections is absent |
+| `docsTemplateCompliance.missingMermaid` | `DocFilePath` | `TemplateComplianceResult{passed=false}` | `error` | Mermaid Diagram section lacks a ```mermaid code block |
+| `docsTemplateCompliance.missingFlowSubsections` | `DocFilePath` | `TemplateComplianceResult{passed=false}` | `error` | Flows section missing #### Types or #### Paths subsection |
+| `docsTemplateCompliance.missingLogsTable` | `DocFilePath` | `TemplateComplianceResult{passed=false}` | `error` | Logs section has no markdown table with a Source column |
+| `docsTemplateCompliance.missingMechanism` | `DocFilePath` | `TemplateComplianceResult{passed=false}` | `error` | Deployment section does not declare `- Mechanism:` |
+
+#### Pseudocode
+
+```
+DOCS_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) + "/docs/docs"
+
+DOC_FILES = [agents.md, commands.md, skills.md, tests.md]
+
+REQUIRED_SECTIONS = [
+  "## Metadata", "## Mermaid Diagram", "## Flows", "## Logs", "## Deployment"
+]
+
+For each doc_path in DOC_FILES:
+  content = read(doc_path)
+  assert all REQUIRED_SECTIONS present in content
+  assert "System type:" in content
+  assert "```mermaid" in content
+  assert "#### Types" in content
+  assert "#### Paths" in content
+  assert "| Source |" in content
+  assert "- Mechanism:" in content
+```
+
+**Parametrized doc paths (4 total):**
+
+- `docs/docs/agents.md`
+- `docs/docs/commands.md`
+- `docs/docs/skills.md`
+- `docs/docs/tests.md`
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| N/A | pytest writes test results to stdout only. No structured log destinations. Run with `-v` flag for verbose output per test case. |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  pytest tests/
+  # or verbose:
+  pytest tests/test_push_notification_declared.py -v
+  ```
+- Notes: Tests run locally against the plugin source files on disk. No external services or network calls required. All assertions operate on local file reads.
 
 ## Background
 
-These tests were added after the bug documented in `docs/bugs/2026-04-25-push-notification-missing-from-tools.md`, where `PushNotification` calls were silently dropped because agents did not declare the tool in their front-matter.
+These tests were added after the bug documented in `docs/bugs/2026-04-25-push-notification-missing-from-tools.md`, where `PushNotification` calls were silently dropped because agents did not declare the tool in their front-matter. The Claude Code runtime does not raise an error for undeclared tools — it simply skips them, making this failure mode invisible without explicit testing.

--- a/docs/plans/2026-04-26-regen-docs-with-template.md
+++ b/docs/plans/2026-04-26-regen-docs-with-template.md
@@ -1,0 +1,315 @@
+# Regenerate docs/docs/ Files Using Documentation Template
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: N/A
+- Depends on: N/A
+- Status: `approved`
+
+## System Intent
+
+- What is being built: Rewrites the four existing `docs/docs/` files (agents.md, commands.md, skills.md, tests.md) so each conforms to the required documentation template — Metadata, Mermaid Diagram, Flows (Types + Paths + optional Pseudocode), Logs, and Deployment.
+- Primary consumer(s): Developers reading system docs; `update-documentation-agent` and `detect-drift-agent` which validate docs against code.
+- Boundary (black-box scope only): Only `docs/docs/agents.md`, `docs/docs/commands.md`, `docs/docs/skills.md`, and `docs/docs/tests.md` are modified. No agent, skill, command, or test files are changed.
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 Flows approved
+- [x] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  Start([Regen Docs Task]):::created
+
+  subgraph Flow1["Flow: regenAgentsDocs"]
+    A1[Investigate agents/ directory]:::created --> A2[Write docs/docs/agents.md]:::created
+  end
+
+  subgraph Flow2["Flow: regenCommandsDocs"]
+    B1[Investigate commands/ directory]:::created --> B2[Write docs/docs/commands.md]:::created
+  end
+
+  subgraph Flow3["Flow: regenSkillsDocs"]
+    C1[Investigate skills/ + agent-local skills]:::created --> C2[Write docs/docs/skills.md]:::created
+  end
+
+  subgraph Flow4["Flow: regenTestsDocs"]
+    D1[Investigate tests/ directory]:::created --> D2[Write docs/docs/tests.md]:::created
+  end
+
+  Start --> Flow1
+  Start --> Flow2
+  Start --> Flow3
+  Start --> Flow4
+
+  A2 --> Done([4 docs/docs/ files updated]):::created
+  B2 --> Done
+  C2 --> Done
+  D2 --> Done
+
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+### Global Types
+
+```txt
+DocInput {
+  systemName: string (one of: agents, commands, skills, tests)
+  sourceDir: string (directory to investigate)
+  outputPath: string (docs/docs/<systemName>.md)
+}
+
+DocOutput {
+  outputPath: string (path written)
+  sectionsWritten: string[] (Metadata, Mermaid, Flows, Logs, Deployment)
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+---
+
+### Flow: `regenAgentsDocs`
+
+- Test files: N/A
+- Core files:
+  - `agents/dark-factory/agents/dark-factory-agent.md`
+  - `agents/featurework/agents/feature-agent.md`
+  - `agents/featurework/planning/agents/planning-agent.md`
+  - `agents/featurework/execution/agents/execution-agent.md`
+  - `agents/featurework/execution/agents/skeleton-agent.md`
+  - `agents/featurework/execution/agents/testing-agent.md`
+  - `agents/featurework/execution/agents/implementation-agent.md`
+  - `agents/debugger/agents/debugger-agent.md`
+  - `agents/fix-flow/agents/fix-flow-orchestrator.md`
+  - `agents/fix-flow/agents/debug-flow-agent.md`
+  - `agents/fix-flow/agents/ralph-fix-and-push.md`
+  - `agents/fix-flow/agents/setup-wizard.md`
+  - `agents/code-review/agents/code-review-orchestrator-agent.md`
+  - `agents/code-review/agents/high-level-review-agent.md`
+  - `agents/code-review/agents/low-level-review-agent.md`
+  - `agents/code-review/agents/resolver-agent.md`
+  - `agents/documentation/agents/investigation-agent.md`
+  - `agents/documentation/agents/update-documentation-agent.md`
+  - `agents/documentation/agents/detect-drift-agent.md`
+  - `agents/initialization/agents/init-orchestrator-agent.md`
+  - `agents/initialization/agents/init-docs-agent.md`
+  - `agents/pr/agents/pr-agent.md`
+  - `agents/pr/agents/resolve-pr-issue.md`
+  - `agents/skill-update/agents/skill-update-agent.md`
+  - `docs/docs/agents.md` (existing — read before overwriting)
+
+#### Types
+
+```txt
+AgentFile {
+  name: string (agent identifier from front-matter)
+  tools: string[] (tools declared in front-matter)
+  model: string
+  userInvocable: boolean
+  skills: string[] (skill paths declared in front-matter)
+  scripts: string[] (script paths declared in front-matter)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `regenAgentsDocs.success` | `DocInput{systemName=agents}` | `DocOutput` | `happy path` | Read all agent .md files; apply investigate skill; write docs/docs/agents.md using documentation template |
+| `regenAgentsDocs.missingFile` | `DocInput{systemName=agents}` | `StandardError` | `error` | An expected agent file is missing from agents/ |
+
+#### Pseudocode
+
+```
+1. Read agents/documentation/skills/investigate/SKILL.md
+2. For each agent directory group (dark-factory, featurework, debugger, fix-flow,
+   code-review, documentation, initialization, pr, skill-update):
+   a. Read each agent .md file — capture: name, tools, model, user-invocable,
+      description, orchestration pseudocode, input/output contracts
+3. Identify system type: library (no runtime — agents are markdown instructions)
+4. Build Mermaid diagram showing top-level orchestration flow from dark-factory-agent
+   through worker agents (feature-agent, debugger-agent, fix-flow-orchestrator)
+5. Write one flow per major agent group with input/output types and paths table
+6. Logs: N/A (agents are markdown — no runtime log emission)
+7. Deployment: local only (agents run inside Claude Code sessions)
+8. Write docs/docs/agents.md using documentation template
+```
+
+---
+
+### Flow: `regenCommandsDocs`
+
+- Test files: N/A
+- Core files:
+  - `commands/manufacture.md`
+  - `commands/init.md`
+  - `commands/update.md`
+  - `docs/docs/commands.md` (existing — read before overwriting)
+
+#### Types
+
+```txt
+CommandFile {
+  name: string (command slug)
+  description: string (front-matter description shown in Claude Code picker)
+  delegatesTo: string (path to agent file)
+  args: string (argument signature, e.g. "<task description>" or "[github_url]")
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `regenCommandsDocs.success` | `DocInput{systemName=commands}` | `DocOutput` | `happy path` | Read all 3 command files; write docs/docs/commands.md using documentation template |
+| `regenCommandsDocs.missingFile` | `DocInput{systemName=commands}` | `StandardError` | `error` | A command file is absent from commands/ |
+
+#### Pseudocode
+
+```
+1. Read commands/manufacture.md, commands/init.md, commands/update.md
+2. For each command capture: front-matter description, delegate agent path, argument format
+3. System type: library (slash-command stubs — no runtime logic)
+4. Build Mermaid diagram: User → /dark-factory:<cmd> → Delegates to → Agent
+5. Write one flow per command (manufacture, init, update) with input type = TaskDescription | void
+6. Logs: N/A (commands are stubs with no log output)
+7. Deployment: local only (plugin install makes commands available in Claude Code)
+8. Write docs/docs/commands.md using documentation template
+```
+
+---
+
+### Flow: `regenSkillsDocs`
+
+- Test files: N/A
+- Core files:
+  - `skills/create-mermaid-diagram/SKILL.md`
+  - `skills/find-dead-code/SKILL.md`
+  - `skills/logging/SKILL.md`
+  - `skills/install-plugin/SKILL.md`
+  - `skills/install/SKILL.md`
+  - `skills/open-in-vscode/SKILL.md`
+  - `skills/handle-idempotent-setup-script/SKILL.md`
+  - `skills/declare-tools-in-agent-frontmatter/SKILL.md`
+  - `agents/documentation/skills/investigate/SKILL.md`
+  - `agents/documentation/skills/documentation/SKILL.md`
+  - `agents/documentation/skills/detect-drift/SKILL.md`
+  - `agents/debugger/skills/debug/SKILL.md`
+  - `agents/fix-flow/skills/generate-fetch-logs/SKILL.md`
+  - `agents/fix-flow/skills/generate-wait-for-completion/SKILL.md`
+  - `agents/fix-flow/skills/generate-trigger/SKILL.md`
+  - `agents/fix-flow/skills/generate-deploy/SKILL.md`
+  - `agents/pr/skills/create-pr/SKILL.md`
+  - `agents/featurework/execution/skills/deviation-protocol/SKILL.md`
+  - `docs/docs/skills.md` (existing — read before overwriting)
+
+#### Types
+
+```txt
+SkillFile {
+  name: string (skill slug from front-matter)
+  description: string (one-sentence description)
+  userInvocable: boolean
+  scope: "project-level" | "agent-local"
+  ownerAgent: string | null (agent directory if agent-local)
+  steps: string[] (procedure steps)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `regenSkillsDocs.success` | `DocInput{systemName=skills}` | `DocOutput` | `happy path` | Read all skill SKILL.md files (project-level + agent-local); write docs/docs/skills.md using documentation template |
+| `regenSkillsDocs.missingFile` | `DocInput{systemName=skills}` | `StandardError` | `error` | A skill file listed in the inventory is missing |
+
+#### Pseudocode
+
+```
+1. Glob skills/**/*.md for project-level skills
+2. Glob agents/*/skills/**/*.md for agent-local skills
+3. For each skill read: name, description, user-invocable, steps, when-to-use, notes
+4. Group by scope: project-level vs agent-local (with owner agent)
+5. System type: library (skills are markdown procedure files consumed by agents)
+6. Build Mermaid diagram: Agent → reads SKILL.md → follows Steps → writes output
+7. Write one flow per skill category group (project-level, documentation, debugger,
+   fix-flow, pr, featurework) with input = AgentContext and output = SkillOutput
+8. Logs: N/A (skills produce no log output themselves)
+9. Deployment: local only (skills live in the plugin repo, loaded by agents at runtime)
+10. Write docs/docs/skills.md using documentation template
+```
+
+---
+
+### Flow: `regenTestsDocs`
+
+- Test files: `tests/test_push_notification_declared.py`
+- Core files:
+  - `tests/test_push_notification_declared.py`
+  - `docs/docs/tests.md` (existing — read before overwriting)
+
+#### Types
+
+```txt
+TestFile {
+  path: string (relative path to test file)
+  purpose: string (what failure mode it guards)
+  parametrizedCases: string[] (agent paths under test)
+  assertionSteps: string[] (ordered assertions per case)
+}
+
+TestResult {
+  passed: boolean
+  failedCases: string[]
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `regenTestsDocs.success` | `DocInput{systemName=tests}` | `DocOutput` | `happy path` | Read tests/*.py; write docs/docs/tests.md using documentation template |
+| `regenTestsDocs.missingFile` | `DocInput{systemName=tests}` | `StandardError` | `error` | tests/ directory or a listed test file is absent |
+
+#### Pseudocode
+
+```
+1. Read tests/test_push_notification_declared.py
+2. Capture: pytest parametrize list (8 agent paths), assertion sequence per case
+3. Cross-reference docs/bugs/ for the originating bug that motivated these tests
+4. System type: library (test suite — no deployed runtime)
+5. Build Mermaid diagram: pytest → parametrized agent paths → parse YAML front-matter
+   → assert PushNotification in tools
+6. Write one flow per test file (currently one: pushNotificationDeclared)
+   with input = AgentFilePath and output = TestResult
+7. Logs: N/A (pytest stdout only — no structured log destinations)
+8. Deployment: local only (`pytest tests/`)
+9. Write docs/docs/tests.md using documentation template
+```
+
+---
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| N/A | This is a documentation-only task; no runtime log sources are modified or introduced. |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment needed — this task only rewrites docs/docs/ markdown files.
+  # Verify by reading the four output files after the flows complete.
+  ```
+- Notes: All four output files must pass a manual review against the documentation template before this plan is considered complete.

--- a/tests/test_docs_template_compliance.py
+++ b/tests/test_docs_template_compliance.py
@@ -1,0 +1,102 @@
+"""
+Tests that each docs/docs/ file conforms to the required documentation template.
+
+Required sections (from agents/documentation/skills/documentation/templates/documentation-template.md):
+  - Metadata
+  - Mermaid Diagram
+  - Flows
+  - Logs
+  - Deployment
+"""
+
+import os
+import pytest
+
+DOCS_ROOT = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "docs", "docs")
+
+DOC_FILES = [
+    f"{DOCS_ROOT}/agents.md",
+    f"{DOCS_ROOT}/commands.md",
+    f"{DOCS_ROOT}/skills.md",
+    f"{DOCS_ROOT}/tests.md",
+]
+
+REQUIRED_SECTIONS = [
+    "## Metadata",
+    "## Mermaid Diagram",
+    "## Flows",
+    "## Logs",
+    "## Deployment",
+]
+
+REQUIRED_FLOW_SUBSECTIONS = [
+    "#### Types",
+    "#### Paths",
+]
+
+REQUIRED_METADATA_FIELDS = [
+    "System type:",
+]
+
+
+@pytest.mark.parametrize("doc_path", DOC_FILES)
+def test_required_sections_present(doc_path):
+    with open(doc_path) as f:
+        content = f.read()
+
+    missing = [s for s in REQUIRED_SECTIONS if s not in content]
+    assert not missing, (
+        f"{doc_path} is missing required template sections: {missing}"
+    )
+
+
+@pytest.mark.parametrize("doc_path", DOC_FILES)
+def test_metadata_has_system_type(doc_path):
+    with open(doc_path) as f:
+        content = f.read()
+
+    assert "System type:" in content, (
+        f"{doc_path} Metadata section must declare 'System type:'"
+    )
+
+
+@pytest.mark.parametrize("doc_path", DOC_FILES)
+def test_mermaid_diagram_has_code_block(doc_path):
+    with open(doc_path) as f:
+        content = f.read()
+
+    assert "```mermaid" in content, (
+        f"{doc_path} must contain a ```mermaid code block in the Mermaid Diagram section"
+    )
+
+
+@pytest.mark.parametrize("doc_path", DOC_FILES)
+def test_flows_section_has_types_and_paths(doc_path):
+    with open(doc_path) as f:
+        content = f.read()
+
+    missing = [s for s in REQUIRED_FLOW_SUBSECTIONS if s not in content]
+    assert not missing, (
+        f"{doc_path} Flows section is missing subsections: {missing}"
+    )
+
+
+@pytest.mark.parametrize("doc_path", DOC_FILES)
+def test_logs_section_has_table(doc_path):
+    with open(doc_path) as f:
+        content = f.read()
+
+    # The Logs section must contain a markdown table (indicated by | Source |)
+    assert "| Source |" in content, (
+        f"{doc_path} Logs section must contain a table with a 'Source' column"
+    )
+
+
+@pytest.mark.parametrize("doc_path", DOC_FILES)
+def test_deployment_section_has_mechanism(doc_path):
+    with open(doc_path) as f:
+        content = f.read()
+
+    assert "- Mechanism:" in content, (
+        f"{doc_path} Deployment section must declare '- Mechanism:'"
+    )


### PR DESCRIPTION
## Description

# Regenerate docs/docs/ Files Using Documentation Template

## Plan Metadata

- Plan type: `plan`
- Parent plan: N/A
- Depends on: N/A
- Status: `approved`

## System Intent

- What is being built: Rewrites the four existing `docs/docs/` files (agents.md, commands.md, skills.md, tests.md) so each conforms to the required documentation template — Metadata, Mermaid Diagram, Flows (Types + Paths + optional Pseudocode), Logs, and Deployment.
- Primary consumer(s): Developers reading system docs; `update-documentation-agent` and `detect-drift-agent` which validate docs against code.
- Boundary (black-box scope only): Only `docs/docs/agents.md`, `docs/docs/commands.md`, `docs/docs/skills.md`, and `docs/docs/tests.md` are modified. No agent, skill, command, or test files are changed.

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [x] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

```mermaid
graph TD
  Start([Regen Docs Task]):::created

  subgraph Flow1["Flow: regenAgentsDocs"]
    A1[Investigate agents/ directory]:::created --> A2[Write docs/docs/agents.md]:::created
  end

  subgraph Flow2["Flow: regenCommandsDocs"]
    B1[Investigate commands/ directory]:::created --> B2[Write docs/docs/commands.md]:::created
  end

  subgraph Flow3["Flow: regenSkillsDocs"]
    C1[Investigate skills/ + agent-local skills]:::created --> C2[Write docs/docs/skills.md]:::created
  end

  subgraph Flow4["Flow: regenTestsDocs"]
    D1[Investigate tests/ directory]:::created --> D2[Write docs/docs/tests.md]:::created
  end

  Start --> Flow1
  Start --> Flow2
  Start --> Flow3
  Start --> Flow4

  A2 --> Done([4 docs/docs/ files updated]):::created
  B2 --> Done
  C2 --> Done
  D2 --> Done

classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
```

## Flows

### Global Types

```txt
DocInput {
  systemName: string (one of: agents, commands, skills, tests)
  sourceDir: string (directory to investigate)
  outputPath: string (docs/docs/<systemName>.md)
}

DocOutput {
  outputPath: string (path written)
  sectionsWritten: string[] (Metadata, Mermaid, Flows, Logs, Deployment)
}

StandardError {
  message: string (human-readable description of what went wrong)
}
```

---

### Flow: `regenAgentsDocs`

- Test files: N/A
- Core files:
  - `agents/dark-factory/agents/dark-factory-agent.md`
  - `agents/featurework/agents/feature-agent.md`
  - `agents/featurework/planning/agents/planning-agent.md`
  - `agents/featurework/execution/agents/execution-agent.md`
  - `agents/featurework/execution/agents/skeleton-agent.md`
  - `agents/featurework/execution/agents/testing-agent.md`
  - `agents/featurework/execution/agents/implementation-agent.md`
  - `agents/debugger/agents/debugger-agent.md`
  - `agents/fix-flow/agents/fix-flow-orchestrator.md`
  - `agents/fix-flow/agents/debug-flow-agent.md`
  - `agents/fix-flow/agents/ralph-fix-and-push.md`
  - `agents/fix-flow/agents/setup-wizard.md`
  - `agents/code-review/agents/code-review-orchestrator-agent.md`
  - `agents/code-review/agents/high-level-review-agent.md`
  - `agents/code-review/agents/low-level-review-agent.md`
  - `agents/code-review/agents/resolver-agent.md`
  - `agents/documentation/agents/investigation-agent.md`
  - `agents/documentation/agents/update-documentation-agent.md`
  - `agents/documentation/agents/detect-drift-agent.md`
  - `agents/initialization/agents/init-orchestrator-agent.md`
  - `agents/initialization/agents/init-docs-agent.md`
  - `agents/pr/agents/pr-agent.md`
  - `agents/pr/agents/resolve-pr-issue.md`
  - `agents/skill-update/agents/skill-update-agent.md`
  - `docs/docs/agents.md` (existing — read before overwriting)

#### Types

```txt
AgentFile {
  name: string (agent identifier from front-matter)
  tools: string[] (tools declared in front-matter)
  model: string
  userInvocable: boolean
  skills: string[] (skill paths declared in front-matter)
  scripts: string[] (script paths declared in front-matter)
}
```

#### Paths

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `regenAgentsDocs.success` | `DocInput{systemName=agents}` | `DocOutput` | `happy path` | Read all agent .md files; apply investigate skill; write docs/docs/agents.md using documentation template |
| `regenAgentsDocs.missingFile` | `DocInput{systemName=agents}` | `StandardError` | `error` | An expected agent file is missing from agents/ |

#### Pseudocode

```
1. Read agents/documentation/skills/investigate/SKILL.md
2. For each agent directory group (dark-factory, featurework, debugger, fix-flow,
   code-review, documentation, initialization, pr, skill-update):
   a. Read each agent .md file — capture: name, tools, model, user-invocable,
      description, orchestration pseudocode, input/output contracts
3. Identify system type: library (no runtime — agents are markdown instructions)
4. Build Mermaid diagram showing top-level orchestration flow from dark-factory-agent
   through worker agents (feature-agent, debugger-agent, fix-flow-orchestrator)
5. Write one flow per major agent group with input/output types and paths table
6. Logs: N/A (agents are markdown — no runtime log emission)
7. Deployment: local only (agents run inside Claude Code sessions)
8. Write docs/docs/agents.md using documentation template
```

---

### Flow: `regenCommandsDocs`

- Test files: N/A
- Core files:
  - `commands/manufacture.md`
  - `commands/init.md`
  - `commands/update.md`
  - `docs/docs/commands.md` (existing — read before overwriting)

#### Types

```txt
CommandFile {
  name: string (command slug)
  description: string (front-matter description shown in Claude Code picker)
  delegatesTo: string (path to agent file)
  args: string (argument signature, e.g. "<task description>" or "[github_url]")
}
```

#### Paths

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `regenCommandsDocs.success` | `DocInput{systemName=commands}` | `DocOutput` | `happy path` | Read all 3 command files; write docs/docs/commands.md using documentation template |
| `regenCommandsDocs.missingFile` | `DocInput{systemName=commands}` | `StandardError` | `error` | A command file is absent from commands/ |

#### Pseudocode

```
1. Read commands/manufacture.md, commands/init.md, commands/update.md
2. For each command capture: front-matter description, delegate agent path, argument format
3. System type: library (slash-command stubs — no runtime logic)
4. Build Mermaid diagram: User → /dark-factory:<cmd> → Delegates to → Agent
5. Write one flow per command (manufacture, init, update) with input type = TaskDescription | void
6. Logs: N/A (commands are stubs with no log output)
7. Deployment: local only (plugin install makes commands available in Claude Code)
8. Write docs/docs/commands.md using documentation template
```

---

### Flow: `regenSkillsDocs`

- Test files: N/A
- Core files:
  - `skills/create-mermaid-diagram/SKILL.md`
  - `skills/find-dead-code/SKILL.md`
  - `skills/logging/SKILL.md`
  - `skills/install-plugin/SKILL.md`
  - `skills/install/SKILL.md`
  - `skills/open-in-vscode/SKILL.md`
  - `skills/handle-idempotent-setup-script/SKILL.md`
  - `skills/declare-tools-in-agent-frontmatter/SKILL.md`
  - `agents/documentation/skills/investigate/SKILL.md`
  - `agents/documentation/skills/documentation/SKILL.md`
  - `agents/documentation/skills/detect-drift/SKILL.md`
  - `agents/debugger/skills/debug/SKILL.md`
  - `agents/fix-flow/skills/generate-fetch-logs/SKILL.md`
  - `agents/fix-flow/skills/generate-wait-for-completion/SKILL.md`
  - `agents/fix-flow/skills/generate-trigger/SKILL.md`
  - `agents/fix-flow/skills/generate-deploy/SKILL.md`
  - `agents/pr/skills/create-pr/SKILL.md`
  - `agents/featurework/execution/skills/deviation-protocol/SKILL.md`
  - `docs/docs/skills.md` (existing — read before overwriting)

#### Types

```txt
SkillFile {
  name: string (skill slug from front-matter)
  description: string (one-sentence description)
  userInvocable: boolean
  scope: "project-level" | "agent-local"
  ownerAgent: string | null (agent directory if agent-local)
  steps: string[] (procedure steps)
}
```

#### Paths

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `regenSkillsDocs.success` | `DocInput{systemName=skills}` | `DocOutput` | `happy path` | Read all skill SKILL.md files (project-level + agent-local); write docs/docs/skills.md using documentation template |
| `regenSkillsDocs.missingFile` | `DocInput{systemName=skills}` | `StandardError` | `error` | A skill file listed in the inventory is missing |

#### Pseudocode

```
1. Glob skills/**/*.md for project-level skills
2. Glob agents/*/skills/**/*.md for agent-local skills
3. For each skill read: name, description, user-invocable, steps, when-to-use, notes
4. Group by scope: project-level vs agent-local (with owner agent)
5. System type: library (skills are markdown procedure files consumed by agents)
6. Build Mermaid diagram: Agent → reads SKILL.md → follows Steps → writes output
7. Write one flow per skill category group (project-level, documentation, debugger,
   fix-flow, pr, featurework) with input = AgentContext and output = SkillOutput
8. Logs: N/A (skills produce no log output themselves)
9. Deployment: local only (skills live in the plugin repo, loaded by agents at runtime)
10. Write docs/docs/skills.md using documentation template
```

---

### Flow: `regenTestsDocs`

- Test files: `tests/test_push_notification_declared.py`
- Core files:
  - `tests/test_push_notification_declared.py`
  - `docs/docs/tests.md` (existing — read before overwriting)

#### Types

```txt
TestFile {
  path: string (relative path to test file)
  purpose: string (what failure mode it guards)
  parametrizedCases: string[] (agent paths under test)
  assertionSteps: string[] (ordered assertions per case)
}

TestResult {
  passed: boolean
  failedCases: string[]
}
```

#### Paths

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `regenTestsDocs.success` | `DocInput{systemName=tests}` | `DocOutput` | `happy path` | Read tests/*.py; write docs/docs/tests.md using documentation template |
| `regenTestsDocs.missingFile` | `DocInput{systemName=tests}` | `StandardError` | `error` | tests/ directory or a listed test file is absent |

#### Pseudocode

```
1. Read tests/test_push_notification_declared.py
2. Capture: pytest parametrize list (8 agent paths), assertion sequence per case
3. Cross-reference docs/bugs/ for the originating bug that motivated these tests
4. System type: library (test suite — no deployed runtime)
5. Build Mermaid diagram: pytest → parametrized agent paths → parse YAML front-matter
   → assert PushNotification in tools
6. Write one flow per test file (currently one: pushNotificationDeclared)
   with input = AgentFilePath and output = TestResult
7. Logs: N/A (pytest stdout only — no structured log destinations)
8. Deployment: local only (`pytest tests/`)
9. Write docs/docs/tests.md using documentation template
```

---

## Logs

| Source | Location |
|--------|----------|
| N/A | This is a documentation-only task; no runtime log sources are modified or introduced. |

## Deployment

- Mechanism: `local only`
- Deploy command:
  ```bash
  # No deployment needed — this task only rewrites docs/docs/ markdown files.
  # Verify by reading the four output files after the flows complete.
  ```
- Notes: All four output files must pass a manual review against the documentation template before this plan is considered complete.

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/lewibs/github/dark_factory/dark_factory-regen-docs-with-template
collecting ... collected 32 items

tests/test_docs_template_compliance.py::test_required_sections_present[...agents.md] PASSED [  3%]
tests/test_docs_template_compliance.py::test_required_sections_present[...commands.md] PASSED [  6%]
tests/test_docs_template_compliance.py::test_required_sections_present[...skills.md] PASSED [  9%]
tests/test_docs_template_compliance.py::test_required_sections_present[...tests.md] PASSED [ 12%]
tests/test_docs_template_compliance.py::test_metadata_has_system_type[...agents.md] PASSED [ 15%]
tests/test_docs_template_compliance.py::test_metadata_has_system_type[...commands.md] PASSED [ 18%]
tests/test_docs_template_compliance.py::test_metadata_has_system_type[...skills.md] PASSED [ 21%]
tests/test_docs_template_compliance.py::test_metadata_has_system_type[...tests.md] PASSED [ 25%]
tests/test_docs_template_compliance.py::test_mermaid_diagram_has_code_block[...agents.md] PASSED [ 28%]
tests/test_docs_template_compliance.py::test_mermaid_diagram_has_code_block[...commands.md] PASSED [ 31%]
tests/test_docs_template_compliance.py::test_mermaid_diagram_has_code_block[...skills.md] PASSED [ 34%]
tests/test_docs_template_compliance.py::test_mermaid_diagram_has_code_block[...tests.md] PASSED [ 37%]
tests/test_docs_template_compliance.py::test_flows_section_has_types_and_paths[...agents.md] PASSED [ 40%]
tests/test_docs_template_compliance.py::test_flows_section_has_types_and_paths[...commands.md] PASSED [ 43%]
tests/test_docs_template_compliance.py::test_flows_section_has_types_and_paths[...skills.md] PASSED [ 46%]
tests/test_docs_template_compliance.py::test_flows_section_has_types_and_paths[...tests.md] PASSED [ 50%]
tests/test_docs_template_compliance.py::test_logs_section_has_table[...agents.md] PASSED [ 53%]
tests/test_docs_template_compliance.py::test_logs_section_has_table[...commands.md] PASSED [ 56%]
tests/test_docs_template_compliance.py::test_logs_section_has_table[...skills.md] PASSED [ 59%]
tests/test_docs_template_compliance.py::test_logs_section_has_table[...tests.md] PASSED [ 62%]
tests/test_docs_template_compliance.py::test_deployment_section_has_mechanism[...agents.md] PASSED [ 65%]
tests/test_docs_template_compliance.py::test_deployment_section_has_mechanism[...commands.md] PASSED [ 68%]
tests/test_docs_template_compliance.py::test_deployment_section_has_mechanism[...skills.md] PASSED [ 71%]
tests/test_docs_template_compliance.py::test_deployment_section_has_mechanism[...tests.md] PASSED [ 75%]
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/featurework/agents/feature-agent.md] PASSED [ 78%]
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/featurework/planning/agents/planning-agent.md] PASSED [ 81%]
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/featurework/execution/agents/execution-agent.md] PASSED [ 84%]
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/fix-flow/agents/fix-flow-orchestrator.md] PASSED [ 87%]
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/fix-flow/agents/ralph-fix-and-push.md] PASSED [ 90%]
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/dark-factory/agents/dark-factory-agent.md] PASSED [ 93%]
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/documentation/agents/detect-drift-agent.md] PASSED [ 96%]
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/documentation/agents/update-documentation-agent.md] PASSED [100%]

============================== 32 passed in 0.04s ==============================
```

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
