### PR TITLE
docs: add /dark-factory:repair to README commands table

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,6 @@ claude plugin list
 | Command | Input | Description |
 |---|---|---|
 | `/dark-factory:manufacture` | Task description (e.g. "add OAuth login") | Full orchestration — routes to the right agent (feature, debug, or fix-flow) end-to-end, runs code review, opens a PR, and cleans up |
+| `/dark-factory:repair` | Fix description (e.g. "fix null check in login handler") | Lightweight targeted fix — implements the change, runs tests, optionally updates docs, and opens a PR — no planning phase |
 | `/dark-factory:init` | Optional GitHub URL | Onboard a project onto dark factory — sets up the structure for infinite autonomous changes and generates a CLAUDE.md |
 | `/dark-factory:update` | None | Update the plugin to the latest version |


### PR DESCRIPTION
## Summary
- Adds the missing `/dark-factory:repair` command to the Commands table in README.md
- The command already existed in `commands/repair.md`, `docs/docs/commands.md`, and `docs/docs/README.md` — the user-facing README was the only place it was absent

## Test plan
- [ ] Verify the Commands table in README.md now lists all four commands: `manufacture`, `repair`, `init`, `update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)