### PR TITLE
fix(init-docs-agent): produce per-flow documentation on project init

### DIFF
--- a/agents/featurework/execution/agents/implementation-agent.md
+++ b/agents/featurework/execution/agents/implementation-agent.md
@@ -3,7 +3,7 @@ name: implementation-agent
 user-invocable: false
 description: Phase 3 of plan execution. Implements each flow from the flows checklist one at a time, runs tests after each, and invokes the deviation-protocol skill when a plan conflict cannot be resolved independently.
 tools: Read, Write, Edit, Bash, Glob, Agent
-skills: deviation-protocol
+skills: deviation-protocol, logging
 model: sonnet
 allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(bash *), Bash(mkdir -p *), Bash(find *), Bash(grep -r *)
 ---
@@ -30,8 +30,9 @@ You will be invoked with:
       - Diagnose the failure.
       - If the fix is clear and stays within the plan (no conflicting requirements, no ambiguous spec): fix and re-run. Repeat until passing or until you judge the issue cannot be resolved within the plan.
       - If the fix requires departing from the plan: invoke `deviation-protocol/SKILL.md` (see Deviation Protocol below).
-3. After all flows are marked done, run the full test suite to confirm everything is green.
-4. Return `{ allFlowsGreen: true, flowsChecklistPath: checklistPath }`.
+3. After all flows are marked done, invoke `skills/logging/SKILL.md` with `planPath` to instrument every flow with structured log statements.
+4. Run the full test suite to confirm everything is green.
+5. Return `{ allFlowsGreen: true, flowsChecklistPath: checklistPath }`.
 
 ## Deviation Protocol
 

--- a/agents/initialization/agents/init-docs-agent.md
+++ b/agents/initialization/agents/init-docs-agent.md
@@ -1,7 +1,7 @@
 ---
 name: init-docs-agent
 user-invocable: false
-description: Explores a newly initialized project, invokes investigation-agent per major system to generate docs/docs/ files, then writes a minimal CLAUDE.md pointer doc at the project root. Called after init.sh sets up the project structure.
+description: Explores a newly initialized project, discovers user-facing flows per system, invokes investigation-agent per flow to generate docs/docs/ files, then writes a minimal CLAUDE.md pointer doc at the project root. Called after init.sh sets up the project structure.
 tools: Read, Grep, Glob, Bash, Write, Task
 model: sonnet
 allowed-tools: Bash(ls *), Bash(find *), Bash(cat *), Bash(grep -r *), Bash(mkdir *)
@@ -12,6 +12,22 @@ You are the init-docs-agent.
 ## Input
 
 You receive a `project_path` — the path to the project directory to document (e.g., `myrepo/myrepo/`).
+
+## Types
+
+```
+SystemInfo {
+  name: string          // e.g. "backend", "frontend"
+  rootDir: string       // absolute path to that system's root directory (e.g. "<project_path>/backend")
+}
+
+FlowInfo {
+  name: string          // kebab-case slug, e.g. "upload-image", "create-account"
+  displayName: string   // human-readable, e.g. "Upload Image"
+  owningSystem: string  // SystemInfo.name
+  outputPath: string    // absolute path: <project_path>/docs/docs/<name>.md (absolute so sub-agents can write without knowing project_path)
+}
+```
 
 ## Steps
 
@@ -31,7 +47,7 @@ Error: project_path "<project_path>" does not exist. Cannot proceed.
 
 Do not continue past this step if `project_path` is invalid.
 
-### Step 2: Orient — discover major systems
+### Step 2: Discover Systems
 
 Read the top-level directory listing of `project_path` to identify major systems and components:
 
@@ -41,12 +57,52 @@ run: ls -la "<project_path>"
 
 Examine the output. Identify distinct top-level directories and files that represent major systems or concerns — for example: API layers, workers, data models, CI/deploy scripts, frontend, backend, CLI, scripts directories, configuration directories, etc.
 
-**What counts as a major system:**
-Use the same heuristics as architecture section generation — primary source directories, entry points, CI/deploy scripts. Each distinct concern becomes one `investigation-agent` invocation. For small projects this may be 2–4 systems; for large ones, more.
+For each distinct system, produce a `SystemInfo`:
+- `name`: the directory or system name (e.g. "backend", "frontend")
+- `rootDir`: absolute path to that system's root directory
 
-**If no clear system boundaries exist** (e.g., the project is a single flat directory with no obvious sub-systems), treat the entire project as one system and use the project name as the system name. Proceed with a single `investigation-agent` invocation.
+**If no clear system boundaries exist** (e.g., the project is a single flat directory with no obvious sub-systems), treat the entire project as one system: `SystemInfo{ name: basename(project_path), rootDir: project_path }`.
 
