### PR TITLE
feat(routing): add repair-agent as 4th route with short-circuit worktree handling

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -28,6 +28,7 @@ All paths are relative to the project dir (or CWD when the agent is running insi
 | `feature-agent` | `agents/featurework/agents/feature-agent.md` |
 | `debugger-agent` | `agents/debugger/agents/debugger-agent.md` |
 | `fix-flow-orchestrator` | `agents/fix-flow/agents/fix-flow-orchestrator.md` |
+| `repair-agent` | `agents/dark-factory/agents/repair-agent.md` |
 | `code-review-orchestrator-agent` | `agents/code-review/agents/code-review-orchestrator-agent.md` |
 | `update-documentation-agent` | `agents/documentation/agents/update-documentation-agent.md` |
 | `skill-update-agent` | `agents/skill-update/agents/skill-update-agent.md` |
@@ -38,17 +39,30 @@ All paths are relative to the project dir (or CWD when the agent is running insi
 ```
 dark-factory-agent(taskDescription, taskName):
 
-  # Step 1 — prep isolated work dir
+  # Step 1 — classify and route
+  Classify taskDescription using the Classification rules table below.
+
+  # Repair route: repair-agent manages its own worktree, PR, and cleanup internally.
+  # Do NOT prep a worktree; just invoke repair-agent and stop.
+  If classified as repair (small change, tweak, rename, minor update, quick fix, adjust, alter):
+    result = invoke repair-agent with: taskDescription, taskName
+    If result is error or hard-stop:
+      report error and STOP
+    prUrl = result.prUrl
+    Report: "Done. PR: <prUrl>."
+    STOP
+
+  # Step 2 — prep isolated work dir (feature / fix-flow / debugger routes only)
   Run from the project root (git repo):
     bash agents/dark-factory/scripts/prep-feature-dir.sh <taskName>
 
   Capture WORK_DIR from stdout line: WORK_DIR=<value>
   If script fails: report error and STOP (no cleanup needed — worktree was never created)
 
-  # Step 2 — route to worker agent
+  # Step 3 — route to worker agent
   cd into WORK_DIR
 
-  Classify taskDescription:
+  Route based on classification:
     - New feature or capability → invoke feature-agent with taskDescription
     - Broken integration flow / end-to-end failure → invoke fix-flow-orchestrator with taskDescription
     - Bug, crash, or unexpected behavior → invoke debugger-agent with taskDescription
@@ -59,7 +73,7 @@ dark-factory-agent(taskDescription, taskName):
 
   planFilePath = path the worker wrote its plan to (null if no plan produced)
 
-  # Step 3 — code review
+  # Step 4 — code review
   invoke code-review-orchestrator-agent with:
     planFilePath = planFilePath ?? "Task: <taskDescription>"
     codePath     = WORK_DIR
@@ -68,12 +82,12 @@ dark-factory-agent(taskDescription, taskName):
     run cleanup(WORK_DIR)
     report error and STOP
 
-  # Step 4 — update docs
-  # IMPORTANT: Documentation agent MUST fully complete before proceeding to Step 5.
-  # The pr-agent (Step 5) uses `git add --all`, which will pick up any docs written here.
+  # Step 5 — update docs
+  # IMPORTANT: Documentation agent MUST fully complete before proceeding to Step 6.
+  # The pr-agent (Step 6) uses `git add --all`, which will pick up any docs written here.
   invoke update-documentation-agent with planFilePath (pass null if none — agent handles gracefully)
 
-  # Step 4c — skill update (non-fatal)
+  # Step 5c — skill update (non-fatal)
   skillsWritten = []
   try:
     skillResult = invoke skill-update-agent with:
@@ -85,9 +99,9 @@ dark-factory-agent(taskDescription, taskName):
   catch error:
     warn developer: "skill-update-agent failed: <error>. Continuing to PR."
 
-  # Step 5 — PR
-  # Only reached after all Step 4 documentation agents have fully completed.
-  # pr-agent uses `git add --all`, so any docs written in Step 4 are included in the PR.
+  # Step 6 — PR
+  # Only reached after all Step 5 documentation agents have fully completed.
+  # pr-agent uses `git add --all`, so any docs written in Step 5 are included in the PR.
   invoke pr-agent with: planFilePath ?? taskDescription
 
   If pr-agent errors or cannot merge:
@@ -96,7 +110,7 @@ dark-factory-agent(taskDescription, taskName):
 
   prUrl = result from pr-agent
 
-  # Step 6 — cleanup
+  # Step 7 — cleanup
   cleanup(WORK_DIR, taskName)
 
   Report: "Done. PR: <prUrl>. Worktree <WORK_DIR> removed. Skills written: <skillsWritten>."
@@ -114,8 +128,11 @@ If either command fails: warn developer but do not halt — this is non-fatal.
 
 ## Classification rules
 
+Match signals in the order listed below — first match wins.
+
 | Signal in taskDescription | Route to |
 |---|---|
+| "small change", "tweak", "rename", "minor update", "quick fix", "adjust", "alter" | `repair-agent` |
 | "add", "build", "create", "implement", "new feature" | `feature-agent` |
 | "broken flow", "integration failing", "end-to-end", "pipeline" | `fix-flow-orchestrator` |
 | "bug", "crash", "error", "fix", "broken", "not working", "debug" | `debugger-agent` |

--- a/agents/dark-factory/agents/repair-agent.md
+++ b/agents/dark-factory/agents/repair-agent.md
@@ -69,6 +69,7 @@ repair-agent(taskDescription, taskName):
   cleanup(WORK_DIR, taskName)
 
   Report: "Done. PR: <prUrl>. Merged: <merged>. Worktree <WORK_DIR> removed."
+  Return: { prUrl: prUrl }
   STOP
 ```
 
@@ -85,7 +86,7 @@ If either command fails: warn developer but do not halt — this is non-fatal.
 
 - Never write, edit, or scaffold code yourself — delegate entirely.
 - Always run cleanup on error before halting, except on prep failure (work dir does not exist yet).
-- cleanup is non-fatal: if rm -rf fails, warn and continue.
+- cleanup is non-fatal: if git worktree remove or git branch -D fails, warn and continue.
 - Skip code review entirely — this is intentional for repair tasks.
 - Skip skill-update-agent — repair tasks do not produce new skills.
 - Doc update is conditional: only invoke update-documentation-agent when repair-implementation-agent reports significantChange == true.

--- a/docs/docs/manufacture.md
+++ b/docs/docs/manufacture.md
@@ -6,20 +6,24 @@
 
 ## System Intent
 
-- What this is: The top-level user-facing orchestration flow. Given a task description, routes to the correct worker agent (feature, debugger, or fix-flow), then runs code review, updates documentation, updates skills, opens a PR, and cleans up an isolated work directory — all without manual intervention.
+- What this is: The top-level user-facing orchestration flow. Given a task description, classifies the request and routes to the correct worker agent (repair, feature, debugger, or fix-flow). Repair tasks short-circuit before worktree prep and delegate entirely to `repair-agent`. All other routes create an isolated work directory, run code review, update documentation, update skills, open a PR, and clean up — all without manual intervention.
 
 ## Mermaid Diagram
 
 ```mermaid
 flowchart TD
   User["User: /dark-factory:manufacture <task>"] --> DarkFactory["dark-factory-agent"]
-  DarkFactory --> Prep["prep-feature-dir.sh\n(creates isolated WORK_DIR)"]
-  Prep --> Classify{Classify task}
-  Classify -->|new feature| Feature["feature-agent"]
-  Classify -->|bug/crash/fix| Debug["debugger-agent"]
-  Classify -->|broken integration flow| FixFlow["fix-flow-orchestrator"]
+  DarkFactory --> Classify{Classify task}
+  Classify -->|repair signals| RepairAgent["repair-agent\n(manages own worktree + PR)"]
+  RepairAgent --> Done2["Report: Done. PR: <url>"]
+  Classify -->|new feature| Prep["prep-feature-dir.sh\n(creates isolated WORK_DIR)"]
+  Classify -->|bug/crash/fix| Prep
+  Classify -->|broken integration flow| Prep
   Classify -->|ambiguous| Push["PushNotification: Clarification Required"]
   Push --> User2["Ask developer one question"]
+  Prep --> Feature["feature-agent"]
+  Prep --> Debug["debugger-agent"]
+  Prep --> FixFlow["fix-flow-orchestrator"]
   Feature --> CodeReview["code-review-orchestrator-agent"]
   Debug --> CodeReview
   FixFlow --> CodeReview
@@ -65,49 +69,60 @@ StandardError {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
+| `manufacture.repair` | `ManufactureInput` | `{ prUrl: string }` | happy path | taskDescription signals repair (small change / tweak / rename / minor update / quick fix / adjust / alter); delegates to repair-agent which manages its own worktree and PR; short-circuits before prep |
 | `manufacture.feature` | `ManufactureInput` | `ManufactureOutput` | happy path | taskDescription signals new feature; routes to feature-agent |
 | `manufacture.debug` | `ManufactureInput` | `ManufactureOutput` | happy path | taskDescription signals bug/crash; routes to debugger-agent |
 | `manufacture.fix-flow` | `ManufactureInput` | `ManufactureOutput` | happy path | taskDescription signals broken integration; routes to fix-flow-orchestrator |
 | `manufacture.ambiguous` | `ManufactureInput` | paused | clarification | agent asks developer one question before routing |
 | `manufacture.worker-error` | `ManufactureInput` | `StandardError` | error | worker agent returns hard-stop; WORK_DIR cleaned up |
-| `manufacture.prep-fail` | `ManufactureInput` | `StandardError` | error | prep-feature-dir.sh fails; no cleanup (work dir never created) |
+| `manufacture.prep-fail` | `ManufactureInput` | `StandardError` | error | prep-feature-dir.sh fails; no cleanup (work dir never created); does not apply to repair route (no prep is run) |
 
 #### Pseudocode
 
 ```
 dark-factory-agent(taskDescription, taskName):
 
-  # Step 1 — prep work dir
+  # Step 1 — classify and route
+  classify taskDescription (first match wins):
+    - repair signals ("small change", "tweak", "rename", "minor update", "quick fix", "adjust", "alter"):
+        result = invoke repair-agent(taskDescription, taskName)
+        if result is error: report error, STOP
+        report "Done. PR: <result.prUrl>."
+        STOP  # repair-agent manages its own worktree, PR, and cleanup — no further steps
+
+    - feature keywords ("add", "build", "create", "implement", "new feature") → will route to feature-agent (Step 3)
+    - flow keywords ("broken flow", "integration failing", "end-to-end", "pipeline") → will route to fix-flow-orchestrator (Step 3)
+    - bug keywords ("bug", "crash", "error", "fix", "broken", "not working", "debug") → will route to debugger-agent (Step 3)
+    - ambiguous → PushNotification("Clarification Required"), ask developer one question, then route
+
+  # Step 2 — prep work dir (feature / fix-flow / debugger routes only)
   bash agents/dark-factory/scripts/prep-feature-dir.sh <taskName>
   capture WORK_DIR from stdout
   if fail: report error, STOP
 
-  # Step 2 — classify and route
+  # Step 3 — delegate to worker
   cd WORK_DIR
-  classify taskDescription:
-    - feature keywords ("add", "build", "create", "implement") → feature-agent
-    - bug keywords ("bug", "crash", "error", "fix", "broken") → debugger-agent
-    - flow keywords ("broken flow", "integration failing", "pipeline") → fix-flow-orchestrator
-    - ambiguous → PushNotification, ask developer one question, then route
+  invoke classified worker agent with taskDescription
   if worker errors: cleanup(WORK_DIR), STOP
+  planFilePath = path worker wrote its plan to (null if debugger-agent)
 
-  # Step 3 — code review
-  code-review-orchestrator-agent(planFilePath, WORK_DIR)
+  # Step 4 — code review
+  code-review-orchestrator-agent(planFilePath ?? "Task: <taskDescription>", WORK_DIR)
   if error: cleanup(WORK_DIR), STOP
 
-  # Step 4 — update docs (must complete before PR)
+  # Step 5 — update docs (must complete before PR)
   update-documentation-agent(planFilePath)
 
-  # Step 4c — skill update (non-fatal)
+  # Step 5c — skill update (non-fatal)
   try: skill-update-agent(planFilePath, WORK_DIR, taskDescription)
   catch: warn and continue
 
-  # Step 5 — open PR
+  # Step 6 — open PR
   pr-agent(planFilePath ?? taskDescription)
   if error: cleanup(WORK_DIR), STOP
 
-  # Step 6 — cleanup
-  rm -rf WORK_DIR
+  # Step 7 — cleanup
+  cleanup(WORK_DIR)
   report "Done. PR: <prUrl>. Skills written: <skillsWritten>."
 ```
 

--- a/skills/classification-table-ordering/SKILL.md
+++ b/skills/classification-table-ordering/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: classification-table-ordering
+description: "When adding a route to the dark-factory-agent classification table, place more-specific signal strings before any signal that is a substring of them to prevent false first-match."
+user-invocable: false
+---
+## When to use
+
+Any time a new route (or new signal strings) is added to the `## Classification rules` table in `agents/dark-factory/agents/dark-factory-agent.md`.
+
+## Steps
+
+1. List all signal strings across every row of the classification table.
+2. For every pair of signals, check whether one is a substring of the other (case-insensitive).
+   - Example: "quick fix" contains "fix", so "quick fix" must appear in an earlier row than "fix".
+3. Place the more-specific (longer / more-constrained) signal in a row that precedes the row containing the substring it overlaps with.
+4. Because matching is first-match-wins, the order of rows is the order of evaluation — verify the final table reads top-to-bottom from most-specific to most-general.
+
+## Notes
+
+- The collision does not cause a compile or runtime error; it silently routes the wrong task to the wrong agent. Always audit ordering after edits.
+- If two signals are independent (neither is a substring of the other), their relative order does not matter for correctness, but prefer alphabetical or by-specificity for readability.
+- The repair-agent signals ("small change", "tweak", "rename", "minor update", "quick fix", "adjust", "alter") were placed before "fix"/"bug"/"crash" specifically because "quick fix" contains "fix".

--- a/skills/short-circuit-self-managed-route/SKILL.md
+++ b/skills/short-circuit-self-managed-route/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: short-circuit-self-managed-route
+description: "When a worker agent manages its own worktree, PR, and cleanup internally, the orchestrator must invoke it and stop before running prep-feature-dir.sh — not after."
+user-invocable: false
+---
+## When to use
+
+Any time a new route is added to `dark-factory-agent.md` where the target agent is responsible for its own isolation (worktree creation), PR, and cleanup — rather than relying on the orchestrator to do those steps.
+
+## Steps
+
+1. Identify whether the new agent creates its own worktree (calls `prep-feature-dir.sh` internally) and opens its own PR.
+2. If yes, place the route check at the very top of the orchestration block — before the `prep-feature-dir.sh` call in Step 2.
+3. After invoking the self-managed agent, capture `prUrl` from its return value and `STOP` immediately. Do not fall through to the worktree prep, code review, doc update, skill update, or cleanup steps.
+4. The reason: if the orchestrator runs `prep-feature-dir.sh` first, a duplicate worktree will be created. When the self-managed agent also calls `prep-feature-dir.sh` with the same `taskName`, it will collide or fail.
+
+## Notes
+
+- The repair-agent is the canonical example: it calls `prep-feature-dir.sh` itself and returns `{ prUrl }`. The orchestrator's repair route appears before Step 2 and terminates with `STOP` after capturing `prUrl`.
+- Self-managed routes also intentionally skip code review, skill-update-agent, and the full doc cycle. Document these omissions explicitly in the route comment so future readers know the skips are deliberate, not accidental.
+- Agents that do NOT manage their own worktree (feature-agent, debugger-agent, fix-flow-orchestrator) should not be placed before Step 2, because they rely on the orchestrator's worktree and cleanup.


### PR DESCRIPTION
## Description

# Add Repair Agent

## Plan Metadata

- Plan type: `plan`
- Parent plan: N/A
- Depends on: N/A
- Status: `approved`

## System Intent

- What is being built: A new top-level `repair` agent — a lightweight alternative to `dark-factory-agent` that skips the planning phase, skips high-level code review, and skips the full documentation update cycle. It is designed for quick targeted fixes: make the change, run tests, optionally update related docs, open and merge a PR.
- Primary consumer(s): Developers invoking `/dark-factory:repair` directly; potentially other agents that want to trigger a focused repair without full feature orchestration.
- Boundary (black-box scope only): `pr-agent` and `update-documentation-agent` are reused unchanged. The existing `dark-factory-agent` is not modified. The `prep-feature-dir.sh` script is reused unchanged.

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [x] Stage 3 Logs + Deployment approved or skipped

## All Files to Create or Modify

### New Files

| File | Purpose |
|---|---|
| `commands/repair.md` | Slash command entry point |
| `agents/dark-factory/agents/repair-agent.md` | Top-level repair orchestrator |
| `agents/repair/agents/repair-implementation-agent.md` | Lightweight implementation agent |
| `skills/repair/SKILL.md` | User-invocable skill |

### Existing Files to Modify

| File | Change |
|---|---|
| `agents/dark-factory/agents/dark-factory-agent.md` | Add repair-agent as 4th routing option with short-circuit before worktree prep |
| `docs/docs/manufacture.md` | Document repair route |
| `skills/classification-table-ordering/SKILL.md` | New skill |
| `skills/short-circuit-self-managed-route/SKILL.md` | New skill |

## Changes in this PR

- Added `repair-agent` as the first entry in the classification table in `dark-factory-agent.md`, matched by signals: "small change", "tweak", "rename", "minor update", "quick fix", "adjust", "alter"
- The repair route short-circuits before worktree prep since repair-agent manages its own worktree, PR, and cleanup
- Repair route skips code review and skill-update-agent (intentional)
- Documentation updated in `docs/docs/manufacture.md`
- Two new skills written: `classification-table-ordering`, `short-circuit-self-managed-route`

---

🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
