### PR TITLE
feat(skills): add explicit path references for create-mermaid-diagram skill

### DIFF
--- a/agents/debugger/skills/debug/templates/bug-audit-log-template.md
+++ b/agents/debugger/skills/debug/templates/bug-audit-log-template.md
@@ -25,12 +25,16 @@
 
 ## Steps to cause failure
 
+> Use the skill at `skills/create-mermaid-diagram/SKILL.md` to generate this diagram.
+
 ```mermaid
 flowchart LR
 Start --> Stop
 ```
 
 ## System
+
+> Use the skill at `skills/create-mermaid-diagram/SKILL.md` to generate this diagram.
 
 ```mermaid
 flowchart TD

--- a/agents/documentation/skills/documentation/templates/documentation-template.md
+++ b/agents/documentation/skills/documentation/templates/documentation-template.md
@@ -10,7 +10,7 @@
 
 ## Mermaid Diagram
 
-> Use the `create-mermaid-diagram` skill to generate this diagram.
+> Use the skill at `skills/create-mermaid-diagram/SKILL.md` to generate this diagram.
 
 ```mermaid
 flowchart TD

--- a/agents/featurework/execution/skills/deviation-protocol/SKILL.md
+++ b/agents/featurework/execution/skills/deviation-protocol/SKILL.md
@@ -25,7 +25,7 @@ You must follow this skill exactly when invoked. Do not write any code from the 
 4. **If course-correct:**
    - Apply the developer's guidance to the plan file:
      - Update the affected flow contracts, pseudocode, or file structure as needed.
-     - If the architecture changed, invoke the `create-mermaid-diagram` skill to update the diagram.
+     - If the architecture changed, invoke the skill at `skills/create-mermaid-diagram/SKILL.md` to update the diagram.
      - Add an entry to the `## Deviations` section at the end of the plan (create the section if it does not exist):
        ```
        - Date: <today>

--- a/agents/featurework/planning/agents/planning-agent.md
+++ b/agents/featurework/planning/agents/planning-agent.md
@@ -32,7 +32,7 @@ Before presenting each stage gate and asking for approval, call PushNotification
 
 | Stage | What to produce | Gate |
 |---|---|---|
-| 1 | Mermaid diagram — use the `create-mermaid-diagram` skill; nodes, boundaries, labeled data flows | User approval required |
+| 1 | Mermaid diagram — invoke the skill at `skills/create-mermaid-diagram/SKILL.md`; nodes, boundaries, labeled data flows | User approval required |
 | 2+ | For each flow identified in the diagram: types (input/output shapes), paths table (happy path + error paths), pseudocode if the flow has non-obvious implementation details | One approval per flow |
 
 ## Scope rule

--- a/agents/featurework/planning/templates/plan-template.md
+++ b/agents/featurework/planning/templates/plan-template.md
@@ -30,7 +30,7 @@ Update rule:
 
 ## Mermaid Diagram
 
-> Use the `create-mermaid-diagram` skill to generate this diagram.
+> Use the skill at `skills/create-mermaid-diagram/SKILL.md` to generate this diagram.
 
 ```mermaid
 graph TD

