### PR TITLE
refactor(repair-agent): unify repair route through full orchestrator flow

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -1,9 +1,9 @@
 ---
 name: dark-factory-agent
 user-invocable: true
-description: Top-level dark-factory orchestrator. Preps an isolated work dir, routes to the right worker agent (feature/debug/fix-flow), runs code review and doc housekeeping, opens a PR, then removes the work dir.
+description: Top-level dark-factory orchestrator. Preps an isolated work dir, routes to the right worker agent (feature/fix-flow/debugger/repair), runs code review and doc housekeeping, opens a PR, then removes the work dir.
 tools: Read, Bash, Agent, PushNotification, AskUserQuestion
-model: sonnet
+model: haiku
 scripts: agents/dark-factory/scripts/prep-feature-dir.sh, agents/dark-factory/scripts/cleanup-worktree.sh
 allowed-tools: Bash(bash agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(bash agents/dark-factory/scripts/cleanup-worktree.sh *), Bash(jq *), Bash(rm -f *), Bash(export *), Bash(python3 scripts/update-metrics.py *)
 ---
@@ -42,17 +42,7 @@ dark-factory-agent(taskDescription, taskName):
   # Step 1 — classify and route
   Classify taskDescription using the Classification rules table below.
 
-  # Repair route: repair-agent manages its own worktree, PR, and cleanup internally.
-  # Do NOT prep a worktree; just invoke repair-agent and stop.
-  If classified as repair (small change, tweak, rename, minor update, quick fix, adjust, alter):
-    result = invoke repair-agent with: taskDescription, taskName
-    If result is error or hard-stop:
-      report error and STOP
-    prUrl = result.prUrl
-    Report: "Done. PR: <prUrl>."
-    STOP
-
-  # Step 2 — prep isolated work dir (feature / fix-flow / debugger routes only)
+  # Step 2 — prep isolated work dir (all routes)
   Run from the project root (git repo):
     bash agents/dark-factory/scripts/prep-feature-dir.sh <taskName>
 
@@ -60,7 +50,7 @@ dark-factory-agent(taskDescription, taskName):
   If script fails: report error and STOP (no cleanup needed — worktree was never created)
 
   # brain.create — write brain.json immediately after WORK_DIR is captured
-  Determine the classification string: one of "feature" | "fix-flow" | "debugger"
+  Determine the classification string: one of "feature" | "fix-flow" | "debugger" | "repair"
   Capture the original git project root (not the worktree):
     PROJECT_DIR = git rev-parse --show-toplevel  (run from CWD before cd-ing into WORK_DIR)
 
@@ -104,6 +94,7 @@ dark-factory-agent(taskDescription, taskName):
     - New feature or capability → invoke feature-agent with taskDescription
     - Broken integration flow / end-to-end failure → invoke fix-flow-orchestrator with taskDescription
     - Bug, crash, or unexpected behavior → invoke debugger-agent with taskDescription
+    - Small change / tweak / rename / quick fix → invoke repair-agent with taskDescription
 
   If worker returns error or hard-stop:
     run cleanup(WORK_DIR)

--- a/agents/dark-factory/agents/repair-agent.md
+++ b/agents/dark-factory/agents/repair-agent.md
@@ -1,92 +1,41 @@
 ---
 name: repair-agent
 user-invocable: false
-description: Lightweight repair orchestrator. Skips planning, code review, and full doc cycle. Makes the change, fixes test breakage, optionally updates related docs, and ships a PR.
-tools: Read, Bash, Agent, PushNotification
+description: Lightweight repair worker. Delegates implementation to repair-implementation-agent and returns. Worktree prep, code review, docs, skills update, PR, and cleanup are all handled by the dark-factory-agent orchestrator.
+tools: Read, Bash, Agent
 model: sonnet
-scripts: agents/dark-factory/scripts/prep-feature-dir.sh
-allowed-tools: Bash(bash agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(git worktree remove *), Bash(git branch -D *)
 ---
 
-You are the repair-agent. Your job is to apply a targeted repair end-to-end: isolate the work in a fresh directory, delegate implementation to repair-implementation-agent, run the docs update if warranted, ship a PR, and clean up. You do not write code or modify files yourself — you delegate entirely.
+You are the repair-agent. Your only job is to apply a targeted repair by delegating to repair-implementation-agent. You do not write code, manage worktrees, open PRs, or run cleanup yourself — the orchestrator handles all of that.
 
 ## Input
 
 You will be invoked with:
 - `taskDescription` — verbatim user request (what to change or fix)
-- `taskName` — short slug for the work dir (e.g. `fix-null-check`); derive from `taskDescription` if omitted (lowercase, hyphens, ≤30 chars)
 
-## Paths to key agents and scripts
+You are already inside the isolated worktree when invoked. Do not call prep-feature-dir.sh.
+
+## Paths to key agents
 
 | Resource | Path |
 |---|---|
-| `prep-feature-dir.sh` | `agents/dark-factory/scripts/prep-feature-dir.sh` |
 | `repair-implementation-agent` | `agents/repair/agents/repair-implementation-agent.md` |
-| `update-documentation-agent` | `agents/documentation/agents/update-documentation-agent.md` |
-| `pr-agent` | `agents/pr/agents/pr-agent.md` |
 
 ## Orchestration
 
 ```
-repair-agent(taskDescription, taskName):
+repair-agent(taskDescription):
 
-  # Step 1 — derive taskName if not provided
-  if taskName not provided:
-    taskName = slugify(taskDescription, maxLen=30)
-    # lowercase, hyphens only, truncated to 30 chars
-
-  # Step 2 — prep isolated work dir
-  Run from the project root (git repo):
-    bash agents/dark-factory/scripts/prep-feature-dir.sh <taskName>
-
-  Capture WORK_DIR from stdout line: WORK_DIR=<value>
-  If script fails: report error and STOP (no cleanup needed — worktree was never created)
-
-  # Step 3 — implement directly (no planning, no routing)
-  cd into WORK_DIR
+  # Step 1 — implement directly (no planning, no routing)
   result = invoke repair-implementation-agent with: taskDescription
 
   If result.success == false:
-    run cleanup(WORK_DIR)
     report result.error.message and STOP
 
-  # Step 4 — optionally update docs
-  If result.significantChange == true:
-    invoke update-documentation-agent with: taskDescription
-    (non-fatal: if it errors, warn and continue)
-
-  # Step 5 — PR
-  invoke pr-agent with: taskDescription
-
-  If pr-agent errors or cannot merge:
-    run cleanup(WORK_DIR)
-    report error and STOP
-
-  prUrl = result from pr-agent
-  merged = true
-
-  # Step 6 — cleanup
-  cleanup(WORK_DIR, taskName)
-
-  Report: "Done. PR: <prUrl>. Merged: <merged>. Worktree <WORK_DIR> removed."
-  Return: { prUrl: prUrl }
-  STOP
-```
-
-## cleanup(WORK_DIR, taskName)
-
-```
-git worktree remove WORK_DIR --force
-git branch -D feature/<taskName>
-
-If either command fails: warn developer but do not halt — this is non-fatal.
+  Return: success
 ```
 
 ## Rules
 
 - Never write, edit, or scaffold code yourself — delegate entirely.
-- Always run cleanup on error before halting, except on prep failure (work dir does not exist yet).
-- cleanup is non-fatal: if git worktree remove or git branch -D fails, warn and continue.
-- Skip code review entirely — this is intentional for repair tasks.
-- Skip skill-update-agent — repair tasks do not produce new skills.
-- Doc update is conditional: only invoke update-documentation-agent when repair-implementation-agent reports significantChange == true.
+- Do not prep a worktree, open a PR, update docs, or run cleanup — the orchestrator does all of this.

--- a/brain.json
+++ b/brain.json
@@ -1,7 +1,7 @@
 {
-  "taskDescription": "Restructure the planning agent into a two-agent system: planning-agent (Haiku orchestrator) and sub-planning-agent (worker). The orchestrator tracks state, displays data to the user, and creates TodoWrite tasks via PreToolUse hook. The worker does all thinking and writing. Phases: draft plan, mermaid diagram (with URL), flows (one at a time).",
-  "taskName": "restructure-planning-agent",
-  "workDir": "/home/lewibs/github/dark_factory/dark_factory-restructure-planning-agent",
+  "taskDescription": "the repair agent should be in the same flow as the other three. the orchestrator decides what type of fix it's doing. update the orchestrator to also use haiku instead since it's not doing anything in-depth.",
+  "taskName": "unify-repair-agent-flow",
+  "workDir": "/home/lewibs/github/dark_factory/dark_factory-unify-repair-agent-flow",
   "projectDir": "/home/lewibs/github/dark_factory/dark_factory",
   "classification": "feature",
   "planFilePath": null,

--- a/docs/docs/agents.md
+++ b/docs/docs/agents.md
@@ -17,17 +17,16 @@
 
 ```mermaid
 flowchart TD
-  User([Developer]) -->|/dark-factory:manufacture| DFA[dark-factory-agent]
-  User -->|/dark-factory:repair| RepA[repair-agent]
-  RepA -->|taskDescription| RepIA[repair-implementation-agent]
-  RepIA -->|success, significantChange| RepA
-  RepA -->|if significantChange| UDA2[update-documentation-agent]
-  RepA -->|taskDescription| PRA2[pr-agent]
+  User([Developer]) -->|/dark-factory:manufacture| DFA[dark-factory-agent\nmodel: haiku]
 
+  DFA -->|repair signals| RepA[repair-agent]
   DFA -->|new feature| FA[feature-agent]
   DFA -->|broken flow| FFO[fix-flow-orchestrator]
   DFA -->|bug / crash| DA[debugger-agent]
   DFA -->|ambiguous| PN[PushNotification → clarify]
+  RepA -->|taskDescription| RepIA[repair-implementation-agent]
+  RepIA -->|success or failure| RepA
+  RepA -->|returns to orchestrator| DFA
 
   FA --> PA[planning-agent\n(Haiku orchestrator)]
   PA -->|phase=draft_plan / mermaid / flows| SPA[sub-planning-agent\n(Sonnet worker)]
@@ -51,7 +50,7 @@ flowchart TD
   RFP --> DFA2[debug-flow-agent]
   DFA2 --> DA
 
-  DFA -->|after worker| CRO[code-review-orchestrator-agent]
+  DFA -->|after any worker| CRO[code-review-orchestrator-agent]
   CRO --> HLR[high-level-review-agent]
   CRO --> LLR[low-level-review-agent]
   CRO --> RA[resolver-agent]
@@ -83,7 +82,7 @@ BrainState {
   taskDescription:  string
   taskName:         string
   workDir:          string   (absolute path to worktree)
-  classification:   string   (one of: feature | fix-flow | debugger)
+  classification:   string   (one of: feature | fix-flow | debugger | repair)
   planFilePath:     string | null  (written by worker via brain-patch.json; null until planning completes)
   bugFiles:         string[] | null
   prUrl:            string | null  (written by pr-agent via brain-patch.json)
@@ -124,6 +123,7 @@ StandardError {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
+| `manufacture.repair` | `TaskInput` | `ManufactureOutput` | `happy path` | Routes to repair-agent; runs code-review, docs, skills, PR, cleanup — same as all other routes |
 | `manufacture.feature` | `TaskInput` | `ManufactureOutput` | `happy path` | Routes to feature-agent; runs code-review, docs, skills, PR, cleanup |
 | `manufacture.fixFlow` | `TaskInput` | `ManufactureOutput` | `happy path` | Routes to fix-flow-orchestrator |
 | `manufacture.debug` | `TaskInput` | `ManufactureOutput` | `happy path` | Routes to debugger-agent; planFilePath is null |
@@ -352,24 +352,19 @@ PROutput {
 
 ### Flow: `repair`
 
-- Core files: `agents/dark-factory/agents/repair-agent.md`, `agents/repair/agents/repair-implementation-agent.md`, `commands/repair.md`
+- Core files: `agents/dark-factory/agents/repair-agent.md`, `agents/repair/agents/repair-implementation-agent.md`
 
 #### Types
 
 ```txt
-RepairInput {
+RepairWorkerInput {
   taskDescription: string (verbatim user request — what to fix or change)
-  taskName: string (optional short slug; derived from taskDescription if omitted)
 }
 
 RepairImplementationOutput {
   success: boolean
   significantChange: boolean  -- true if change touches agents, skills, commands, or public APIs
   error?: StandardError
-}
-
-RepairOrchestrationOutput {
-  prUrl: string
 }
 
 StandardError {
@@ -381,10 +376,8 @@ StandardError {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `repair.success` | `RepairInput` | `RepairOrchestrationOutput` | `happy path` | change applied, tests pass, PR opened and merged by repair-agent; doc update runs only if significantChange=true |
-| `repair.prep-failure` | `RepairInput` | `StandardError` | `error` | prep-feature-dir.sh fails; no cleanup needed |
-| `repair.implementation-failure` | `RepairInput` | `StandardError` | `error` | repair-implementation-agent returns success=false after 5 retries; cleanup runs |
-| `repair.pr-failure` | `RepairInput` | `StandardError` | `error` | pr-agent fails to open PR or returns error; cleanup runs |
+| `repair.success` | `RepairWorkerInput` | `RepairImplementationOutput{success: true}` | `happy path` | change applied, tests pass; repair-agent returns to orchestrator; orchestrator handles code review, docs, skills, PR, cleanup |
+| `repair.implementation-failure` | `RepairWorkerInput` | `StandardError` | `error` | repair-implementation-agent returns success=false after 5 retries; repair-agent reports error; orchestrator runs cleanup |
 
 ---
 

--- a/docs/docs/manufacture.md
+++ b/docs/docs/manufacture.md
@@ -6,29 +6,31 @@
 
 ## System Intent
 
-- What this is: The top-level user-facing orchestration flow. Given a task description, classifies the request and routes to the correct worker agent (repair, feature, debugger, or fix-flow). Repair tasks short-circuit before worktree prep and delegate entirely to `repair-agent`. All other routes create an isolated work directory, run code review, update documentation, update skills, open a PR, and clean up — all without manual intervention.
+- What this is: The top-level user-facing orchestration flow. Given a task description, classifies the request and routes to the correct worker agent (repair, feature, debugger, or fix-flow). All routes — including repair — create an isolated work directory, run code review, update documentation, update skills, open a PR, and clean up without manual intervention.
 
 ## Mermaid Diagram
 
 ```mermaid
 flowchart TD
-  User["User: /dark-factory:manufacture <task>"] --> DarkFactory["dark-factory-agent"]
+  User["User: /dark-factory:manufacture <task>"] --> DarkFactory["dark-factory-agent\n(model: haiku)"]
   DarkFactory --> Classify{Classify task}
-  Classify -->|repair signals| RepairAgent["repair-agent\n(manages own worktree + PR)"]
-  RepairAgent --> Done2["Report: Done. PR: <url>"]
-  Classify -->|new feature| Prep["prep-feature-dir.sh\n(creates isolated WORK_DIR)"]
+  Classify -->|repair signals| Prep["prep-feature-dir.sh\n(creates isolated WORK_DIR)"]
+  Classify -->|new feature| Prep
   Classify -->|bug/crash/fix| Prep
   Classify -->|broken integration flow| Prep
   Classify -->|ambiguous| Push["PushNotification: Clarification Required"]
   Push --> User2["Ask developer one question"]
   Prep --> BrainCreate["Write brain.json\n(export DARK_FACTORY_WORK_DIR)"]
+  BrainCreate --> RepairAgent["repair-agent"]
   BrainCreate --> Feature["feature-agent"]
   BrainCreate --> Debug["debugger-agent"]
   BrainCreate --> FixFlow["fix-flow-orchestrator"]
-  PreHook["pre-tool-use-hook.sh\n(injects brain state + sets *-running)"] -.->|fires before each Agent call| Feature
+  PreHook["pre-tool-use-hook.sh\n(injects brain state + sets *-running)"] -.->|fires before each Agent call| RepairAgent
+  PreHook -.->|fires before each Agent call| Feature
   PreHook -.->|fires before each Agent call| Debug
   PreHook -.->|fires before each Agent call| FixFlow
-  Feature -->|writes brain-patch.json| PostHook["post-tool-use-hook.sh\n(merges patch + sets *-complete)"]
+  RepairAgent -->|writes brain-patch.json| PostHook["post-tool-use-hook.sh\n(merges patch + sets *-complete)"]
+  Feature -->|writes brain-patch.json| PostHook
   Debug -->|writes brain-patch.json| PostHook
   FixFlow -->|writes brain-patch.json| PostHook
   PostHook --> ReadBrain["Read brain.json\n(planFilePath, prUrl from hooks)"]
@@ -77,13 +79,13 @@ StandardError {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `manufacture.repair` | `ManufactureInput` | `{ prUrl: string }` | happy path | taskDescription signals repair (small change / tweak / rename / minor update / quick fix / adjust / alter); delegates to repair-agent which manages its own worktree and PR; short-circuits before prep |
+| `manufacture.repair` | `ManufactureInput` | `ManufactureOutput` | happy path | taskDescription signals repair (small change / tweak / rename / minor update / quick fix / adjust / alter); preps worktree, delegates to repair-agent, then runs full review, docs, skills, PR, and cleanup — same as all other routes |
 | `manufacture.feature` | `ManufactureInput` | `ManufactureOutput` | happy path | taskDescription signals new feature; routes to feature-agent |
 | `manufacture.debug` | `ManufactureInput` | `ManufactureOutput` | happy path | taskDescription signals bug/crash; routes to debugger-agent |
 | `manufacture.fix-flow` | `ManufactureInput` | `ManufactureOutput` | happy path | taskDescription signals broken integration; routes to fix-flow-orchestrator |
 | `manufacture.ambiguous` | `ManufactureInput` | paused | clarification | agent asks developer one question before routing |
 | `manufacture.worker-error` | `ManufactureInput` | `StandardError` | error | worker agent returns hard-stop; WORK_DIR cleaned up |
-| `manufacture.prep-fail` | `ManufactureInput` | `StandardError` | error | prep-feature-dir.sh fails; no cleanup (work dir never created); does not apply to repair route (no prep is run) |
+| `manufacture.prep-fail` | `ManufactureInput` | `StandardError` | error | prep-feature-dir.sh fails; no cleanup (work dir never created) |
 | `manufacture.metrics-flush` | brain.json with metrics section | metrics.csv upserted at `$PROJECT_DIR/metrics.csv` | happy path | runs before `rm -f brain.json`; non-fatal — `|| true` ensures failure never blocks cleanup |
 | `manufacture.metrics-flush-error` | scripts/update-metrics.py error | error logged to stderr; manufacture continues | error | Non-fatal; metrics failure never blocks a PR or worktree cleanup |
 
@@ -94,18 +96,13 @@ dark-factory-agent(taskDescription, taskName):
 
   # Step 1 — classify and route
   classify taskDescription (first match wins):
-    - repair signals ("small change", "tweak", "rename", "minor update", "quick fix", "adjust", "alter"):
-        result = invoke repair-agent(taskDescription, taskName)
-        if result is error: report error, STOP
-        report "Done. PR: <result.prUrl>."
-        STOP  # repair-agent manages its own worktree, PR, and cleanup — no further steps
-
+    - repair signals ("small change", "tweak", "rename", "minor update", "quick fix", "adjust", "alter") → will route to repair-agent (Step 3)
     - feature keywords ("add", "build", "create", "implement", "new feature") → will route to feature-agent (Step 3)
     - flow keywords ("broken flow", "integration failing", "end-to-end", "pipeline") → will route to fix-flow-orchestrator (Step 3)
     - bug keywords ("bug", "crash", "error", "fix", "broken", "not working", "debug") → will route to debugger-agent (Step 3)
     - ambiguous → PushNotification("Clarification Required"), ask developer one question, then route
 
-  # Step 2 — prep work dir (feature / fix-flow / debugger routes only)
+  # Step 2 — prep work dir (all routes)
   bash agents/dark-factory/scripts/prep-feature-dir.sh <taskName>
   capture WORK_DIR from stdout
   if fail: report error, STOP
@@ -121,7 +118,11 @@ dark-factory-agent(taskDescription, taskName):
 
   # Step 3 — delegate to worker
   cd WORK_DIR
-  invoke classified worker agent with taskDescription
+  invoke classified worker agent with taskDescription:
+    - repair signals → repair-agent(taskDescription)
+    - feature → feature-agent(taskDescription)
+    - fix-flow → fix-flow-orchestrator(taskDescription)
+    - debugger → debugger-agent(taskDescription)
   if worker errors: cleanup(WORK_DIR), STOP
 
   # brain.read-results — read brain.json to get planFilePath (hooks merged it from sub-agent patches)

--- a/docs/docs/repair.md
+++ b/docs/docs/repair.md
@@ -6,46 +6,43 @@
 
 ## System Intent
 
-- What this is: A lightweight repair orchestrator. Given a task description, it creates an isolated work directory, delegates implementation directly to `repair-implementation-agent` (no planning phase), optionally updates documentation for significant changes, opens a PR (pr-agent returns it as ready), merges it, then cleans up. It is designed for quick targeted fixes where the change is already clear and no design phase is needed.
+- What this is: A lightweight repair worker. Given a task description, it delegates implementation directly to `repair-implementation-agent` (no planning phase) and returns. Worktree prep, code review, documentation update, skills update, PR, and cleanup are all handled by the `dark-factory-agent` orchestrator. It is designed for quick targeted fixes where the change is already clear and no design phase is needed.
 
 ## Mermaid Diagram
 
 ```mermaid
 flowchart TD
-  User([Developer]) -->|/dark-factory:repair| CMD[commands/repair.md]
-  CMD -->|taskDescription, taskName| RA[repair-agent.md]
-  RA -->|taskName| PREP[prep-feature-dir.sh]
-  PREP -->|WORK_DIR| RA
+  DFA[dark-factory-agent\norchestrator] -->|taskDescription| RA[repair-agent.md]
   RA -->|taskDescription| RIA[repair-implementation-agent.md]
   RIA -->|makes changes| CODE[Codebase Files]
   RIA -->|runs tests| TESTS[Test Suite]
   TESTS -->|pass| RIA
   TESTS -->|fail - fix and retry| RIA
-  RIA -->|success, significantChange| RA
-  RA -->|if significantChange| UDA[update-documentation-agent]
-  UDA --> RA
-  RA -->|taskDescription| PRA[pr-agent]
-  PRA -->|pr_url, status: ready| RA
-  RA -->|cleanup| CLEANUP[rm -rf WORK_DIR]
-  CLEANUP --> Done([Done])
+  RIA -->|success or failure| RA
+  RA -->|returns to orchestrator| DFA
+  DFA --> CRO[code-review-orchestrator-agent]
+  CRO --> UDA[update-documentation-agent]
+  UDA --> SUA[skill-update-agent]
+  SUA --> PRA[pr-agent]
+  PRA --> Cleanup[cleanup-worktree.sh]
+  Cleanup --> Done([Done])
 ```
 
 ## Flows
 
-### Flow: `repairOrchestration`
+### Flow: `repairWorker`
 
-- Core files: `agents/dark-factory/agents/repair-agent.md`, `commands/repair.md`
+- Core files: `agents/dark-factory/agents/repair-agent.md`
 
 #### Types
 
 ```txt
-RepairInput {
+RepairWorkerInput {
   taskDescription: string (verbatim user request — what to fix or change)
-  taskName: string (short slug for the work dir, e.g. "fix-login-bug"; derived if omitted)
 }
 
-RepairOrchestrationOutput {
-  prUrl: string
+RepairWorkerOutput {
+  success: boolean
 }
 
 StandardError {
@@ -57,51 +54,24 @@ StandardError {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `repairOrchestration.success` | `RepairInput` | `RepairOrchestrationOutput` | `happy path` | change applied, tests pass, PR opened (pr-agent returns ready), repair-agent merges |
-| `repairOrchestration.prep-failure` | `RepairInput` | `StandardError` | `error` | prep-feature-dir.sh fails; no cleanup needed (work dir never created) |
-| `repairOrchestration.implementation-failure` | `RepairInput` | `StandardError` | `error` | repair-implementation-agent returns success=false; cleanup runs before halt |
-| `repairOrchestration.pr-failure` | `RepairInput` | `StandardError` | `error` | pr-agent fails to open PR or returns error; cleanup runs before halt |
+| `repairWorker.success` | `RepairWorkerInput` | `RepairWorkerOutput{success: true}` | `happy path` | change applied, tests pass; orchestrator continues to code review, docs, PR, cleanup |
+| `repairWorker.implementation-failure` | `RepairWorkerInput` | `StandardError` | `error` | repair-implementation-agent returns success=false; repair-agent reports error; orchestrator runs cleanup |
 
 #### Pseudocode
 
 ```
-repair-agent(taskDescription, taskName):
+repair-agent(taskDescription):
 
-  # Step 1 — derive taskName if not provided
-  if taskName not provided:
-    taskName = slugify(taskDescription, maxLen=30)
+  # Already inside the isolated worktree when invoked — no prep needed.
 
-  # Step 2 — prep isolated work dir
-  Run from the outer wrapper (dark_factory/):
-    bash agents/dark-factory/scripts/prep-feature-dir.sh <taskName>
-  Capture WORK_DIR from stdout line: WORK_DIR=<value>
-  If script fails: report error and STOP (no cleanup needed)
-
-  # Step 3 — implement directly (no planning, no routing)
-  cd into WORK_DIR
+  # Step 1 — implement directly (no planning, no routing)
   result = invoke repair-implementation-agent with: taskDescription
+
   If result.success == false:
-    run cleanup(WORK_DIR)
     report result.error.message and STOP
 
-  # Step 4 — optionally update docs
-  If result.significantChange == true:
-    invoke update-documentation-agent with: taskDescription
-    (non-fatal: if it errors, warn and continue)
-
-  # Step 5 — PR
-  invoke pr-agent with: taskDescription
-  // pr-agent returns { pr_url, status: "ready" } — caller is responsible for merge
-  If pr-agent errors:
-    run cleanup(WORK_DIR)
-    report error and STOP
-  prUrl = result.pr_url
-  merge PR (squash-merge and delete branch)
-
-  # Step 6 — cleanup
-  cleanup(WORK_DIR)
-  Report: "Done. PR: <prUrl>. Work dir <WORK_DIR> removed."
-  STOP
+  Return: success
+  # Orchestrator (dark-factory-agent) handles code review, docs, skills, PR, and cleanup.
 ```
 
 ---

--- a/docs/plans/2026-04-27-unify-repair-agent-flow.md
+++ b/docs/plans/2026-04-27-unify-repair-agent-flow.md
@@ -1,0 +1,147 @@
+# Unify Repair Agent into the Full Orchestrator Flow
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: N/A
+- Depends on: N/A
+- Status: `draft`
+
+## System Intent
+
+- What is being built: Removing the early-exit repair shortcut in `dark-factory-agent.md` so that `repair-agent` goes through the same full orchestration flow (worktree, brain.json, code review, docs, skills update, PR) as `feature-agent`, `fix-flow-orchestrator`, and `debugger-agent`. Also changing the orchestrator model from `sonnet` to `haiku` since it only does routing/delegation.
+- Primary consumer(s): `dark-factory-agent` (orchestrator), developers invoking dark-factory for repair-type tasks
+- Boundary (black-box scope only): `agents/dark-factory/agents/dark-factory-agent.md` and `agents/dark-factory/agents/repair-agent.md` are modified. No changes to scripts or any other agents.
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 Flows approved
+- [ ] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+    In[taskDescription + taskName]:::unchanged --> Classify[Step 1: Classify]:::updated
+    Classify -->|feature| PrepDir[Step 2: prep-feature-dir.sh]:::unchanged
+    Classify -->|fix-flow| PrepDir
+    Classify -->|debugger| PrepDir
+    Classify -->|repair| PrepDir
+    PrepDir --> WriteBrain[Write brain.json]:::unchanged
+    WriteBrain --> Route[Step 3: Route to Worker]:::updated
+    Route -->|feature| FA[feature-agent]:::unchanged
+    Route -->|fix-flow| FF[fix-flow-orchestrator]:::unchanged
+    Route -->|debugger| DA[debugger-agent]:::unchanged
+    Route -->|repair| RA[repair-agent]:::created
+    FA --> Review[Step 4: code-review-orchestrator-agent]:::unchanged
+    FF --> Review
+    DA --> Review
+    RA --> Review
+    Review --> Docs[Step 5: update-documentation-agent]:::unchanged
+    Docs --> Skills[Step 5c: skill-update-agent]:::unchanged
+    Skills --> PR[Step 6: pr-agent]:::unchanged
+    PR --> Cleanup[Step 7: cleanup + metrics]:::unchanged
+    Cleanup --> Done[Done. PR: prUrl]:::unchanged
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef updated fill:#ffd580,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+### Flow: `unifyRepairAgentFlow`
+
+- Test files: N/A (agent instruction file, no automated tests)
+- Core files: `agents/dark-factory/agents/dark-factory-agent.md`
+
+#### Types
+
+```txt
+OrchestratorInput {
+  taskDescription: string (required)
+  taskName: string (optional, derived if absent)
+}
+
+Classification {
+  type: "feature" | "fix-flow" | "debugger" | "repair"
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `unifyRepairAgentFlow.repair-via-full-flow` | `OrchestratorInput` with repair signals | Full flow output (PR URL) | `happy path` | repair-agent now gets worktree, brain.json, review, docs, skills, PR | yes |
+| `unifyRepairAgentFlow.feature` | `OrchestratorInput` with feature signals | Full flow output (PR URL) | `happy path` | unchanged | no |
+| `unifyRepairAgentFlow.fix-flow` | `OrchestratorInput` with fix-flow signals | Full flow output (PR URL) | `happy path` | unchanged | no |
+| `unifyRepairAgentFlow.debugger` | `OrchestratorInput` with debug signals | Full flow output (PR URL) | `happy path` | unchanged | no |
+
+#### Pseudocode
+
+```
+dark-factory-agent(taskDescription, taskName):
+
+  # Step 1 — classify
+  classification = classify(taskDescription)
+  # Routes: "feature" | "fix-flow" | "debugger" | "repair"
+  # NO early-exit for repair — fall through to prep
+
+  # Step 2 — prep isolated work dir (all routes)
+  run prep-feature-dir.sh <taskName>
+  capture WORK_DIR
+  write brain.json with classification = <classification>
+  export DARK_FACTORY_WORK_DIR
+
+  # Step 3 — route to worker
+  if classification == "feature":     invoke feature-agent(taskDescription)
+  if classification == "fix-flow":    invoke fix-flow-orchestrator(taskDescription)
+  if classification == "debugger":    invoke debugger-agent(taskDescription)
+  if classification == "repair":      invoke repair-agent(taskDescription)   # NEW — full flow
+
+  # Steps 4–7 unchanged: review, docs, skills, PR, cleanup
+```
+
+#### Changes to dark-factory-agent.md
+
+1. **YAML frontmatter**: `model: sonnet` → `model: haiku`
+2. **Remove** the early-exit repair block (lines 45–53 in the current file):
+   ```
+   # Repair route: repair-agent manages its own worktree...
+   If classified as repair ...:
+     result = invoke repair-agent ...
+     ...
+     STOP
+   ```
+3. **Step 2 comment**: Change "feature / fix-flow / debugger routes only" → "all routes"
+4. **brain.json `classification` field**: Change `"feature" | "fix-flow" | "debugger"` → `"feature" | "fix-flow" | "debugger" | "repair"`
+5. **Step 3 routing table**: Add fourth route: `Small change / tweak / rename / quick fix → invoke repair-agent with taskDescription`
+6. **Classification rules table**: The repair row already exists and maps to `repair-agent` — no change needed to the table itself; the early-exit block removal is what unifies the flow.
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| N/A | N/A — agent instruction file only |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment needed — editing a markdown agent instruction file
+  ```
+- Notes: Changes take effect immediately when dark-factory-agent is next invoked.
+
+## Handoff to Related Plan Reconciliation
+
+After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans.

--- a/skills/short-circuit-self-managed-route/SKILL.md
+++ b/skills/short-circuit-self-managed-route/SKILL.md
@@ -16,6 +16,17 @@ Any time a new route is added to `dark-factory-agent.md` where the target agent 
 
 ## Notes
 
-- The repair-agent is the canonical example: it calls `prep-feature-dir.sh` itself and returns `{ prUrl }`. The orchestrator's repair route appears before Step 2 and terminates with `STOP` after capturing `prUrl`.
 - Self-managed routes also intentionally skip code review, skill-update-agent, and the full doc cycle. Document these omissions explicitly in the route comment so future readers know the skips are deliberate, not accidental.
-- Agents that do NOT manage their own worktree (feature-agent, debugger-agent, fix-flow-orchestrator) should not be placed before Step 2, because they rely on the orchestrator's worktree and cleanup.
+- Agents that do NOT manage their own worktree (feature-agent, debugger-agent, fix-flow-orchestrator, repair-agent) should not be placed before Step 2, because they rely on the orchestrator's worktree and cleanup.
+- **Historical note:** repair-agent was previously a self-managed route (called `prep-feature-dir.sh` internally and short-circuited the orchestrator). It was unified into the full orchestrator flow in April 2026. The repair-agent is no longer a self-managed route — it is invoked in Step 3 like any other worker and relies on the orchestrator for worktree, review, docs, skills, PR, and cleanup.
+
+## Inverse: unifying a self-managed route back into the orchestrator
+
+When an agent that previously used the early-exit pattern is folded back into the full orchestrator flow, reverse all of the steps above:
+
+1. Remove the early-exit block from the orchestrator (the block that appears before Step 2 and ends with `STOP`).
+2. Add the route to the Step 3 routing table (alongside other workers).
+3. Update the brain.json `classification` field comment to include the new classification value.
+4. Update the worker agent's description (frontmatter and prose) to clarify that it no longer manages its own worktree, PR, or cleanup — the orchestrator does.
+5. Remove any `prep-feature-dir.sh` call and PR/cleanup logic from the worker agent itself.
+6. Verify the worker agent's `tools:` list does not include tools it no longer needs (e.g. if it previously used `Bash` only for `prep-feature-dir.sh` and cleanup scripts, those can be removed if no other Bash usage remains).


### PR DESCRIPTION
## Description

# Unify Repair Agent into the Full Orchestrator Flow

## Plan Metadata

- Plan type: `plan`
- Parent plan: N/A
- Depends on: N/A
- Status: `draft`

## System Intent

- What is being built: Removing the early-exit repair shortcut in `dark-factory-agent.md` so that `repair-agent` goes through the same full orchestration flow (worktree, brain.json, code review, docs, skills update, PR) as `feature-agent`, `fix-flow-orchestrator`, and `debugger-agent`. Also changing the orchestrator model from `sonnet` to `haiku` since it only does routing/delegation.
- Primary consumer(s): `dark-factory-agent` (orchestrator), developers invoking dark-factory for repair-type tasks
- Boundary (black-box scope only): `agents/dark-factory/agents/dark-factory-agent.md` and `agents/dark-factory/agents/repair-agent.md` are modified. No changes to scripts or any other agents.

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [ ] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

```mermaid
graph TD
    In[taskDescription + taskName]:::unchanged --> Classify[Step 1: Classify]:::updated
    Classify -->|feature| PrepDir[Step 2: prep-feature-dir.sh]:::unchanged
    Classify -->|fix-flow| PrepDir
    Classify -->|debugger| PrepDir
    Classify -->|repair| PrepDir
    PrepDir --> WriteBrain[Write brain.json]:::unchanged
    WriteBrain --> Route[Step 3: Route to Worker]:::updated
    Route -->|feature| FA[feature-agent]:::unchanged
    Route -->|fix-flow| FF[fix-flow-orchestrator]:::unchanged
    Route -->|debugger| DA[debugger-agent]:::unchanged
    Route -->|repair| RA[repair-agent]:::created
    FA --> Review[Step 4: code-review-orchestrator-agent]:::unchanged
    FF --> Review
    DA --> Review
    RA --> Review
    Review --> Docs[Step 5: update-documentation-agent]:::unchanged
    Docs --> Skills[Step 5c: skill-update-agent]:::unchanged
    Skills --> PR[Step 6: pr-agent]:::unchanged
    PR --> Cleanup[Step 7: cleanup + metrics]:::unchanged
    Cleanup --> Done[Done. PR: prUrl]:::unchanged

classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
classDef updated fill:#ffd580,stroke:#666,stroke-width:1px;
classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
```

## Flows

### Global Types

```txt
StandardError {
  message: string (human-readable description of what went wrong)
}
```

### Flow: `unifyRepairAgentFlow`

- Test files: N/A (agent instruction file, no automated tests)
- Core files: `agents/dark-factory/agents/dark-factory-agent.md`

#### Types

```txt
OrchestratorInput {
  taskDescription: string (required)
  taskName: string (optional, derived if absent)
}

Classification {
  type: "feature" | "fix-flow" | "debugger" | "repair"
}
```

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `unifyRepairAgentFlow.repair-via-full-flow` | `OrchestratorInput` with repair signals | Full flow output (PR URL) | `happy path` | repair-agent now gets worktree, brain.json, review, docs, skills, PR | yes |
| `unifyRepairAgentFlow.feature` | `OrchestratorInput` with feature signals | Full flow output (PR URL) | `happy path` | unchanged | no |
| `unifyRepairAgentFlow.fix-flow` | `OrchestratorInput` with fix-flow signals | Full flow output (PR URL) | `happy path` | unchanged | no |
| `unifyRepairAgentFlow.debugger` | `OrchestratorInput` with debug signals | Full flow output (PR URL) | `happy path` | unchanged | no |

#### Pseudocode

```
dark-factory-agent(taskDescription, taskName):

  # Step 1 — classify
  classification = classify(taskDescription)
  # Routes: "feature" | "fix-flow" | "debugger" | "repair"
  # NO early-exit for repair — fall through to prep

  # Step 2 — prep isolated work dir (all routes)
  run prep-feature-dir.sh <taskName>
  capture WORK_DIR
  write brain.json with classification = <classification>
  export DARK_FACTORY_WORK_DIR

  # Step 3 — route to worker
  if classification == "feature":     invoke feature-agent(taskDescription)
  if classification == "fix-flow":    invoke fix-flow-orchestrator(taskDescription)
  if classification == "debugger":    invoke debugger-agent(taskDescription)
  if classification == "repair":      invoke repair-agent(taskDescription)   # NEW — full flow

  # Steps 4–7 unchanged: review, docs, skills, PR, cleanup
```

#### Changes to dark-factory-agent.md

1. **YAML frontmatter**: `model: sonnet` → `model: haiku`
2. **Remove** the early-exit repair block (lines 45–53 in the current file):
   ```
   # Repair route: repair-agent manages its own worktree...
   If classified as repair ...:
     result = invoke repair-agent ...
     ...
     STOP
   ```
3. **Step 2 comment**: Change "feature / fix-flow / debugger routes only" → "all routes"
4. **brain.json `classification` field**: Change `"feature" | "fix-flow" | "debugger"` → `"feature" | "fix-flow" | "debugger" | "repair"`
5. **Step 3 routing table**: Add fourth route: `Small change / tweak / rename / quick fix → invoke repair-agent with taskDescription`
6. **Classification rules table**: The repair row already exists and maps to `repair-agent` — no change needed to the table itself; the early-exit block removal is what unifies the flow.

## Logs

| Source | Location |
|--------|----------|
| N/A | N/A — agent instruction file only |

## Deployment

- Mechanism: `local only`
- Deploy command:
  ```bash
  # No deployment needed — editing a markdown agent instruction file
  ```
- Notes: Changes take effect immediately when dark-factory-agent is next invoked.

## Handoff to Related Plan Reconciliation

After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans.

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
