### PR TITLE
fix(plugin): prevent marketplace registration from being overwritten by worktree path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
       "source": {
         "source": "url",
-        "url": "https://github.com/lewibs/dark-factory.git"
+        "url": "https://github.com/lewibs/skills.git"
       }
     }
   ]

--- a/skills/bump-version/SKILL.md
+++ b/skills/bump-version/SKILL.md
@@ -31,8 +31,10 @@ When the dark-factory plugin needs a new release: increment the patch segment of
    ```
 8. Re-register and update the locally installed plugin so the running Claude Code environment reflects the new version:
    ```bash
-   claude plugin marketplace add "$(pwd)"
-   claude plugin update dark-factory
+   DARK_FACTORY_ROOT=$(git worktree list | head -1 | awk '{print $1}')
+   claude plugin marketplace add "$DARK_FACTORY_ROOT"
+   claude plugin marketplace update dark-factory
+   claude plugin update "dark-factory@dark-factory"
    claude plugin list   # confirm new version appears
    ```
 
@@ -40,5 +42,5 @@ When the dark-factory plugin needs a new release: increment the patch segment of
 
 - The tag format is `dark-factory--v<version>` — two dashes between `dark-factory` and `v`. Using a single dash (`dark-factory-v1.1.5`) is wrong and will not match the convention already established by prior tags.
 - Always run the duplicate-tag guard (step 3) before modifying any file. Writing the file and then discovering the tag exists leaves the repo in a dirty state with an uncommitted version change.
-- `claude plugin marketplace add "$(pwd)"` must be run from the repo root. Use `$(pwd)` rather than a hardcoded path so the skill is portable across machines and clone locations.
+- Always use `git worktree list | head -1 | awk '{print $1}'` (not `$(pwd)`) to get the main repo root for marketplace registration. When this skill runs inside a git worktree, `$(pwd)` resolves to the worktree path — which gets deleted after cleanup — causing the marketplace registration to point to a dead path and the plugin to disappear on next restart.
 - This skill covers patch bumps only. Minor and major bumps follow the same steps but increment the respective segment and reset lower segments to zero.


### PR DESCRIPTION
## Summary

- **Root cause**: `bump-version` skill called `claude plugin marketplace add "$(pwd)"` from inside a git worktree. When the worktree is deleted after the manufacture run, `settings.json` keeps pointing to the dead path — plugin disappears on next Claude restart.
- **Fix**: use `git worktree list | head -1 | awk '{print $1}'` to resolve the main repo root regardless of which worktree the skill runs in.
- Also corrects the stale plugin source URL in `marketplace.json` (`dark-factory.git` → `skills.git`) and updates the bump-version update command to the full form `dark-factory@dark-factory` with the marketplace update step.

## Test plan

- [ ] Run `/dark-factory:manufacture` on a task in the dark-factory repo to trigger a version bump
- [ ] Confirm the marketplace entry in `settings.json` still points to the main repo path after the worktree is cleaned up
- [ ] Restart Claude and verify the plugin is still listed as enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)