--- a/docs/docs/agents.md
+++ b/docs/docs/agents.md
@@ -103,7 +103,7 @@ StandardError {
 
 ### Flow: `featurework`
 
-- Core files: `agents/featurework/agents/feature-agent.md`, `agents/featurework/planning/agents/planning-agent.md`, `agents/featurework/execution/agents/execution-agent.md`, `agents/featurework/execution/agents/skeleton-agent.md`, `agents/featurework/execution/agents/testing-agent.md`, `agents/featurework/execution/agents/implementation-agent.md`
+- Core files: `agents/featurework/agents/feature-agent.md`, `agents/featurework/planning/agents/planning-agent.md`, `agents/featurework/planning/templates/plan-template.md`, `agents/featurework/execution/agents/execution-agent.md`, `agents/featurework/execution/agents/skeleton-agent.md`, `agents/featurework/execution/agents/testing-agent.md`, `agents/featurework/execution/agents/implementation-agent.md`, `agents/featurework/execution/skills/deviation-protocol/SKILL.md`, `skills/create-mermaid-diagram/SKILL.md`
 
 #### Types
 
@@ -135,7 +135,7 @@ ReviewDecision {
 | `featurework.approved` | `FeatureInput` | `FeatureOutput` | `happy path` | planning-agent writes plan; feature-agent opens it in VS Code, reads and displays it inline, sends PushNotification, developer replies "yes" or "approve"; execution-agent implements |
 | `featurework.feedbackLoop` | `FeatureInput` | revised plan + PushNotification | `loop` | Developer replies with feedback text; feature-agent re-invokes planning-agent with feedback, re-opens in VS Code, re-displays, re-prompts; loop repeats until explicit approval |
 | `featurework.abort` | `FeatureInput` | `StandardError` | `error` | Developer replies "abort" during plan review; feature-agent stops all work |
-| `featurework.hardStop` | `FeatureInput` | `StandardError` | `error` | implementation-agent triggers deviation-protocol and cannot self-resolve |
+| `featurework.hardStop` | `FeatureInput` | `StandardError` | `error` | implementation-agent triggers deviation-protocol; if architecture changed, deviation-protocol invokes `skills/create-mermaid-diagram/SKILL.md` to update the diagram before halting |
 
 ---
 

--- a/docs/docs/build-feature.md
+++ b/docs/docs/build-feature.md
@@ -35,7 +35,7 @@ flowchart TD
 ### Flow: `planFeature`
 
 - Test files: `tests/`
-- Core files: `agents/featurework/agents/feature-agent.md`, `agents/featurework/planning/agents/planning-agent.md`, `agents/featurework/planning/templates/plan-template.md`
+- Core files: `agents/featurework/agents/feature-agent.md`, `agents/featurework/planning/agents/planning-agent.md`, `agents/featurework/planning/templates/plan-template.md`, `skills/create-mermaid-diagram/SKILL.md`
 
 #### Types
 
@@ -57,7 +57,7 @@ StandardError {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `planFeature.success` | `PlanFeatureInput` | `PlanFeatureOutput` | happy path | planning-agent writes plan, opens it in VSCode, returns planPath |
+| `planFeature.success` | `PlanFeatureInput` | `PlanFeatureOutput` | happy path | planning-agent invokes `skills/create-mermaid-diagram/SKILL.md` to produce the diagram, writes plan, opens it in VSCode, returns planPath |
 | `planFeature.error` | `PlanFeatureInput` | `StandardError` | error | planning-agent fails or returns no planPath |
 
 ### Flow: `approveFeature`
@@ -132,7 +132,7 @@ execution-agent(planPath):
 
   # Stage 3: implementation
   implementation-agent(planPath, tmp/flows-checklist.md)
-  if hardStop: PushNotification, pause, wait for developer, re-run implementation-agent
+  if hardStop: PushNotification, pause, wait for developer (deviation-protocol updates diagram via skills/create-mermaid-diagram/SKILL.md if architecture changed), re-run implementation-agent
   if allFlowsGreen:
     rm tmp/files-checklist.md
     rm tmp/flows-checklist.md

--- a/docs/docs/debug-bug.md
+++ b/docs/docs/debug-bug.md
@@ -35,7 +35,7 @@ flowchart TD
 ### Flow: `debugBug`
 
 - Test files: `tests/`
-- Core files: `agents/debugger/agents/debugger-agent.md`, `agents/debugger/skills/debug/SKILL.md`, `agents/debugger/skills/debug/templates/bug-audit-log-template.md`
+- Core files: `agents/debugger/agents/debugger-agent.md`, `agents/debugger/skills/debug/SKILL.md`, `agents/debugger/skills/debug/templates/bug-audit-log-template.md`, `skills/create-mermaid-diagram/SKILL.md`
 
 #### Types
 
@@ -90,6 +90,8 @@ debugger-agent(bugDescription, scriptPaths?, previousBugFiles?):
 
   # Step 4: fill bug file
   populate bug-audit-log-template fields with gathered context
+  # bug-audit-log-template instructs use of skills/create-mermaid-diagram/SKILL.md for the
+  # "Steps to cause failure" and "System" diagrams
 
   # Step 5: reproduce
   write a failing reproduction test

--- a/docs/docs/update-documentation.md
+++ b/docs/docs/update-documentation.md
@@ -31,7 +31,7 @@ flowchart TD
 
 ### Flow: `updateDocumentation`
 
-- Core files: `agents/documentation/agents/update-documentation-agent.md`, `agents/documentation/skills/documentation/SKILL.md`, `agents/documentation/skills/documentation/templates/documentation-template.md`
+- Core files: `agents/documentation/agents/update-documentation-agent.md`, `agents/documentation/skills/documentation/SKILL.md`, `agents/documentation/skills/documentation/templates/documentation-template.md`, `skills/create-mermaid-diagram/SKILL.md`
 
 #### Types
 
@@ -81,6 +81,7 @@ update-documentation-agent(planPath):
       edit file: delete removed sections, update modified sections, add new sections
     if new flow + plan has enough detail:
       create docs/docs/<flow-name>.md from documentation-template
+      # documentation-template instructs use of skills/create-mermaid-diagram/SKILL.md for diagrams
     if new flow + plan is unrelated:
       copy plan content to docs/docs/<plan-name>.md
     mark item [x]

--- a/skills/reference-skills-by-path/SKILL.md
+++ b/skills/reference-skills-by-path/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: reference-skills-by-path
+description: "Use this skill when writing or updating any agent, template, or skill file that needs to invoke another skill — always use an explicit path reference, never a short name."
+user-invocable: false
+---
+## When to use
+
+Any time you write or edit an agent (`.md` in `agents/`), a template, or a skill file that needs to tell a downstream agent to invoke a skill. This applies equally to new skill references and to updating existing ones.
+
+## Steps
+
+1. Identify every place the text says to "use the X skill" or "invoke the X skill" using only the short slug name.
+2. Replace each short-name reference with the full explicit path form:
+   - Pattern: `invoke the skill at \`skills/<slug>/SKILL.md\``
+   - Example: replace "use the create-mermaid-diagram skill" with "invoke the skill at `skills/create-mermaid-diagram/SKILL.md`"
+3. In agent frontmatter `skills:` declarations, the short slug is still correct (that field is metadata, not an invocation instruction). Do not change frontmatter slugs.
+4. In prose instructions inside agent bodies, templates, and other skill files, always use the full backtick path form.
+5. Verify every affected file contains the full path form before finishing.
+
+## Notes
+
+- Agents resolve skill references at runtime by reading the file at the stated path. A vague short name like "use the create-mermaid-diagram skill" does not give the agent a resolvable location, so the skill is silently skipped.
+- The frontmatter `skills:` field is an exception — it is a metadata declaration consumed by the plugin loader, not a prose instruction to an agent, so short slugs remain correct there.
+- When a new skill is added to `skills/`, audit all agents and templates that logically depend on that skill and ensure they reference it by path, not by name.


### PR DESCRIPTION
## Description

Added explicit path references to `skills/create-mermaid-diagram/SKILL.md` in all templates and agents that produce mermaid diagrams. Agents were previously referencing the skill by short name only, causing them to silently skip it. Also updated 4 doc files and added a new skill `skills/reference-skills-by-path/SKILL.md` capturing the pattern.

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
