### PR TITLE
feat(bump-version): add bump-version skill, update install-plugin, and add docs

### DIFF
--- a/docs/docs/bump-version.md
+++ b/docs/docs/bump-version.md
@@ -1,0 +1,90 @@
+# bump-version
+
+## Metadata
+
+- System type: `flow`
+
+## System Intent
+
+- What this is: A patch-version increment flow. Reads the current version from `.claude-plugin/plugin.json`, increments the patch segment, writes the new version back, and creates a git commit and annotated tag for the new version.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  PluginJson[".claude-plugin/plugin.json"] -->|read current version| BumpFlow["bump-version flow"]
+  BumpFlow -->|patch += 1| Guard{Tag already exists?}
+  Guard -->|yes| Abort["return StandardError: tag already exists"]
+  Guard -->|no| Write["write newVersion to plugin.json"]
+  Write --> Commit["git add plugin.json\ngit commit -m 'chore: bump version to vX.Y.Z'"]
+  Commit --> Tag["git tag dark-factory--vX.Y.Z"]
+  Tag --> Done["return VersionBumpOutput"]
+```
+
+## Flows
+
+### Flow: `bump-version`
+
+- Test files: N/A
+- Core files: `.claude-plugin/plugin.json`
+
+#### Types
+
+```txt
+VersionBumpInput {
+  currentVersion: string  (semver string read from plugin.json, e.g. "1.1.4")
+  bumpType: "patch"       (always patch)
+}
+
+VersionBumpOutput {
+  newVersion: string      (incremented semver, e.g. "1.1.5")
+  commitSha: string       (sha of the resulting git commit)
+  tag: string             (git tag created, e.g. "dark-factory--v1.1.5")
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `bump-version.success` | `VersionBumpInput` | `VersionBumpOutput` | happy path | Increments patch segment of version in `.claude-plugin/plugin.json`, commits, and creates git tag `dark-factory--v<newVersion>` |
+| `bump-version.already-bumped` | `VersionBumpInput` | `StandardError` | error | Tag already exists for this version — abort to avoid duplicate tags |
+
+#### Pseudocode
+
+```
+read version from .claude-plugin/plugin.json
+split on "." → [major, minor, patch]
+patch += 1
+newVersion = major.minor.patch
+# guard: if git tag "dark-factory--v<newVersion>" already exists → return StandardError { message: "tag already exists: dark-factory--v<newVersion>" }
+write newVersion back to plugin.json
+git add .claude-plugin/plugin.json
+git commit -m "chore: bump version to <newVersion>"
+git tag "dark-factory--v<newVersion>"
+return { newVersion, commitSha, tag }
+```
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| git output | stdout/stderr of terminal session |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # Edit .claude-plugin/plugin.json to increment patch version, then:
+  git add .claude-plugin/plugin.json
+  git commit -m "chore: bump version to 1.1.5"
+  git tag dark-factory--v1.1.5
+  # Push tag to remote separately after local verification:
+  git push origin dark-factory--v1.1.5
+  ```
+- Notes: Always verify the tag does not already exist before running. Push the tag to remote only after confirming the local plugin update works.

--- a/docs/docs/install-plugin.md
+++ b/docs/docs/install-plugin.md
@@ -1,0 +1,91 @@
+# install-plugin
+
+## Metadata
+
+- System type: `flow`
+
+## System Intent
+
+- What this is: The one-time install and update flow for the dark-factory Claude Code plugin. Registers the local repository as a marketplace source using a dynamic path (`$(pwd)`), then installs or updates the plugin. Includes error handling guidance for common failure modes.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  User["Developer (from repo root)"] --> MarketplaceAdd["claude plugin marketplace add $(pwd)"]
+  MarketplaceAdd -->|registered source| InstallOrUpdate{First time?}
+  InstallOrUpdate -->|yes| Install["claude plugin install dark-factory"]
+  InstallOrUpdate -->|no| Update["claude plugin update dark-factory"]
+  Install --> Verify["claude plugin list"]
+  Update --> Verify
+  Verify --> Done["Plugin active at new version"]
+```
+
+## Flows
+
+### Flow: `install-plugin`
+
+- Test files: N/A
+- Core files: `skills/install-plugin/SKILL.md`
+
+#### Types
+
+```txt
+InstallPluginInput {
+  repoPath: string   (absolute path to the plugin source repo; resolved via $(pwd) when run from repo root)
+}
+
+InstallPluginOutput {
+  installedVersion: string  (version string confirmed by `claude plugin list`)
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `install-plugin.install-success` | `InstallPluginInput` | `InstallPluginOutput` | happy path | First-time install: marketplace add then `claude plugin install dark-factory` |
+| `install-plugin.update-success` | `InstallPluginInput` | `InstallPluginOutput` | happy path | Re-registers local repo as marketplace source then runs `claude plugin update dark-factory`; confirms new version via `claude plugin list` |
+| `install-plugin.not-registered` | `InstallPluginInput` | `StandardError` | error | Marketplace add fails (path not found or already registered differently) — verify repo root and path validity |
+| `install-plugin.update-failed` | `InstallPluginInput` | `StandardError` | error | `claude plugin update` exits non-zero — re-run `claude plugin marketplace add $(pwd)` and retry |
+
+#### Pseudocode
+
+```
+# Install (one-time)
+claude plugin marketplace add "$(pwd)"
+claude plugin install dark-factory
+claude plugin list   # verify version appears
+
+# Update (after pulling new changes)
+git pull
+claude plugin marketplace add "$(pwd)"
+claude plugin update dark-factory
+claude plugin list   # verify new version appears
+```
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| claude plugin CLI | stdout/stderr of terminal session |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # One-time install (run from repo root)
+  claude plugin marketplace add "$(pwd)"
+  claude plugin install dark-factory
+
+  # Update after new version (run from repo root)
+  claude plugin marketplace add "$(pwd)"
+  claude plugin update dark-factory
+  claude plugin list
+  ```
+- Notes: Always run from the repo root so `$(pwd)` resolves to the correct path. If `marketplace add` fails with "already registered differently", verify you are in the correct directory. If `plugin update` exits non-zero, re-run `marketplace add` before retrying.

--- a/docs/plans/2026-04-26-bump-version-update-plugin.md
+++ b/docs/plans/2026-04-26-bump-version-update-plugin.md
@@ -1,0 +1,159 @@
+# Bump Version and Update Plugin
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: N/A
+- Depends on: N/A
+- Status: `draft`
+
+## System Intent
+
+- What is being built: A two-step process that increments the plugin's patch version in `.claude-plugin/plugin.json`, creates a git commit and tag, then re-registers and updates the locally installed Claude Code plugin so the running environment reflects the new version.
+- Primary consumer(s): Developer / CI — anyone who invokes dark-factory commands in Claude Code.
+- Boundary (black-box scope only): Claude Code plugin registry (external); GitHub remote (external, for push only).
+
+## Stage Gate Tracker
+
+- [ ] Stage 1 Mermaid approved
+- [ ] Stage 2 Flows approved
+- [ ] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  PluginJson[".claude-plugin/plugin.json"]:::updated -->|version 1.1.4| Bump["bump-version flow"]:::created
+  Bump -->|version 1.1.5 written| PluginJson
+  Bump -->|git commit and tag dark-factory--v1.1.5| Git["Git Repo"]:::unchanged
+  Git -->|local repo path| MarketplaceAdd["claude plugin marketplace add"]:::unchanged
+  MarketplaceAdd -->|registered source| PluginUpdate["claude plugin update dark-factory"]:::unchanged
+  PluginUpdate -->|active plugin v1.1.5| ClaudeCode["Claude Code - external"]:::unchanged
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef updated fill:#ffe58a,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Flows
+
+- Flow naming rule: ``### Flow: `<flowname>` ``
+- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+### Flow: `bump-version`
+
+- Test files: N/A
+- Core files: `.claude-plugin/plugin.json`
+
+#### Types
+
+```txt
+VersionBumpInput {
+  currentVersion: string  (semver string read from plugin.json, e.g. "1.1.4")
+  bumpType: "patch"       (always patch for this plan)
+}
+
+VersionBumpOutput {
+  newVersion: string      (incremented semver, e.g. "1.1.5")
+  commitSha: string       (sha of the resulting git commit)
+  tag: string             (git tag created, e.g. "dark-factory--v1.1.5")
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `bump-version.success` | `VersionBumpInput` | `VersionBumpOutput` | happy path | Increments patch segment of version in `.claude-plugin/plugin.json`, commits, and creates git tag `dark-factory--v<newVersion>` | |
+| `bump-version.already-bumped` | `VersionBumpInput` | `StandardError` | error | Tag already exists for this version — abort to avoid duplicate tags | |
+
+#### Pseudocode
+
+```
+read version from .claude-plugin/plugin.json
+split on "." → [major, minor, patch]
+patch += 1
+newVersion = major.minor.patch
+# guard: if git tag "dark-factory--v<newVersion>" already exists → return StandardError { message: "tag already exists: dark-factory--v<newVersion>" }
+write newVersion back to plugin.json
+git add .claude-plugin/plugin.json
+git commit -m "chore: bump version to <newVersion>"
+git tag "dark-factory--v<newVersion>"
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+### Flow: `update-plugin`
+
+- Test files: N/A
+- Core files: `skills/install-plugin/SKILL.md`
+
+#### Types
+
+```txt
+UpdatePluginInput {
+  repoPath: string   (absolute path to the plugin source repo)
+}
+
+UpdatePluginOutput {
+  installedVersion: string  (version string confirmed by `claude plugin list`)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `update-plugin.success` | `UpdatePluginInput` | `UpdatePluginOutput` | happy path | Re-registers local repo as marketplace source then runs `claude plugin update dark-factory`; confirms new version via `claude plugin list` | |
+| `update-plugin.not-registered` | `UpdatePluginInput` | `StandardError` | error | Marketplace add fails (path not found or already registered differently) | |
+| `update-plugin.update-failed` | `UpdatePluginInput` | `StandardError` | error | `claude plugin update` exits non-zero | |
+
+#### Pseudocode
+
+```
+claude plugin marketplace add <repoPath>
+claude plugin update dark-factory
+claude plugin list   # verify new version appears
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| claude plugin CLI | stdout/stderr of terminal session |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # Step 1 — bump version (run from repo root)
+  # (edit .claude-plugin/plugin.json, then:)
+  git add .claude-plugin/plugin.json
+  git commit -m "chore: bump version to 1.1.5"
+  git tag dark-factory--v1.1.5
+
+  # Step 2 — update locally installed plugin
+  claude plugin marketplace add /home/lewibs/github/dark_factory/dark_factory-bump-version-update-plugin
+  claude plugin update dark-factory
+  claude plugin list
+  ```
+- Notes: Push tag to remote separately with `git push origin dark-factory--v1.1.5` after local verification.
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Handoff to Related Plan Reconciliation
+
+After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans.

--- a/skills/bump-version/SKILL.md
+++ b/skills/bump-version/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: bump-version
+description: "Increment the patch version in .claude-plugin/plugin.json, commit, and create a git tag using the dark-factory double-dash tag convention."
+user-invocable: false
+---
+## When to use
+When the dark-factory plugin needs a new release: increment the patch segment of the version in `.claude-plugin/plugin.json`, produce a commit, and apply the canonical git tag so the version is findable and push-ready.
+
+## Steps
+
+1. Read the current version from `.claude-plugin/plugin.json` (field `"version"`).
+2. Split on `"."` into `[major, minor, patch]`; increment `patch` by 1 to get `newVersion`.
+3. **Guard — check for duplicate tag before writing anything:**
+   ```bash
+   git tag -l "dark-factory--v<newVersion>"
+   ```
+   If the tag already exists, abort and surface `StandardError { message: "tag already exists: dark-factory--v<newVersion>" }`. Do not overwrite an existing tag.
+4. Write `newVersion` back into `.claude-plugin/plugin.json`.
+5. Stage and commit:
+   ```bash
+   git add .claude-plugin/plugin.json
+   git commit -m "chore: bump version to <newVersion>"
+   ```
+6. Create the tag using the double-dash convention:
+   ```bash
+   git tag "dark-factory--v<newVersion>"
+   ```
+7. After local verification, push the tag separately:
+   ```bash
+   git push origin "dark-factory--v<newVersion>"
+   ```
+8. Re-register and update the locally installed plugin so the running Claude Code environment reflects the new version:
+   ```bash
+   claude plugin marketplace add "$(pwd)"
+   claude plugin update dark-factory
+   claude plugin list   # confirm new version appears
+   ```
+
+## Notes
+
+- The tag format is `dark-factory--v<version>` — two dashes between `dark-factory` and `v`. Using a single dash (`dark-factory-v1.1.5`) is wrong and will not match the convention already established by prior tags.
+- Always run the duplicate-tag guard (step 3) before modifying any file. Writing the file and then discovering the tag exists leaves the repo in a dirty state with an uncommitted version change.
+- `claude plugin marketplace add "$(pwd)"` must be run from the repo root. Use `$(pwd)` rather than a hardcoded path so the skill is portable across machines and clone locations.
+- This skill covers patch bumps only. Minor and major bumps follow the same steps but increment the respective segment and reset lower segments to zero.

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -7,8 +7,8 @@ user-invocable: true
 ## Install (one-time)
 
 ```bash
-# 1. Register the local repo as a marketplace
-claude plugin marketplace add /home/lewibs/github/dark_factory/dark_factory
+# 1. Register the local repo as a marketplace source (run from repo root)
+claude plugin marketplace add "$(pwd)"
 
 # 2. Install the plugin
 claude plugin install dark-factory
@@ -17,9 +17,16 @@ claude plugin install dark-factory
 ## Update (after pulling new changes)
 
 ```bash
-git -C /home/lewibs/github/dark_factory/dark_factory pull
+git pull
+# Re-register local repo as marketplace source, then update
+claude plugin marketplace add "$(pwd)"
 claude plugin update dark-factory
 ```
+
+## Error handling
+
+- If `claude plugin marketplace add` fails with "path not found" or "already registered differently", verify you are running the command from inside the correct repo root directory and that the path is valid.
+- If `claude plugin update` exits non-zero, check `claude plugin list` to confirm the plugin name and re-run `claude plugin marketplace add "$(pwd)"` before retrying.
 
 ## Verify
 


### PR DESCRIPTION
## Description

# Bump Version and Update Plugin

## Plan Metadata

- Plan type: `plan`
- Parent plan: N/A
- Depends on: N/A
- Status: `draft`

## System Intent

- What is being built: A two-step process that increments the plugin's patch version in `.claude-plugin/plugin.json`, creates a git commit and tag, then re-registers and updates the locally installed Claude Code plugin so the running environment reflects the new version.
- Primary consumer(s): Developer / CI — anyone who invokes dark-factory commands in Claude Code.
- Boundary (black-box scope only): Claude Code plugin registry (external); GitHub remote (external, for push only).

## Stage Gate Tracker

- [ ] Stage 1 Mermaid approved
- [ ] Stage 2 Flows approved
- [ ] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

```mermaid
graph TD
  PluginJson[".claude-plugin/plugin.json"]:::updated -->|version 1.1.4| Bump["bump-version flow"]:::created
  Bump -->|version 1.1.5 written| PluginJson
  Bump -->|git commit and tag dark-factory--v1.1.5| Git["Git Repo"]:::unchanged
  Git -->|local repo path| MarketplaceAdd["claude plugin marketplace add"]:::unchanged
  MarketplaceAdd -->|registered source| PluginUpdate["claude plugin update dark-factory"]:::unchanged
  PluginUpdate -->|active plugin v1.1.5| ClaudeCode["Claude Code - external"]:::unchanged

classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
classDef updated fill:#ffe58a,stroke:#666,stroke-width:1px;
classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
```

ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER

## Flows

- Flow naming rule: `### Flow: \`<flowname>\``
- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).

