### PR TITLE
fix(update): re-register marketplace before updating to prevent cache loss on restart

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/commands/update.md
+++ b/commands/update.md
@@ -2,9 +2,10 @@
 description: Update the dark-factory plugin to the latest version.
 ---
 
-Run these two commands:
+Run these commands from the repo root (`~/github/dark_factory/dark_factory` or wherever you cloned it):
 
 ```bash
 git pull
-claude plugin update "dark-factory@dark-factory"
+claude plugin marketplace add "$(pwd)"
+claude plugin update dark-factory
 ```

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -38,5 +38,7 @@ claude plugin list
 
 | Command | Description |
 |---|---|
-| `/dark-factory:dark-factory` | Full orchestration — feature, debug, or fix-flow end-to-end |
+| `/dark-factory:manufacture` | Full orchestration — feature, debug, or fix-flow end-to-end |
+| `/dark-factory:repair` | Lightweight targeted fix — no planning phase |
 | `/dark-factory:init` | Initialize a new project with dark factory |
+| `/dark-factory:update` | Update the plugin to the latest version |

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -17,6 +17,7 @@ claude plugin install dark-factory
 
 ```bash
 git pull
+claude plugin marketplace add "$(pwd)"
 claude plugin update dark-factory
 ```
 
@@ -31,5 +32,6 @@ claude plugin list
 | Command | Description |
 |---|---|
 | `/dark-factory:manufacture` | Full orchestration — feature, debug, or fix-flow end-to-end |
+| `/dark-factory:repair` | Lightweight targeted fix — no planning phase |
 | `/dark-factory:init` | Initialize a new project with dark factory |
 | `/dark-factory:update` | Update the plugin to the latest version |


### PR DESCRIPTION
## Summary
- Fixes `/dark-factory:update` command which used `claude plugin update "dark-factory@dark-factory"` without re-registering the marketplace first — causing the plugin cache to go missing after restarts when the marketplace registration was lost
- Aligns the update command with the `install-plugin` skill which already correctly calls `claude plugin marketplace add "$(pwd)"` before updating
- Fixes stale command tables in `install` and `install-plugin` skills (adds `repair`, corrects `manufacture` command name)
- Bumps version to 1.1.7

## Root Cause
After a restart, the `known_marketplaces.json` registration can drift or be cleared. The old update command didn't re-register, so `claude plugin update` couldn't locate the source and silently failed, leaving the cache at the old path with no new files.

## Test plan
- [ ] Run `/dark-factory:update`, restart Claude Code, verify `/dark-factory` commands are still available
- [ ] Verify `claude plugin list` shows version 1.1.7 after update

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)