-### Step 3: Ensure docs/docs/ directory exists
+### Step 3: Discover Flows Per System
+
+For each `SystemInfo`, read its source files to enumerate specific user-facing flows.
+
+**For each system:**
+
+1. Glob `<system.rootDir>` **recursively** for entry-point files matching these patterns (search all subdirectories, not just the top level):
+   - Routes files: `**/routes.*`, `**/urls.*`, `**/router.*`
+   - CLI entry points: `**/cli.*`, `**/commands/*`
+   - Event handlers: `**/handlers/*`, `**/listeners/*`
+   - API controllers: `**/controllers/*`, `**/views/*`, `**/endpoints/*`
+
+2. Read each entry-point file found. Extract named actions, endpoints, or commands. Examples:
+   - `GET /upload` → name: `"upload-image"`, displayName: `"Upload Image"`
+   - `POST /register` → name: `"create-account"`, displayName: `"Create Account"`
+   - `cli send-message` → name: `"send-message"`, displayName: `"Send Message"`
+
+3. For each distinct action found, create a `FlowInfo`:
+   ```
+   FlowInfo {
+     name: kebab-case slug derived from the action,
+     displayName: human-readable label (title-cased words),
+     owningSystem: system.name,
+     outputPath: "<project_path>/docs/docs/<name>.md"
+   }
+   ```
+
+4. **Fallback — no flows found for a system:** If no entry-point files exist or no named actions can be extracted, emit exactly one `FlowInfo` using the system name:
+   ```
+   FlowInfo {
+     name: system.name,
+     displayName: <title-cased system.name>,
+     owningSystem: system.name,
+     outputPath: "<project_path>/docs/docs/<system.name>.md"
+   }
+   ```
+
+After processing all systems, deduplicate the combined `FlowInfo[]` by `name`. When two entries share the same `name` slug but have different `owningSystem` values, keep the entry whose `owningSystem` comes first in the original system discovery order (i.e., retain the first occurrence). This is your `flows` list.
+
+### Step 4: Ensure docs/docs/ directory exists
 
 Before invoking any investigation-agent, ensure the output directory exists:
 
@@ -60,35 +116,33 @@ If this command fails, return an error immediately:
 Error: could not create docs/docs/ directory under "<project_path>". Cannot proceed.
 ```
 
-### Step 4: Invoke investigation-agent per system
+### Step 5: Invoke investigation-agent per flow
 
-For each major system identified:
+For each `FlowInfo` in `flows`:
 
 1. Invoke `investigation-agent` as a sub-agent (using Task tool) with:
    - Agent path: `agents/documentation/agents/investigation-agent.md`
-   - The system name as the topic to investigate.
-   - `project_path` as context — instruct investigation-agent to operate within `project_path` and write its output to `<project_path>/docs/docs/<system-name>.md`.
+   - Prompt:
+     ```
+     Investigate the '<flow.displayName>' user flow within the '<flow.owningSystem>' system of the project located at '<project_path>'.
+     Focus on the specific actions a user takes to complete this flow end-to-end.
+     Treat '<project_path>' as the project root for all file reads and writes.
+     Write your documentation to '<flow.outputPath>'.
+     Return the path to the file you wrote.
+     ```
 
-   Example invocation context to pass to investigation-agent:
-   ```
-   Investigate the "<system-name>" system within the project located at "<project_path>".
-   Treat "<project_path>" as the project root for all file reads and writes.
-   Write your documentation to "<project_path>/docs/docs/<system-name>.md".
-   Return the path to the file you wrote.
-   ```
+2. On success: add `flow.outputPath` to `docs_written`.
 
-2. Collect the file paths returned by each `investigation-agent` invocation.
+3. On failure:
+   - Log: `Warning: investigation-agent failed for flow '<flow.name>'. Skipping.`
+   - Skip that flow.
+   - Continue processing remaining flows.
 
-3. If `investigation-agent` fails for a particular system:
-   - Log the failure: `Warning: investigation-agent failed for system "<system-name>". Skipping.`
-   - Skip that system.
-   - Continue processing remaining systems.
+After all flows are processed, you have a list `docs_written` of all `docs/docs/` files that were successfully written.
 
-After all systems are processed, you have a list `docs_written` of all `docs/docs/` files that were successfully written.
+### Step 6: Write docs/docs/README.md index
 
-### Step 5: Write docs/docs/README.md index
-
-Write `<project_path>/docs/docs/README.md` as an index of all successfully written docs files.
+Write `<project_path>/docs/docs/README.md` as an index of all successfully written flow docs.
 
 The file should have this structure:
 
@@ -97,17 +151,17 @@ The file should have this structure:
 
 | Document | Description |
 |---|---|
-| [<system-name>.md](./<system-name>.md) | <one-line summary of what that doc covers> |
+| [<flow-name>.md](./<flow-name>.md) | <one-line summary of what that flow doc covers> |
 ...
 ```
 
 Rules:
-- Include one row per file in `docs_written` (excluding CLAUDE.md).
-- The description for each row is a one-line summary derived from the investigation — what system or concern that file documents.
-- If `docs_written` is empty, write a single-sentence body: "No documentation has been generated yet."
+- Include one row per flow doc in `docs_written` (one row per user-facing flow, excluding CLAUDE.md).
+- For each row, re-read the corresponding flow doc file to derive the one-line description: extract the first non-heading, non-empty sentence from the file. If the file cannot be read or has no such sentence, use `FlowInfo.displayName` as the description fallback.
+- If `docs_written` is empty, write a single-sentence body: "No documentation generated yet"
 - Do not include `README.md` itself as a row in the table.
 
-### Step 6: Write minimal CLAUDE.md
+### Step 7: Write minimal CLAUDE.md
 
 Derive `project_name` from `basename(project_path)`.
 
@@ -131,7 +185,7 @@ Rules for the CLAUDE.md content:
 - If all `investigation-agent` invocations failed (i.e., `docs_written` is empty), write the CLAUDE.md with generic pointer text only — use "A software project." as the one-line description placeholder.
 - Do NOT include: architecture sections, entry points tables, development instructions, deploy sections, notes sections. Those all live in `docs/docs/` files generated by `investigation-agent`.
 
-### Step 7: Return all written file paths
+### Step 8: Return all written file paths
 
 Collect and return the complete list of all files written:
 - All `docs/docs/*.md` files written by `investigation-agent` invocations.
@@ -150,6 +204,7 @@ Return all written file paths: `docs/docs/*.md` files, `docs/docs/README.md`, an
 |---|---|
 | `project_path` does not exist | Return error immediately, do not proceed |
 | `docs/docs/` directory cannot be created | Return error immediately, do not proceed |
-| No clear system boundaries | Single `investigation-agent` call for the whole project |
-| `investigation-agent` fails for one system | Log failure, skip that system, continue with others |
-| All investigations fail | Write CLAUDE.md with generic pointer text only |
+| No clear system boundaries | Single system using basename(project_path) as name |
+| No flows found for a system | One FlowInfo using system name as the flow name/slug |
+| `investigation-agent` fails for one flow | Log `Warning: investigation-agent failed for flow '<flow.name>'. Skipping.`, continue |
+| All investigations fail | README.md: "No documentation generated yet"; CLAUDE.md with generic pointer text |