### Global Types

```txt
StandardError {
  message: string (human-readable description of what went wrong)
}
```

### Flow: `bump-version`

- Test files: N/A
- Core files: `.claude-plugin/plugin.json`

#### Types

```txt
VersionBumpInput {
  currentVersion: string  (semver string read from plugin.json, e.g. "1.1.4")
  bumpType: "patch"       (always patch for this plan)
}

VersionBumpOutput {
  newVersion: string      (incremented semver, e.g. "1.1.5")
  commitSha: string       (sha of the resulting git commit)
  tag: string             (git tag created, e.g. "dark-factory--v1.1.5")
}
```

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `bump-version.success` | `VersionBumpInput` | `VersionBumpOutput` | happy path | Increments patch segment of version in `.claude-plugin/plugin.json`, commits, and creates git tag `dark-factory--v<newVersion>` | |
| `bump-version.already-bumped` | `VersionBumpInput` | `StandardError` | error | Tag already exists for this version — abort to avoid duplicate tags | |

#### Pseudocode

```
read version from .claude-plugin/plugin.json
split on "." → [major, minor, patch]
patch += 1
newVersion = major.minor.patch
# guard: if git tag "dark-factory--v<newVersion>" already exists → return StandardError { message: "tag already exists: dark-factory--v<newVersion>" }
write newVersion back to plugin.json
git add .claude-plugin/plugin.json
git commit -m "chore: bump version to <newVersion>"
git tag "dark-factory--v<newVersion>"
```

ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER

