### PR TITLE
fix(update): use full plugin id and marketplace update step

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/commands/update.md
+++ b/commands/update.md
@@ -7,5 +7,6 @@ Run these commands from the repo root (`~/github/dark_factory/dark_factory` or w
 ```bash
 git pull
 claude plugin marketplace add "$(pwd)"
-claude plugin update dark-factory
+claude plugin marketplace update dark-factory
+claude plugin update "dark-factory@dark-factory"
 ```

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -20,13 +20,14 @@ claude plugin install dark-factory
 git pull
 # Re-register local repo as marketplace source, then update
 claude plugin marketplace add "$(pwd)"
-claude plugin update dark-factory
+claude plugin marketplace update dark-factory
+claude plugin update "dark-factory@dark-factory"
 ```
 
 ## Error handling
 
 - If `claude plugin marketplace add` fails with "path not found" or "already registered differently", verify you are running the command from inside the correct repo root directory and that the path is valid.
-- If `claude plugin update` exits non-zero, check `claude plugin list` to confirm the plugin name and re-run `claude plugin marketplace add "$(pwd)"` before retrying.
+- If `claude plugin update` exits non-zero, check `claude plugin list --json` to confirm the full plugin id (format: `name@marketplace`) and use that exact id with `claude plugin update`. Also re-run `claude plugin marketplace add "$(pwd)"` and `claude plugin marketplace update dark-factory` before retrying.
 
 ## Verify
 

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -18,7 +18,8 @@ claude plugin install dark-factory
 ```bash
 git pull
 claude plugin marketplace add "$(pwd)"
-claude plugin update dark-factory
+claude plugin marketplace update dark-factory
+claude plugin update "dark-factory@dark-factory"
 ```
 
 ## Verify


### PR DESCRIPTION
## Summary
- `claude plugin update dark-factory` always fails with "Plugin not found" — the command requires the full id format `dark-factory@dark-factory` (name@marketplace)
- Adds `claude plugin marketplace update dark-factory` step before the plugin update to refresh the local marketplace index so the latest version is visible
- Fixes `commands/update.md`, `skills/install/SKILL.md`, and `skills/install-plugin/SKILL.md`
- Bumps version to 1.1.8

## Root Cause
The Claude plugin CLI's `update` subcommand resolves plugins by their full `name@marketplace` id, not just the name. Passing only `dark-factory` results in "Plugin not found" regardless of marketplace registration.

## Test plan
- [ ] Run the update sequence and verify it succeeds end-to-end without errors
- [ ] `claude plugin list` shows version 1.1.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)