--- a/docs/docs/agents.md
+++ b/docs/docs/agents.md
@@ -216,6 +216,65 @@ DocUpdateOutput {
 
 ---
 
+### Flow: `init`
+
+- Core files: `agents/initialization/agents/init-orchestrator-agent.md`, `agents/initialization/agents/init-docs-agent.md`
+
+#### Types
+
+```txt
+InitInput {
+  project_path: string (absolute path to the project directory to document)
+}
+
+SystemInfo {
+  name: string          // e.g. "backend", "frontend"
+  rootDir: string       // absolute path to that system's root directory
+}
+
+FlowInfo {
+  name: string          // kebab-case slug, e.g. "upload-image", "create-account"
+  displayName: string   // human-readable label, e.g. "Upload Image"
+  owningSystem: string  // SystemInfo.name
+  outputPath: string    // absolute path: <project_path>/docs/docs/<name>.md
+}
+
+InitDocsOutput {
+  docsWritten: string[] (paths to all docs/docs/*.md files written)
+  readmePath: string    (path to docs/docs/README.md)
+  claudeMdPath: string  (path to CLAUDE.md)
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `init.success` | `InitInput` | `InitDocsOutput` | `happy path` | Guard → discoverSystems → discoverFlowsPerSystem → invoke investigation-agent per flow → write README index → write CLAUDE.md |
+| `init.noFlows` | `SystemInfo` with no entry-point files | `FlowInfo[name=<system>]` | `fallback` | System has no routes/CLI/handlers; one FlowInfo using system name is emitted |
+| `init.flatProject` | `InitInput` with no sub-systems | `FlowInfo[name=basename(project_path)]` | `fallback` | No distinct sub-directories; entire project treated as one system and one flow |
+| `init.agentFailure` | `FlowInfo` | warning logged, flow skipped | `error` | investigation-agent fails for one flow; log warning and continue remaining flows |
+| `init.allFailed` | all FlowInfo fail | README: "No documentation generated yet"; generic CLAUDE.md | `error` | All investigation-agent calls fail; placeholder docs written |
+| `init.invalidPath` | `InitInput{project_path=invalid}` | `StandardError` | `error` | project_path does not exist; init-docs-agent halts immediately |
+
+#### Steps
+
+init-docs-agent runs these steps in order:
+
+1. **Guard** — `ls <project_path>` verifies the path exists; halts on failure.
+2. **Discover Systems** — `ls -la <project_path>` identifies top-level directories; each becomes a `SystemInfo`.
+3. **Discover Flows Per System** — for each `SystemInfo`, globs entry-point files (`routes.*`, `urls.*`, `router.*`, `cli.*`, `commands/*`, `handlers/*`, `listeners/*`, `controllers/*`, `views/*`, `endpoints/*`) and reads them to extract named actions/endpoints/commands. Each distinct action becomes a `FlowInfo`. If no flows are found for a system, one fallback `FlowInfo` using the system name is emitted. Duplicates are deduplicated by name slug.
+4. **Ensure docs/docs/ exists** — `mkdir -p <project_path>/docs/docs`.
+5. **Invoke investigation-agent per flow** — one Task-tool call per `FlowInfo`; each writes `docs/docs/<flow-name>.md` using the documentation template.
+6. **Write docs/docs/README.md** — index table with one row per successfully written flow doc.
+7. **Write CLAUDE.md** — minimal pointer doc at project root.
+
+---
+
 ### Flow: `pr`
 
 - Core files: `agents/pr/agents/pr-agent.md`, `agents/pr/agents/resolve-pr-issue.md`

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -78,8 +78,8 @@ InitOutput {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `init.newRepo` | `InitInput{githubUrl}` | `InitOutput` | `happy path` | Clones repo, runs init.sh, generates docs, opens PR |
-| `init.existingCWD` | `InitInput{void}` | `InitOutput` | `happy path` | Treats CWD as target; runs init.sh, generates docs, opens PR |
+| `init.newRepo` | `InitInput{githubUrl}` | `InitOutput` | `happy path` | Clones repo, runs init.sh, discovers user-facing flows per system, generates one docs/docs/<flow-name>.md per flow, opens PR |
+| `init.existingCWD` | `InitInput{void}` | `InitOutput` | `happy path` | Treats CWD as target; runs init.sh, discovers user-facing flows per system, generates one docs/docs/<flow-name>.md per flow, opens PR |
 
 ---
 

--- a/docs/plans/2026-04-26-fix-init-doc-granularity.md
+++ b/docs/plans/2026-04-26-fix-init-doc-granularity.md
@@ -1,0 +1,248 @@
+# Fix Init Doc Granularity: Per-Flow Documentation
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: N/A
+- Depends on: N/A
+- Status: `approved`
+
+## System Intent
+
+- What is being built: A rewrite of `agents/initialization/agents/init-docs-agent.md` so that on project init, documentation is produced at user-flow granularity (e.g. "upload image", "create account", "send message") rather than at coarse system granularity (e.g. "frontend", "backend"). Each discovered flow becomes one `docs/docs/<flow-name>.md` file following the documentation template.
+- Primary consumer(s): Developers reading generated docs; `update-documentation-agent` and `detect-drift-agent` which validate docs against code.
+- Boundary (black-box scope only): Only `agents/initialization/agents/init-docs-agent.md` is modified. `investigation-agent`, the documentation template, and all other agents/skills are unchanged.
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 Flows approved
+- [x] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  Start([init-docs-agent receives project_path]):::created
+
+  subgraph Step1["Step 1: Guard"]
+    G[ls project_path — verify exists]:::created
+  end
+
+  subgraph Step2["Step 2: Discover Systems"]
+    S[ls -la project_path — identify top-level systems]:::created
+  end
+
+  subgraph Step3["Step 3: Discover Flows per System"]
+    F1[For each system: read source dirs, entry points, routes, CLI commands]:::created
+    F2[Produce list of specific user-facing flows with owning system]:::created
+    F1 --> F2
+  end
+
+  subgraph Step4["Step 4: Ensure docs/docs/ exists"]
+    D[mkdir -p project_path/docs/docs]:::created
+  end
+
+  subgraph Step5["Step 5: Invoke investigation-agent per flow"]
+    I1[investigation-agent: flow A → docs/docs/flow-a.md]:::created
+    I2[investigation-agent: flow B → docs/docs/flow-b.md]:::created
+    I3[investigation-agent: flow N → docs/docs/flow-n.md]:::created
+  end
+
+  subgraph Step6["Step 6: Write docs/docs/README.md index"]
+    R[One row per flow doc written]:::created
+  end
+
+  subgraph Step7["Step 7: Write CLAUDE.md"]
+    C[Minimal pointer doc]:::created
+  end
+
+  Start --> Step1 --> Step2 --> Step3 --> Step4 --> Step5
+  Step5 --> I1 & I2 & I3
+  I1 & I2 & I3 --> Step6 --> Step7
+
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+### Global Types
+
+```txt
+SystemInfo {
+  name: string (e.g. "backend", "frontend")
+  rootDir: string (relative path within project_path)
+}
+
+FlowInfo {
+  name: string (slug, e.g. "upload-image", "create-account")
+  displayName: string (human-readable, e.g. "Upload Image")
+  owningSystem: string (SystemInfo.name)
+  outputPath: string (docs/docs/<name>.md)
+}
+
+FlowDocInput {
+  flowName: string
+  displayName: string
+  owningSystem: string
+  projectPath: string
+  outputPath: string
+}
+
+FlowDocOutput {
+  outputPath: string (path written)
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+---
+
+### Flow: `discoverSystems`
+
+- Test files: N/A
+- Core files:
+  - `agents/initialization/agents/init-docs-agent.md` (Step 2)
+
+#### Types
+
+```txt
+Input: project_path string
+Output: SystemInfo[]
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `discoverSystems.success` | `project_path` | `SystemInfo[]` | `happy path` | ls -la identifies distinct top-level directories; each becomes a SystemInfo |
+| `discoverSystems.flat` | `project_path` | `SystemInfo[name=project]` | `fallback` | No sub-directories detected; treat entire project as one system |
+
+---
+
+### Flow: `discoverFlowsPerSystem`
+
+This is the new step inserted between current Steps 2 and 4. For each `SystemInfo`, the agent reads source files to enumerate specific user-facing flows.
+
+- Test files: N/A
+- Core files:
+  - `agents/initialization/agents/init-docs-agent.md` (new Step 3)
+
+#### Types
+
+```txt
+Input: SystemInfo[]
+Output: FlowInfo[]
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `discoverFlowsPerSystem.success` | `SystemInfo[]` | `FlowInfo[]` | `happy path` | Agent reads routes, CLI entry points, event handlers, and API endpoints per system; maps each to a named FlowInfo |
+| `discoverFlowsPerSystem.noFlows` | `SystemInfo` | `FlowInfo[name=<system>]` | `fallback` | No discrete flows found; treat the whole system as one flow using the system name |
+
+#### Pseudocode
+
+```
+For each system in SystemInfo[]:
+  1. Glob <system.rootDir> for entry-point files:
+     - routes files (routes.*, urls.*, router.*)
+     - CLI entry points (cli.*, commands/*)
+     - event handlers (handlers/*, listeners/*)
+     - API controllers (controllers/*, views/*, endpoints/*)
+  2. Read each entry-point file; extract named actions/endpoints/commands
+     Examples: GET /upload → "upload-image", POST /register → "create-account"
+  3. For each distinct action, create FlowInfo{
+       name: kebab-case slug,
+       displayName: human-readable label,
+       owningSystem: system.name,
+       outputPath: "docs/docs/<name>.md"
+     }
+  4. If no actions found, emit one FlowInfo using system.name as the name
+Return deduplicated FlowInfo[] across all systems
+```
+
+---
+
+### Flow: `invokeInvestigationPerFlow`
+
+Replaces the old per-system investigation-agent invocation. One `investigation-agent` call per `FlowInfo`.
+
+- Test files: N/A
+- Core files:
+  - `agents/initialization/agents/init-docs-agent.md` (Step 5, replaces old Step 4)
+  - `agents/documentation/agents/investigation-agent.md`
+
+#### Types
+
+```txt
+Input: FlowInfo[]
+Output: FlowDocOutput[]
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `invokeInvestigationPerFlow.success` | `FlowInfo` | `FlowDocOutput` | `happy path` | investigation-agent investigates the flow and writes docs/docs/<flow-name>.md using the documentation template |
+| `invokeInvestigationPerFlow.agentFailure` | `FlowInfo` | `StandardError` | `error` | investigation-agent fails; log warning, skip this flow, continue with remaining flows |
+
+#### Pseudocode
+
+```
+For each flow in FlowInfo[]:
+  Invoke investigation-agent (Task tool) with prompt:
+    "Investigate the '<flow.displayName>' user flow within the '<flow.owningSystem>'
+     system of the project located at '<projectPath>'.
+     Focus on the specific actions a user takes to complete this flow end-to-end.
+     Treat '<projectPath>' as the project root for all file reads and writes.
+     Write your documentation to '<flow.outputPath>'.
+     Return the path to the file you wrote."
+  On success: add flow.outputPath to docs_written
+  On failure: log "Warning: investigation-agent failed for flow '<flow.name>'. Skipping."
+```
+
+---
+
+### Flow: `writeIndexAndClaude`
+
+Unchanged from current Steps 5 and 6, except the index now lists one row per flow doc instead of one row per system doc.
+
+- Test files: N/A
+- Core files:
+  - `agents/initialization/agents/init-docs-agent.md` (Steps 6–7)
+
+#### Types
+
+```txt
+Input: FlowDocOutput[] (docs_written)
+Output: paths to docs/docs/README.md and CLAUDE.md
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `writeIndexAndClaude.success` | `FlowDocOutput[]` | `README.md + CLAUDE.md` | `happy path` | README index lists one row per flow doc; CLAUDE.md is a minimal pointer |
+| `writeIndexAndClaude.empty` | `[]` | `README.md + CLAUDE.md` | `fallback` | All flows failed; README says "No documentation generated yet"; CLAUDE.md uses generic placeholder |
+
+---
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| N/A | This is an agent instruction rewrite — no runtime log sources are introduced or modified. |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment needed — modifying agents/initialization/agents/init-docs-agent.md
+  # takes effect immediately for the next /dark-factory:init run.
+  ```
+- Notes: Verify by running `/dark-factory:init` on a sample project and confirming that `docs/docs/` contains one file per user flow (e.g. `upload-image.md`, `create-account.md`) rather than one file per top-level directory.

--- a/skills/declare-tools-in-agent-frontmatter/SKILL.md
+++ b/skills/declare-tools-in-agent-frontmatter/SKILL.md
@@ -1,24 +1,31 @@
 ---
 name: declare-tools-in-agent-frontmatter
-description: "Ensures every tool called in an agent's instruction body is also listed in the tools: YAML front-matter, because Claude Code uses that list as an access-control gate — omitting a tool there causes it to be silently unavailable at runtime."
+description: "Ensures every tool called in an agent's instruction body is listed in the tools: YAML front-matter, and every skill invoked in the body is listed in the skills: front-matter. Both fields act as access-control gates — omitting either causes the tool or skill to be silently unavailable at runtime."
 user-invocable: false
 ---
 ## When to use
 
-Use this whenever you create or modify an agent file (any `agents/**/*.md`) that calls a tool in its instruction body — especially native Claude Code tools like `PushNotification`, `WebSearch`, or custom tools. Also use it when debugging an agent that appears to skip a step silently (no error, but no effect).
+Use this whenever you create or modify an agent file (any `agents/**/*.md`) that calls a tool or invokes a skill in its instruction body. Also use it when debugging an agent that appears to skip a step silently (no error, but no effect).
 
 ## Steps
 
 1. Open the agent file and read its YAML front-matter block (the section between the opening and closing `---` delimiters).
-2. Identify the `tools:` field. If it is absent, add it.
-3. Read the agent instruction body and collect every tool the agent is instructed to call (look for tool names like `PushNotification`, `Read`, `Bash`, `Agent`, `WebSearch`, etc.).
-4. For each tool found in the body, confirm it is listed in the `tools:` front-matter field. If it is missing, add it to the comma-separated list.
-5. Save the file.
-6. Repeat for every agent file that was created or touched in the current task.
+2. **Tools check:**
+   a. Identify the `tools:` field. If it is absent, add it.
+   b. Read the agent instruction body and collect every tool the agent is instructed to call (look for tool names like `PushNotification`, `Read`, `Bash`, `Agent`, `WebSearch`, `Task`, etc.).
+   c. For each tool found in the body, confirm it is listed in the `tools:` front-matter field. If it is missing, add it to the comma-separated list.
+3. **Skills check:**
+   a. Identify the `skills:` field. If the agent body references any skill (e.g., `invoke skills/logging/SKILL.md`, `use skills/deviation-protocol/SKILL.md`), the field must be present.
+   b. Read the agent instruction body and collect every skill slug referenced (the directory name under `skills/`, e.g., `logging`, `deviation-protocol`).
+   c. For each skill slug found in the body, confirm it appears in the `skills:` front-matter field (comma-separated). If it is missing, add it.
+4. Save the file.
+5. Repeat for every agent file that was created or touched in the current task.
 
 ## Notes
 
 - Claude Code grants an agent access to a tool **only** if that tool appears in the agent's `tools:` front-matter field. A tool referenced in the instruction body but absent from `tools:` is silently inaccessible — the agent will not error, it will simply skip or never reach that call.
+- The same gate applies to skills: if a skill slug is invoked in the body but omitted from `skills:`, the agent cannot load it at runtime.
 - `PushNotification` is particularly easy to miss because it was added to agent bodies as a "notify before blocking on input" pattern after the initial `tools:` lists were written. Any future agent that adds this pattern must remember to add `PushNotification` to `tools:` as well.
 - The `allowed-tools:` field (which restricts which sub-commands of `Bash` are permitted) is separate from `tools:` — both may need to be updated when adding new tool usage.
 - A regression test (`tests/test_push_notification_declared.py`) exists in this repo that parses the YAML front-matter of all agent files and asserts `PushNotification` is present in `tools:` for every agent that references it in its body. Run this test after modifying agent files to catch omissions early.
+- When adding a new skill invocation to an existing agent (e.g., adding `skills/logging/SKILL.md` to `implementation-agent.md`), always update the `skills:` field in the same edit — do not treat it as optional cleanup.

--- a/skills/embed-absolute-output-path-in-handoff/SKILL.md
+++ b/skills/embed-absolute-output-path-in-handoff/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: embed-absolute-output-path-in-handoff
+description: "When a parent agent discovers items and dispatches sub-agents (via Task tool) to write files, always embed the absolute output file path in the handoff struct rather than letting the sub-agent reconstruct it from parts."
+user-invocable: false
+---
+## When to use
+
+When you are designing or modifying an agent that:
+1. Discovers a list of items (systems, flows, components, etc.) at runtime, and
+2. Invokes a sub-agent via the Task tool for each item to write a file to disk.
+
+The sub-agent will not have access to the same runtime context (project_path, naming conventions, output directory) unless you explicitly pass it. Embed the resolved absolute path in the struct you hand off.
+
+## Steps
+
+1. In the parent agent's discovery step, resolve the full absolute output path for each item as soon as its name is known.
+   - Pattern: `outputPath = "<project_path>/docs/docs/<item-slug>.md"` (constructed by the parent).
+2. Include `outputPath` as a field in the handoff struct (e.g., `FlowInfo`, `SystemInfo`, or equivalent).
+3. In the Task-tool prompt to the sub-agent, reference `outputPath` directly:
+   ```
+   Write your documentation to '<item.outputPath>'.
+   Return the path to the file you wrote.
+   ```
+4. Do NOT instruct the sub-agent to derive the output path itself from a base directory and slug — it will not reliably reproduce the parent's naming logic.
+5. Collect the returned path to confirm what was written; add it to the parent's `docs_written` (or equivalent) list.
+
+## Notes
+
+- The root cause of path mismatches in multi-agent pipelines is that sub-agents reconstruct paths independently and may use different slugging or casing logic. Pre-computing and embedding the path in the parent eliminates this class of bug entirely.
+- This pattern was established when `init-docs-agent` was refactored from per-system to per-flow granularity: `FlowInfo.outputPath` is set by the parent as an absolute path so each `investigation-agent` invocation knows exactly where to write without needing `project_path` or the flow-name slug.
+- If the output directory may not exist yet, the parent should `mkdir -p` it before dispatching any sub-agent calls — do not rely on sub-agents to create directories.


### PR DESCRIPTION
## Description

# Fix Init Doc Granularity: Per-Flow Documentation

## Plan Metadata

- Plan type: `plan`
- Parent plan: N/A
- Depends on: N/A
- Status: `approved`

## System Intent

- What is being built: A rewrite of `agents/initialization/agents/init-docs-agent.md` so that on project init, documentation is produced at user-flow granularity (e.g. "upload image", "create account", "send message") rather than at coarse system granularity (e.g. "frontend", "backend"). Each discovered flow becomes one `docs/docs/<flow-name>.md` file following the documentation template.
- Primary consumer(s): Developers reading generated docs; `update-documentation-agent` and `detect-drift-agent` which validate docs against code.
- Boundary (black-box scope only): Only `agents/initialization/agents/init-docs-agent.md` is modified. `investigation-agent`, the documentation template, and all other agents/skills are unchanged.

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [x] Stage 3 Logs + Deployment approved or skipped

## Flows

### Flow: `discoverSystems`

- Core files: `agents/initialization/agents/init-docs-agent.md` (Step 2)

#### Paths

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `discoverSystems.success` | `project_path` | `SystemInfo[]` | `happy path` | ls -la identifies distinct top-level directories; each becomes a SystemInfo |
| `discoverSystems.flat` | `project_path` | `SystemInfo[name=project]` | `fallback` | No sub-directories detected; treat entire project as one system |

---

### Flow: `discoverFlowsPerSystem`

New step inserted between Steps 2 and 4. For each `SystemInfo`, the agent reads source files to enumerate specific user-facing flows.

- Core files: `agents/initialization/agents/init-docs-agent.md` (new Step 3)

#### Paths

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `discoverFlowsPerSystem.success` | `SystemInfo[]` | `FlowInfo[]` | `happy path` | Agent reads routes, CLI entry points, event handlers, and API endpoints per system; maps each to a named FlowInfo |
| `discoverFlowsPerSystem.noFlows` | `SystemInfo` | `FlowInfo[name=<system>]` | `fallback` | No discrete flows found; treat the whole system as one flow using the system name |

---

### Flow: `invokeInvestigationPerFlow`

Replaces the old per-system investigation-agent invocation. One `investigation-agent` call per `FlowInfo`.

- Core files: `agents/initialization/agents/init-docs-agent.md` (Step 5)

#### Paths

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `invokeInvestigationPerFlow.success` | `FlowInfo` | `FlowDocOutput` | `happy path` | investigation-agent writes docs/docs/<flow-name>.md using the documentation template |
| `invokeInvestigationPerFlow.agentFailure` | `FlowInfo` | `StandardError` | `error` | investigation-agent fails; log warning, skip this flow, continue with remaining flows |

---

### Flow: `writeIndexAndClaude`

Unchanged except the index now lists one row per flow doc instead of one row per system doc.

#### Paths

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `writeIndexAndClaude.success` | `FlowDocOutput[]` | `README.md + CLAUDE.md` | `happy path` | README index lists one row per flow doc; CLAUDE.md is a minimal pointer |
| `writeIndexAndClaude.empty` | `[]` | `README.md + CLAUDE.md` | `fallback` | All flows failed; README says "No documentation generated yet"; CLAUDE.md uses generic placeholder |

---

## Deployment

- Mechanism: `local only`
- Notes: Verify by running `/dark-factory:init` on a sample project and confirming that `docs/docs/` contains one file per user flow (e.g. `upload-image.md`, `create-account.md`) rather than one file per top-level directory.

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
rootdir: /home/lewibs/github/dark_factory/dark_factory-fix-init-doc-granularity
collected 32 items

tests/test_docs_template_compliance.py::test_required_sections_present[...agents.md] PASSED
tests/test_docs_template_compliance.py::test_required_sections_present[...commands.md] PASSED
tests/test_docs_template_compliance.py::test_required_sections_present[...skills.md] PASSED
tests/test_docs_template_compliance.py::test_required_sections_present[...tests.md] PASSED
tests/test_docs_template_compliance.py::test_metadata_has_system_type[...agents.md] PASSED
tests/test_docs_template_compliance.py::test_metadata_has_system_type[...commands.md] PASSED
tests/test_docs_template_compliance.py::test_metadata_has_system_type[...skills.md] PASSED
tests/test_docs_template_compliance.py::test_metadata_has_system_type[...tests.md] PASSED
tests/test_docs_template_compliance.py::test_mermaid_diagram_has_code_block[...agents.md] PASSED
tests/test_docs_template_compliance.py::test_mermaid_diagram_has_code_block[...commands.md] PASSED
tests/test_docs_template_compliance.py::test_mermaid_diagram_has_code_block[...skills.md] PASSED
tests/test_docs_template_compliance.py::test_mermaid_diagram_has_code_block[...tests.md] PASSED
tests/test_docs_template_compliance.py::test_flows_section_has_types_and_paths[...agents.md] PASSED
tests/test_docs_template_compliance.py::test_flows_section_has_types_and_paths[...commands.md] PASSED
tests/test_docs_template_compliance.py::test_flows_section_has_types_and_paths[...skills.md] PASSED
tests/test_docs_template_compliance.py::test_flows_section_has_types_and_paths[...tests.md] PASSED
tests/test_docs_template_compliance.py::test_logs_section_has_table[...agents.md] PASSED
tests/test_docs_template_compliance.py::test_logs_section_has_table[...commands.md] PASSED
tests/test_docs_template_compliance.py::test_logs_section_has_table[...skills.md] PASSED
tests/test_docs_template_compliance.py::test_logs_section_has_table[...tests.md] PASSED
tests/test_docs_template_compliance.py::test_deployment_section_has_mechanism[...agents.md] PASSED
tests/test_docs_template_compliance.py::test_deployment_section_has_mechanism[...commands.md] PASSED
tests/test_docs_template_compliance.py::test_deployment_section_has_mechanism[...skills.md] PASSED
tests/test_docs_template_compliance.py::test_deployment_section_has_mechanism[...tests.md] PASSED
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/featurework/agents/feature-agent.md] PASSED
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/featurework/planning/agents/planning-agent.md] PASSED
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/featurework/execution/agents/execution-agent.md] PASSED
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/fix-flow/agents/fix-flow-orchestrator.md] PASSED
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/fix-flow/agents/ralph-fix-and-push.md] PASSED
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/dark-factory/agents/dark-factory-agent.md] PASSED
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/documentation/agents/detect-drift-agent.md] PASSED
tests/test_push_notification_declared.py::test_push_notification_in_tools_field[agents/documentation/agents/update-documentation-agent.md] PASSED

============================== 32 passed in 0.02s ==============================
```

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
