### PR TITLE
feat(isolation): replace cp-r directory copy with git worktrees for agent isolation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -5,7 +5,7 @@ description: Top-level dark-factory orchestrator. Preps an isolated work dir, ro
 tools: Read, Bash, Agent, PushNotification
 model: sonnet
 scripts: agents/dark-factory/scripts/prep-feature-dir.sh
-allowed-tools: Bash(bash agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(rm -rf dark_factory-*), Bash(cd *)
+allowed-tools: Bash(bash agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(git worktree remove *), Bash(git branch -D *)
 ---
 
 You are the dark-factory-agent. Your job is to orchestrate an entire unit of work end-to-end: isolate it in a fresh working directory, delegate to the right worker, review the result, keep docs current, ship a PR, and clean up. You do not write code or modify files yourself — you delegate entirely.
@@ -20,7 +20,7 @@ If `taskName` is not provided, derive a short slug from `taskDescription` (lower
 
 ## Paths to key agents and scripts
 
-All paths are relative to the inner project dir (`dark_factory/dark_factory/` from the outer wrapper, or the CWD when the agent is running inside the work dir).
+All paths are relative to the project dir (or CWD when the agent is running inside the worktree).
 
 | Resource | Path |
 |---|---|
@@ -39,11 +39,11 @@ All paths are relative to the inner project dir (`dark_factory/dark_factory/` fr
 dark-factory-agent(taskDescription, taskName):
 
   # Step 1 — prep isolated work dir
-  Run from the outer wrapper (dark_factory/):
+  Run from the project root (git repo):
     bash agents/dark-factory/scripts/prep-feature-dir.sh <taskName>
 
   Capture WORK_DIR from stdout line: WORK_DIR=<value>
-  If script fails: report error and STOP (no cleanup needed — work dir was never created)
+  If script fails: report error and STOP (no cleanup needed — worktree was never created)
 
   # Step 2 — route to worker agent
   cd into WORK_DIR
@@ -97,19 +97,19 @@ dark-factory-agent(taskDescription, taskName):
   prUrl = result from pr-agent
 
   # Step 6 — cleanup
-  cleanup(WORK_DIR)
+  cleanup(WORK_DIR, taskName)
 
-  Report: "Done. PR: <prUrl>. Work dir <WORK_DIR> removed. Skills written: <skillsWritten>."
+  Report: "Done. PR: <prUrl>. Worktree <WORK_DIR> removed. Skills written: <skillsWritten>."
   STOP
 ```
 
-## cleanup(WORK_DIR)
+## cleanup(WORK_DIR, taskName)
 
 ```
-cd dark_factory/   # outer wrapper
-rm -rf WORK_DIR
+git worktree remove WORK_DIR --force
+git branch -D feature/<taskName>
 
-If rm fails: warn developer but do not halt — this is non-fatal.
+If either command fails: warn developer but do not halt — this is non-fatal.
 ```
 
 ## Classification rules
@@ -125,6 +125,6 @@ If rm fails: warn developer but do not halt — this is non-fatal.
 
 - Never write, edit, or scaffold code yourself — delegate entirely.
 - Always run cleanup on error before halting, except on prep failure (work dir does not exist yet).
-- cleanup is non-fatal: if rm -rf fails, warn and continue.
+- cleanup is non-fatal: if git worktree remove fails, warn and continue.
 - planFilePath is null when the worker agent (e.g. debugger-agent) does not produce a plan file. Pass the taskDescription string as a fallback to downstream agents that require a plan.
 - When classifying, prefer asking one question over guessing wrong and invoking the wrong worker.

--- a/agents/dark-factory/agents/repair-agent.md
+++ b/agents/dark-factory/agents/repair-agent.md
@@ -5,7 +5,7 @@ description: Lightweight repair orchestrator. Skips planning, code review, and f
 tools: Read, Bash, Agent, PushNotification
 model: sonnet
 scripts: agents/dark-factory/scripts/prep-feature-dir.sh
-allowed-tools: Bash(bash agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(rm -rf dark_factory-*), Bash(cd *)
+allowed-tools: Bash(bash agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(git worktree remove *), Bash(git branch -D *)
 ---
 
 You are the repair-agent. Your job is to apply a targeted repair end-to-end: isolate the work in a fresh directory, delegate implementation to repair-implementation-agent, run the docs update if warranted, ship a PR, and clean up. You do not write code or modify files yourself — you delegate entirely.
@@ -36,11 +36,11 @@ repair-agent(taskDescription, taskName):
     # lowercase, hyphens only, truncated to 30 chars
 
   # Step 2 — prep isolated work dir
-  Run from the outer wrapper (dark_factory/):
+  Run from the project root (git repo):
     bash agents/dark-factory/scripts/prep-feature-dir.sh <taskName>
 
   Capture WORK_DIR from stdout line: WORK_DIR=<value>
-  If script fails: report error and STOP (no cleanup needed)
+  If script fails: report error and STOP (no cleanup needed — worktree was never created)
 
   # Step 3 — implement directly (no planning, no routing)
   cd into WORK_DIR
@@ -66,19 +66,19 @@ repair-agent(taskDescription, taskName):
   merged = true
 
   # Step 6 — cleanup
-  cleanup(WORK_DIR)
+  cleanup(WORK_DIR, taskName)
 
-  Report: "Done. PR: <prUrl>. Merged: <merged>. Work dir <WORK_DIR> removed."
+  Report: "Done. PR: <prUrl>. Merged: <merged>. Worktree <WORK_DIR> removed."
   STOP
 ```
 
-## cleanup(WORK_DIR)
+## cleanup(WORK_DIR, taskName)
 
 ```
-cd dark_factory/   # outer wrapper
-rm -rf WORK_DIR
+git worktree remove WORK_DIR --force
+git branch -D feature/<taskName>
 
-If rm fails: warn developer but do not halt — this is non-fatal.
+If either command fails: warn developer but do not halt — this is non-fatal.
 ```
 
 ## Rules

--- a/agents/dark-factory/scripts/prep-feature-dir.sh
+++ b/agents/dark-factory/scripts/prep-feature-dir.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run from the outer wrapper directory (dark_factory/).
+# Run from anywhere inside a git repository.
 # Usage: bash prep-feature-dir.sh <task-name>
-# Prints: WORK_DIR=dark_factory-<task-name>
+# Prints: WORK_DIR=<absolute-path-to-worktree>
 
 TASK_NAME="${1:-}"
 if [ -z "$TASK_NAME" ]; then
@@ -11,17 +11,18 @@ if [ -z "$TASK_NAME" ]; then
     exit 1
 fi
 
-WORK_DIR="dark_factory-${TASK_NAME}"
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not inside a git repository." >&2; exit 1; }
 
-if [ -d "$WORK_DIR" ]; then
-    echo "Error: work directory '$WORK_DIR' already exists." >&2
+PROJECT_NAME=$(basename "$GIT_ROOT")
+WORKTREE_NAME="${PROJECT_NAME}-${TASK_NAME}"
+WORK_DIR="${GIT_ROOT}/../${WORKTREE_NAME}"
+
+if git -C "$GIT_ROOT" worktree list | grep -qF "$WORKTREE_NAME"; then
+    echo "Error: worktree '${WORKTREE_NAME}' already exists." >&2
     exit 1
 fi
 
-cd dark_factory
-git pull origin main || { echo "Error: git pull failed." >&2; exit 1; }
-cd ..
-
-cp -r dark_factory "$WORK_DIR" || { echo "Error: cp failed." >&2; exit 1; }
+git -C "$GIT_ROOT" pull origin main || { echo "Error: git pull failed." >&2; exit 1; }
+git -C "$GIT_ROOT" worktree add "$WORK_DIR" -b "feature/${TASK_NAME}" || { echo "Error: git worktree add failed." >&2; exit 1; }
 
 echo "WORK_DIR=${WORK_DIR}"

--- a/agents/initialization/agents/init-docs-agent.md
+++ b/agents/initialization/agents/init-docs-agent.md
@@ -1,7 +1,7 @@
 ---
 name: init-docs-agent
 user-invocable: false
-description: Explores a newly initialized project, discovers user-facing flows per system, invokes investigation-agent per flow to generate docs/docs/ files, then writes a minimal CLAUDE.md pointer doc at the project root. Called after init.sh sets up the project structure.
+description: Explores a newly initialized project, discovers user-facing flows per system, invokes investigation-agent per flow to generate docs/docs/ files, then writes a minimal CLAUDE.md pointer doc at the project root.
 tools: Read, Grep, Glob, Bash, Write, Task
 model: sonnet
 allowed-tools: Bash(ls *), Bash(find *), Bash(cat *), Bash(grep -r *), Bash(mkdir *)

--- a/agents/initialization/agents/init-orchestrator-agent.md
+++ b/agents/initialization/agents/init-orchestrator-agent.md
@@ -1,11 +1,10 @@
 ---
 name: init-orchestrator-agent
 user-invocable: true
-description: 'Sets up a project to use dark factory. Runs init.sh, generates docs/docs/ files and a minimal CLAUDE.md via init-docs-agent, then opens a PR titled "init: dark factory".'
+description: 'Sets up a project to use dark factory. Generates docs/docs/ files and a minimal CLAUDE.md via init-docs-agent, then opens a PR titled "init: dark factory".'
 tools: Bash, Agent
 model: sonnet
-scripts: agents/initialization/scripts/init.sh
-allowed-tools: "Bash(bash agents/initialization/scripts/init.sh *), Bash(find *)"
+allowed-tools: "Bash(git clone *), Bash(jq *), Bash(find *)"
 ---
 
 You are the init-orchestrator-agent. Your job is to set up a project to use dark factory end-to-end.
@@ -19,26 +18,14 @@ Optionally receive a `github_url`. If not provided, treat the current directory 
 ```
 init-orchestrator-agent(github_url?):
 
-  # Step 1: run init.sh to set up directory structure
-  SCRIPT = path to agents/initialization/scripts/init.sh (find it relative to where dark factory is installed)
-
+  # Step 1: resolve the project path
   If github_url is provided:
-    run: bash <SCRIPT> <github_url>
     REPO_NAME = basename(github_url, ".git")
-    DERIVED_PROJECT_PATH = REPO_NAME/REPO_NAME
+    run: git clone <github_url>
+    If git clone fails: report the error and STOP.
+    PROJECT_PATH = REPO_NAME
   Else:
-    run: bash <SCRIPT>
-    DIRNAME = basename(CWD)
-    DERIVED_PROJECT_PATH = DIRNAME/DIRNAME
-
-  If the script succeeds:
-    Capture PROJECT_PATH from the script's stdout line: `PROJECT_PATH=<value>`
-
-  If the script fails with an "already exists" error:
-    Log: "Directory already exists — skipping init.sh, proceeding to documentation phase."
-    PROJECT_PATH = DERIVED_PROJECT_PATH
-
-  If the script fails for any other reason: report the error and STOP.
+    PROJECT_PATH = CWD  (the directory the agent is currently running in)
 
   # Step 2: set bypassPermissions in ~/.claude/settings.json
   run: jq '.permissions.defaultMode = "bypassPermissions"' ~/.claude/settings.json > /tmp/claude-settings-tmp.json && mv /tmp/claude-settings-tmp.json ~/.claude/settings.json
@@ -59,6 +46,5 @@ init-orchestrator-agent(github_url?):
 
 ## Rules
 
-- Never modify init.sh or init-docs-agent.
-- Do not create or edit any files yourself — delegate entirely to the script and agents.
-- If init.sh fails because the target directory already exists, derive PROJECT_PATH and proceed directly to Step 2 — do not stop.
+- Never modify init-docs-agent.
+- Do not create or edit any files yourself — delegate entirely to Bash and agents.


### PR DESCRIPTION
## Summary

- Replaces `cp -r` directory copy with `git worktree add` for agent isolation in `prep-feature-dir.sh`
- Updates `dark-factory-agent` and `repair-agent` cleanup to use `git worktree remove` + `git branch -D` instead of `rm -rf`
- Removes dependency on outer `dark_factory/` wrapper directory — script now works from any location inside the git repo
- Removes `init.sh` script dependency from `init-orchestrator-agent`; clones directly via `git clone` when a GitHub URL is provided

## Test plan

- [ ] Run `bash agents/dark-factory/scripts/prep-feature-dir.sh <task-name>` from the repo root and confirm a worktree is created at `../<project>-<task-name>`
- [ ] Confirm `git worktree list` shows the new worktree
- [ ] Verify cleanup with `git worktree remove <path> --force && git branch -D feature/<task-name>` succeeds
- [ ] Run `/dark-factory:manufacture` end-to-end and confirm isolation and cleanup work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