### Flow: `update-plugin`

- Test files: N/A
- Core files: `skills/install-plugin/SKILL.md`

#### Types

```txt
UpdatePluginInput {
  repoPath: string   (absolute path to the plugin source repo)
}

UpdatePluginOutput {
  installedVersion: string  (version string confirmed by `claude plugin list`)
}
```

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `update-plugin.success` | `UpdatePluginInput` | `UpdatePluginOutput` | happy path | Re-registers local repo as marketplace source then runs `claude plugin update dark-factory`; confirms new version via `claude plugin list` | |
| `update-plugin.not-registered` | `UpdatePluginInput` | `StandardError` | error | Marketplace add fails (path not found or already registered differently) | |
| `update-plugin.update-failed` | `UpdatePluginInput` | `StandardError` | error | `claude plugin update` exits non-zero | |

#### Pseudocode

```
claude plugin marketplace add <repoPath>
claude plugin update dark-factory
claude plugin list   # verify new version appears
```

ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER

## Logs

| Source | Location |
|--------|----------|
| claude plugin CLI | stdout/stderr of terminal session |

## Deployment

- Mechanism: `local only`
- Deploy command:
  ```bash
  # Step 1 — bump version (run from repo root)
  # (edit .claude-plugin/plugin.json, then:)
  git add .claude-plugin/plugin.json
  git commit -m "chore: bump version to 1.1.5"
  git tag dark-factory--v1.1.5

  # Step 2 — update locally installed plugin
  claude plugin marketplace add /home/lewibs/github/dark_factory/dark_factory-bump-version-update-plugin
  claude plugin update dark-factory
  claude plugin list
  ```
- Notes: Push tag to remote separately with `git push origin dark-factory--v1.1.5` after local verification.

ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER

## Handoff to Related Plan Reconciliation

After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans.

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
