### PR TITLE
chore(agents): switch 6 orchestrator agents from sonnet to haiku

### DIFF
--- a/agents/code-review/agents/code-review-orchestrator-agent.md
+++ b/agents/code-review/agents/code-review-orchestrator-agent.md
@@ -3,7 +3,7 @@ name: code-review-orchestrator-agent
 user-invocable: false
 description: Orchestrates automated code review by spawning high-level and low-level reviewers in parallel, then running the resolver in a loop until all issues are resolved.
 tools: Read, Write, Edit, Bash, Agent
-model: sonnet
+model: haiku
 allowed-tools:
   - Bash(cat > tmp/issues.md)
   - Bash(rm tmp/issues.md)

--- a/agents/featurework/agents/feature-agent.md
+++ b/agents/featurework/agents/feature-agent.md
@@ -3,7 +3,7 @@ name: feature-agent
 user-invocable: false
 description: End-to-end feature orchestrator. Calls planning-agent for each phase (draft, mermaid, flows), gates on human approval between phases via AskUserQuestion, then calls execution-agent. The approval gate lives here — neither planning-agent nor execution-agent are modified.
 tools: Read, Write, Bash, Agent, PushNotification, AskUserQuestion, Skill
-model: sonnet
+model: haiku
 allowed-tools: Bash(find *), Bash(grep -r *)
 ---
 

--- a/agents/featurework/execution/agents/execution-agent.md
+++ b/agents/featurework/execution/agents/execution-agent.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Orchestrates end-to-end execution of an approved plan file. Spawns skeleton-agent, testing-agent, and implementation-agent in sequence. Enters planning mode if a hard-stop deviation is triggered.
 tools: Read, Write, Edit, Bash, Agent, PushNotification, AskUserQuestion
 allowed-tools: Bash(rm tmp/files-checklist.md), Bash(rm tmp/flows-checklist.md)
-model: sonnet
+model: haiku
 ---
 
 You are the execution-agent. Your job is to take an approved plan file and execute it end-to-end by spawning three agents in strict sequence. You do not write code yourself.

--- a/agents/fix-flow/agents/fix-flow-orchestrator.md
+++ b/agents/fix-flow/agents/fix-flow-orchestrator.md
@@ -3,7 +3,7 @@ name: fix-flow-orchestrator
 user-invocable: false
 description: "Autonomously drives a failing integration flow to green. Generates test/log/deploy scripts, then loops: trigger, debug, PR, deploy until the flow passes."
 tools: Read, Bash, PushNotification, AskUserQuestion
-model: sonnet
+model: haiku
 allowed-tools: "Bash(find *), Bash(grep -r *)"
 ---
 

--- a/agents/fix-flow/agents/ralph-fix-and-push.md
+++ b/agents/fix-flow/agents/ralph-fix-and-push.md
@@ -2,7 +2,7 @@
 name: ralph-fix-and-push
 description: Owns the bug-fixing loop for fix-flow-orchestrator. Spawns debugger-agent and pr-agent repeatedly until the integration flow passes green. Use after setup-wizard has generated the scripts.
 tools: Read, Bash, Agent, PushNotification, AskUserQuestion
-model: sonnet
+model: haiku
 user-invocable: false
 allowed-tools: Bash(bash *), Bash(find *)
 ---

--- a/agents/initialization/agents/init-orchestrator-agent.md
+++ b/agents/initialization/agents/init-orchestrator-agent.md
@@ -3,7 +3,7 @@ name: init-orchestrator-agent
 user-invocable: true
 description: 'Sets up a project to use dark factory. Generates docs/docs/ files and a minimal CLAUDE.md via init-docs-agent, then opens a PR titled "init: dark factory".'
 tools: Bash, Agent
-model: sonnet
+model: haiku
 allowed-tools: "Bash(git clone *), Bash(jq *), Bash(find *)"
 ---
 

--- a/brain.json
+++ b/brain.json
@@ -1,9 +1,9 @@
 {
-  "taskDescription": "there seems to be an issue with planning. whenever I call manufacture the top agent is accepting the plans and I the user never see the mermaid diagram or the flows. this is incorrect and needs to be fixed. I the user need to be part of the planning cycle 100% of the time",
-  "taskName": "fix-planning-approval-gate",
-  "workDir": "/home/lewibs/github/dark_factory/dark_factory-fix-planning-approval-gate",
+  "taskDescription": "update all the orchestrator agents to use haiku instead of a more expensive model. an orchestrator ideally don't make significant decisions.",
+  "taskName": "orchestrators-to-haiku",
+  "workDir": "/home/lewibs/github/dark_factory/dark_factory-orchestrators-to-haiku",
   "projectDir": "/home/lewibs/github/dark_factory/dark_factory",
-  "classification": "debugger",
+  "classification": "feature",
   "planFilePath": null,
   "bugFiles": null,
   "prUrl": null,

--- a/docs/docs/agents.md
+++ b/docs/docs/agents.md
@@ -471,9 +471,49 @@ Every agent file has a YAML front-matter block:
 | `user-invocable` | Whether the agent can be invoked directly by the developer |
 | `description` | One-line summary shown in Claude Code |
 | `tools` | Comma-separated list of Claude tools the agent may use |
-| `model` | Model to use (typically `sonnet`) |
+| `model` | Model to use (`haiku` for pure orchestrators, `sonnet` for workers) |
 | `skills` | Skill files the agent references |
 | `allowed-tools` | Fine-grained bash command allowlist |
 | `scripts` | Shell scripts the agent is permitted to run |
+
+### Model Assignment
+
+Agents are split into two tiers based on whether they perform deep reasoning:
+
+**Orchestrators — `model: haiku`** (route, sequence, and delegate; no code/plan/doc writing):
+
+| Agent | Role |
+|---|---|
+| `dark-factory-agent` | Classifies task, preps work dir, routes to worker, coordinates cleanup |
+| `planning-agent` | Pure phase-delegator; spawns sub-planning-agent per phase |
+| `feature-agent` | Drives phase-by-phase planning gate; calls planning-agent and execution-agent |
+| `execution-agent` | Sequences skeleton → testing → implementation agents; gate-checks checklists |
+| `code-review-orchestrator-agent` | Creates issues.md, spawns parallel reviewers, runs resolver loop |
+| `fix-flow-orchestrator` | Sequences investigation → setup-wizard → ralph-fix-and-push; no debugging |
+| `ralph-fix-and-push` | Loops: debugger-agent → pr-agent → deploy; no debugging or PR work itself |
+| `init-orchestrator-agent` | Clones repo, sets bypassPermissions, delegates to init-docs-agent and pr-agent |
+
+**Workers — `model: sonnet`** (write code, plans, docs, tests, or perform deep reasoning/debugging/review):
+
+| Agent | Role |
+|---|---|
+| `sub-planning-agent` | Researches codebase, writes plan files, runs mermaid scripts |
+| `skeleton-agent` | Reads plan, builds files checklist, creates skeleton files |
+| `testing-agent` | Reads plan, builds flows checklist, writes failing tests |
+| `implementation-agent` | Implements each flow from checklist, runs tests, invokes deviation-protocol |
+| `high-level-review-agent` | Reviews code against plan for structural/architectural conformance |
+| `low-level-review-agent` | Reviews code at function level for bugs, untested paths, conflicts |
+| `resolver-agent` | Reads issues, applies fixes, checks them off |
+| `debugger-agent` | Systematic debugging following debug skill checklist |
+| `detect-drift-agent` | Audits parity between docs and code, fixes drift in place |
+| `investigation-agent` | Explores codebase, validates/creates authoritative docs |
+| `update-documentation-agent` | Identifies affected flows/docs, updates/adds sections |
+| `debug-flow-agent` | Runs integration flow, waits, fetches logs, hands off to debugger-agent |
+| `setup-wizard` | Reads system document, generates trigger/wait/fetch-logs/deploy scripts |
+| `init-docs-agent` | Discovers systems, discovers flows per system, writes docs and CLAUDE.md |
+| `pr-agent` | Manages full PR lifecycle: build body, open PR, CI watch loop, comment resolution |
+| `resolve-pr-issue` | Resolves single PR issue (CI failure or review thread) |
+| `repair-agent` | Applies targeted changes, runs test suite, iteratively fixes failures |
+| `skill-update-agent` | Reviews completed work, identifies patterns, writes/updates skill files |
 
 Agents that call `PushNotification` in their body must declare it in `tools:` — the Claude Code runtime silently skips notifications for agents missing this declaration (see `docs/bugs/2026-04-25-push-notification-missing-from-tools.md`).

--- a/docs/plans/2026-04-27-orchestrators-to-haiku.md
+++ b/docs/plans/2026-04-27-orchestrators-to-haiku.md
@@ -1,0 +1,290 @@
+# Orchestrators to Haiku
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: N/A
+- Depends on: N/A
+- Status: `draft`
+
+## System Intent
+
+- **What is being built:** A cost-reduction change that switches all pure orchestrator agents from `model: sonnet` to `model: haiku`. Orchestrators that only classify input, call sub-agents, read results, and route — without doing deep reasoning, writing code, plans, or docs — are converted to haiku. Worker agents that write plans, implement code, debug, review, or write docs remain on sonnet.
+- **Primary consumer(s):** dark-factory-agent and all callers that invoke the manufacture workflow.
+- **Boundary (black-box scope only):** Only `model:` field changes in agent `.md` front-matter files. No logic, instructions, or tooling changes.
+
+## Agent Audit
+
+### Classification Table
+
+| Agent | File | Current Model | Classification | Justification | Action |
+|---|---|---|---|---|---|
+| `dark-factory-agent` | `agents/dark-factory/agents/dark-factory-agent.md` | haiku | Orchestrator | Classifies input, preps work dir, routes to worker, reads brain.json results, coordinates cleanup. No deep reasoning. | Already haiku — no change |
+| `feature-agent` | `agents/featurework/agents/feature-agent.md` | sonnet | Orchestrator | Drives phase-by-phase planning gate; calls planning-agent per phase, presents sections to user, then calls execution-agent. Does not write plans or code. Uses AskUserQuestion for user interaction only. | **Switch to haiku** |
+| `planning-agent` | `agents/featurework/planning/agents/planning-agent.md` | haiku | Orchestrator | Pure phase-delegator. Receives phase + context, spawns sub-planning-agent, returns structured output. No reasoning. | Already haiku — no change |
+| `sub-planning-agent` | `agents/featurework/planning/agents/sub-planning-agent.md` | sonnet | Worker | Researches codebase, writes plan files, runs mermaid scripts. Heavy reasoning and writing. | Keep sonnet |
+| `execution-agent` | `agents/featurework/execution/agents/execution-agent.md` | sonnet | Orchestrator | Sequences skeleton → testing → implementation agents in strict order; gate-checks checklists; enters planning mode on hard-stop. No code writing. | **Switch to haiku** |
+| `skeleton-agent` | `agents/featurework/execution/agents/skeleton-agent.md` | sonnet | Worker | Reads plan, builds files checklist, creates skeleton files. Does actual file creation and reasoning. | Keep sonnet |
+| `testing-agent` | `agents/featurework/execution/agents/testing-agent.md` | sonnet | Worker | Reads plan, builds flows checklist, writes failing tests. Does actual test writing. | Keep sonnet |
+| `implementation-agent` | `agents/featurework/execution/agents/implementation-agent.md` | sonnet | Worker | Implements each flow from checklist, runs tests, invokes deviation-protocol. Heavy implementation work. | Keep sonnet |
+| `code-review-orchestrator-agent` | `agents/code-review/agents/code-review-orchestrator-agent.md` | sonnet | Orchestrator | Creates issues.md, spawns parallel reviewers, runs resolver loop until clean. No review reasoning itself. | **Switch to haiku** |
+| `high-level-review-agent` | `agents/code-review/agents/high-level-review-agent.md` | sonnet | Worker | Reviews code against plan for structural/architectural conformance. Deep reasoning required. | Keep sonnet |
+| `low-level-review-agent` | `agents/code-review/agents/low-level-review-agent.md` | sonnet | Worker | Reviews code at function level for bugs, untested paths, conflicts. Deep reasoning required. | Keep sonnet |
+| `resolver-agent` | `agents/code-review/agents/resolver-agent.md` | sonnet | Worker | Reads issues, applies fixes, checks them off. Does actual code editing and reasoning. | Keep sonnet |
+| `debugger-agent` | `agents/debugger/agents/debugger-agent.md` | sonnet | Worker | Systematic debugging following debug skill checklist. Heavy reasoning and investigation. | Keep sonnet |
+| `detect-drift-agent` | `agents/documentation/agents/detect-drift-agent.md` | sonnet | Worker | Audits parity between docs and code, fixes drift in place. Deep analysis required. | Keep sonnet |
+| `investigation-agent` | `agents/documentation/agents/investigation-agent.md` | sonnet | Worker | Explores codebase, validates/creates authoritative docs. Heavy research and writing. | Keep sonnet |
+| `update-documentation-agent` | `agents/documentation/agents/update-documentation-agent.md` | sonnet | Worker | Identifies affected flows/docs, deletes stale content, updates/adds sections. Complex writing. | Keep sonnet |
+| `fix-flow-orchestrator` | `agents/fix-flow/agents/fix-flow-orchestrator.md` | sonnet | Orchestrator | Runs 3 phases in strict sequence: spawns investigation-agent, setup-wizard, ralph-fix-and-push. Routing and sequencing only. Handles required-argument clarification via AskUserQuestion. | **Switch to haiku** |
+| `debug-flow-agent` | `agents/fix-flow/agents/debug-flow-agent.md` | sonnet | Worker | Runs integration flow, waits, fetches logs, hands off to debugger-agent. Complex coordination and log analysis. Borderline — but reads and interprets logs. | Keep sonnet |
+| `ralph-fix-and-push` | `agents/fix-flow/agents/ralph-fix-and-push.md` | sonnet | Orchestrator | Loops: trigger flow → spawn debugger-agent → spawn pr-agent → deploy. Sequencing and loop management; no debugging or PRs itself. Handles stuck-loop user interaction. | **Switch to haiku** |
+| `setup-wizard` | `agents/fix-flow/agents/setup-wizard.md` | sonnet | Worker | Reads system document, generates trigger.sh, wait-for-completion.sh, fetch-logs.sh, deploy.sh. Actual script writing and reasoning. | Keep sonnet |
+| `init-orchestrator-agent` | `agents/initialization/agents/init-orchestrator-agent.md` | sonnet | Orchestrator | Clones repo, sets bypassPermissions, invokes init-docs-agent, invokes pr-agent. Pure delegation with minimal logic. | **Switch to haiku** |
+| `init-docs-agent` | `agents/initialization/agents/init-docs-agent.md` | sonnet | Worker | Discovers systems, discovers flows per system, invokes investigation-agent per flow, writes CLAUDE.md index. Heavy codebase exploration and writing. | Keep sonnet |
+| `pr-agent` | `agents/pr/agents/pr-agent.md` | sonnet | Worker | Manages full PR lifecycle: builds PR body, opens PR, CI watch loop, comment resolution loop, spawns resolve-pr-issue. Complex multi-loop management with real reasoning about CI failures. | Keep sonnet |
+| `resolve-pr-issue` | `agents/pr/agents/resolve-pr-issue.md` | sonnet | Worker | Resolves single PR issue (CI failure or review thread): reads issue, applies fix, pushes, resolves thread. Actual fix implementation. | Keep sonnet |
+| `repair-agent` | `agents/repair/agents/repair-agent.md` | sonnet | Worker | Applies targeted changes, runs test suite, iteratively fixes failures up to 5 times. Actual implementation work. | Keep sonnet |
+| `skill-update-agent` | `agents/skill-update/agents/skill-update-agent.md` | sonnet | Worker | Reviews completed work, identifies patterns, writes/updates skill files. Deep analysis and writing. | Keep sonnet |
+
+### Summary of Changes
+
+**Switch to haiku (5 agents):**
+1. `feature-agent` — orchestrates planning phases and approval gates; no plan writing
+2. `execution-agent` — sequences skeleton/testing/implementation; no code writing
+3. `code-review-orchestrator-agent` — spawns parallel reviewers and loops resolver; no review reasoning
+4. `fix-flow-orchestrator` — sequences 3 phases; no investigation/debugging/fixing
+5. `ralph-fix-and-push` — loops debugger/pr-agent; no debugging or PR work itself
+6. `init-orchestrator-agent` — clones repo, delegates to init-docs-agent and pr-agent; minimal logic
+
+**Already haiku (2 agents):**
+- `dark-factory-agent`
+- `planning-agent`
+
+**Stay sonnet (19 agents):**
+All workers that write code, plans, docs, tests, scripts, or do deep reasoning/debugging/review.
+
+## Stage Gate Tracker
+
+- [ ] Stage 1 Mermaid approved
+- [ ] Stage 2 Flows approved
+- [ ] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  subgraph Orchestrators["Orchestrators — switch to haiku"]
+    DFA["dark-factory-agent<br/>(already haiku)"]
+    FA["feature-agent<br/>sonnet → haiku"]
+    PA["planning-agent<br/>(already haiku)"]
+    EA["execution-agent<br/>sonnet → haiku"]
+    CROA["code-review-orchestrator-agent<br/>sonnet → haiku"]
+    FFO["fix-flow-orchestrator<br/>sonnet → haiku"]
+    RFAP["ralph-fix-and-push<br/>sonnet → haiku"]
+    IOA["init-orchestrator-agent<br/>sonnet → haiku"]
+  end
+
+  subgraph Workers["Workers — stay on sonnet"]
+    SPA["sub-planning-agent"]
+    SKA["skeleton-agent"]
+    TA["testing-agent"]
+    IA["implementation-agent"]
+    HLRA["high-level-review-agent"]
+    LLRA["low-level-review-agent"]
+    RA2["resolver-agent"]
+    DA["debugger-agent"]
+    DDA["detect-drift-agent"]
+    INVA["investigation-agent"]
+    UDA["update-documentation-agent"]
+    DFA2["debug-flow-agent"]
+    SW["setup-wizard"]
+    IDA["init-docs-agent"]
+    PRA["pr-agent"]
+    RPRI["resolve-pr-issue"]
+    REP["repair-agent"]
+    SUA["skill-update-agent"]
+  end
+
+  DFA -->|routes to| FA
+  FA -->|delegates phase| PA
+  PA -->|delegates| SPA
+  FA -->|invokes| EA
+  EA -->|sequences| SKA
+  EA -->|sequences| TA
+  EA -->|sequences| IA
+  DFA -->|invokes| CROA
+  CROA -->|parallel| HLRA
+  CROA -->|parallel| LLRA
+  CROA -->|loops| RA2
+  DFA -->|routes to| FFO
+  FFO -->|phase 1| INVA
+  FFO -->|phase 2| SW
+  FFO -->|phase 3| RFAP
+  RFAP -->|loops| DA
+  RFAP -->|loops| PRA
+  DFA -->|routes to| IOA
+  IOA -->|delegates| IDA
+  IOA -->|delegates| PRA
+
+  classDef haiku fill:#a8e6a3,stroke:#2d7a2d,stroke-width:2px;
+  classDef sonnet fill:#d3d3d3,stroke:#666,stroke-width:1px;
+  classDef already fill:#c8f0c8,stroke:#2d7a2d,stroke-width:1px,stroke-dasharray:4;
+
+  class FA,EA,CROA,FFO,RFAP,IOA haiku;
+  class DFA,PA already;
+  class SPA,SKA,TA,IA,HLRA,LLRA,RA2,DA,DDA,INVA,UDA,DFA2,SW,IDA,PRA,RPRI,REP,SUA sonnet;
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Flows
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+### Flow: `update-feature-agent`
+
+- Test files: N/A (config change only — no logic change)
+- Core files: `agents/featurework/agents/feature-agent.md`
+
+#### Types
+
+```txt
+AgentModelChange {
+  file: string (path to agent .md file)
+  oldModel: "sonnet"
+  newModel: "haiku"
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `update-feature-agent.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` in YAML front-matter | |
+
+#### Pseudocode
+
+```
+Read agents/featurework/agents/feature-agent.md
+Replace `model: sonnet` with `model: haiku` in YAML front-matter
+Write updated file
+```
+
+### Flow: `update-execution-agent`
+
+- Test files: N/A
+- Core files: `agents/featurework/execution/agents/execution-agent.md`
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `update-execution-agent.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` | |
+
+#### Pseudocode
+
+```
+Read agents/featurework/execution/agents/execution-agent.md
+Replace `model: sonnet` with `model: haiku` in YAML front-matter
+Write updated file
+```
+
+### Flow: `update-code-review-orchestrator-agent`
+
+- Test files: N/A
+- Core files: `agents/code-review/agents/code-review-orchestrator-agent.md`
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `update-code-review-orchestrator-agent.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` | |
+
+#### Pseudocode
+
+```
+Read agents/code-review/agents/code-review-orchestrator-agent.md
+Replace `model: sonnet` with `model: haiku` in YAML front-matter
+Write updated file
+```
+
+### Flow: `update-fix-flow-orchestrator`
+
+- Test files: N/A
+- Core files: `agents/fix-flow/agents/fix-flow-orchestrator.md`
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `update-fix-flow-orchestrator.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` | |
+
+#### Pseudocode
+
+```
+Read agents/fix-flow/agents/fix-flow-orchestrator.md
+Replace `model: sonnet` with `model: haiku` in YAML front-matter
+Write updated file
+```
+
+### Flow: `update-ralph-fix-and-push`
+
+- Test files: N/A
+- Core files: `agents/fix-flow/agents/ralph-fix-and-push.md`
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `update-ralph-fix-and-push.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` | |
+
+#### Pseudocode
+
+```
+Read agents/fix-flow/agents/ralph-fix-and-push.md
+Replace `model: sonnet` with `model: haiku` in YAML front-matter
+Write updated file
+```
+
+### Flow: `update-init-orchestrator-agent`
+
+- Test files: N/A
+- Core files: `agents/initialization/agents/init-orchestrator-agent.md`
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `update-init-orchestrator-agent.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` | |
+
+#### Pseudocode
+
+```
+Read agents/initialization/agents/init-orchestrator-agent.md
+Replace `model: sonnet` with `model: haiku` in YAML front-matter
+Write updated file
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Logs
+
+N/A — this is a configuration-only change with no runtime logs.
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command: N/A (changes take effect immediately on next agent invocation)
+- Notes: Model changes are read at agent spawn time. No restart or deploy needed.
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Handoff to Related Plan Reconciliation
+
+No linked plans depend on agent model fields. No reconciliation needed.

--- a/skills/haiku-orchestrator-worker-split/SKILL.md
+++ b/skills/haiku-orchestrator-worker-split/SKILL.md
@@ -9,6 +9,7 @@ Use this pattern when:
 - A single agent is growing expensive because it both reasons heavily AND blocks on user interaction (paying Sonnet tokens for idle wait time).
 - An agent mixes responsibilities: user-facing display/questioning AND heavy codebase research or file writing.
 - You want to preserve an existing agent's external interface (input/output contract) while restructuring its internals.
+- You are auditing an existing multi-agent system to ensure all agents are on the correct model tier (see Auditing Existing Agents below).
 
 The canonical example is `planning-agent` (Haiku orchestrator) + `sub-planning-agent` (Sonnet worker).
 
@@ -61,6 +62,32 @@ The canonical example is `planning-agent` (Haiku orchestrator) + `sub-planning-a
    ```
 
 7. **Worker reads its own artifact on every invocation** — never trust that state from a previous invocation is in memory. The worker always reads the file at `<artifact path>` before modifying it.
+
+## Auditing Existing Agents
+
+When adding new agents or doing a cost-reduction pass, audit all agents in the system using a classification table. For each agent, answer:
+
+| Question | Orchestrator (haiku) | Worker (sonnet) |
+|---|---|---|
+| Does it write or edit files? | No | Yes |
+| Does it run Bash commands? | No | Yes |
+| Does it do codebase research or deep analysis? | No | Yes |
+| Does it write plans, code, docs, or tests? | No | Yes |
+| Does it spawn sub-agents and only pass results through? | Yes | Rarely |
+| Does it sequence phases or manage a loop without reasoning about what's inside? | Yes | No |
+| Does it use AskUserQuestion or PushNotification as its primary user-facing tool? | Yes | No |
+
+**Classification heuristics:**
+- If an agent's job is "call agent A, then agent B, then agent C and return" with no content reasoning — it is an orchestrator; use haiku.
+- If an agent reads logs, interprets failures, writes anything, or makes decisions based on content — it is a worker; use sonnet.
+- Borderline case: an agent that reads logs AND delegates debugging to another agent. Apply the "does it interpret content to make a decision?" test. If yes, keep sonnet.
+
+**Audit workflow:**
+1. List all agent `.md` files in the codebase.
+2. For each agent, read its instructions to classify as orchestrator or worker using the table above.
+3. Build a classification table in the plan with columns: Agent | File | Current Model | Classification | Justification | Action.
+4. For agents where Current Model does not match Classification, change only the `model:` field in YAML front-matter.
+5. No logic, instruction, or tooling changes are needed — model is purely a front-matter field.
 
 ## Notes
 


### PR DESCRIPTION
## Description

# Orchestrators to Haiku

## Plan Metadata

- Plan type: `plan`
- Parent plan: N/A
- Depends on: N/A
- Status: `draft`

## System Intent

- **What is being built:** A cost-reduction change that switches all pure orchestrator agents from `model: sonnet` to `model: haiku`. Orchestrators that only classify input, call sub-agents, read results, and route — without doing deep reasoning, writing code, plans, or docs — are converted to haiku. Worker agents that write plans, implement code, debug, review, or write docs remain on sonnet.
- **Primary consumer(s):** dark-factory-agent and all callers that invoke the manufacture workflow.
- **Boundary (black-box scope only):** Only `model:` field changes in agent `.md` front-matter files. No logic, instructions, or tooling changes.

## Agent Audit

### Classification Table

| Agent | File | Current Model | Classification | Justification | Action |
|---|---|---|---|---|---|
| `dark-factory-agent` | `agents/dark-factory/agents/dark-factory-agent.md` | haiku | Orchestrator | Classifies input, preps work dir, routes to worker, reads brain.json results, coordinates cleanup. No deep reasoning. | Already haiku — no change |
| `feature-agent` | `agents/featurework/agents/feature-agent.md` | sonnet | Orchestrator | Drives phase-by-phase planning gate; calls planning-agent per phase, presents sections to user, then calls execution-agent. Does not write plans or code. Uses AskUserQuestion for user interaction only. | **Switch to haiku** |
| `planning-agent` | `agents/featurework/planning/agents/planning-agent.md` | haiku | Orchestrator | Pure phase-delegator. Receives phase + context, spawns sub-planning-agent, returns structured output. No reasoning. | Already haiku — no change |
| `sub-planning-agent` | `agents/featurework/planning/agents/sub-planning-agent.md` | sonnet | Worker | Researches codebase, writes plan files, runs mermaid scripts. Heavy reasoning and writing. | Keep sonnet |
| `execution-agent` | `agents/featurework/execution/agents/execution-agent.md` | sonnet | Orchestrator | Sequences skeleton → testing → implementation agents in strict order; gate-checks checklists; enters planning mode on hard-stop. No code writing. | **Switch to haiku** |
| `skeleton-agent` | `agents/featurework/execution/agents/skeleton-agent.md` | sonnet | Worker | Reads plan, builds files checklist, creates skeleton files. Does actual file creation and reasoning. | Keep sonnet |
| `testing-agent` | `agents/featurework/execution/agents/testing-agent.md` | sonnet | Worker | Reads plan, builds flows checklist, writes failing tests. Does actual test writing. | Keep sonnet |
| `implementation-agent` | `agents/featurework/execution/agents/implementation-agent.md` | sonnet | Worker | Implements each flow from checklist, runs tests, invokes deviation-protocol. Heavy implementation work. | Keep sonnet |
| `code-review-orchestrator-agent` | `agents/code-review/agents/code-review-orchestrator-agent.md` | sonnet | Orchestrator | Creates issues.md, spawns parallel reviewers, runs resolver loop until clean. No review reasoning itself. | **Switch to haiku** |
| `high-level-review-agent` | `agents/code-review/agents/high-level-review-agent.md` | sonnet | Worker | Reviews code against plan for structural/architectural conformance. Deep reasoning required. | Keep sonnet |
| `low-level-review-agent` | `agents/code-review/agents/low-level-review-agent.md` | sonnet | Worker | Reviews code at function level for bugs, untested paths, conflicts. Deep reasoning required. | Keep sonnet |
| `resolver-agent` | `agents/code-review/agents/resolver-agent.md` | sonnet | Worker | Reads issues, applies fixes, checks them off. Does actual code editing and reasoning. | Keep sonnet |
| `debugger-agent` | `agents/debugger/agents/debugger-agent.md` | sonnet | Worker | Systematic debugging following debug skill checklist. Heavy reasoning and investigation. | Keep sonnet |
| `detect-drift-agent` | `agents/documentation/agents/detect-drift-agent.md` | sonnet | Worker | Audits parity between docs and code, fixes drift in place. Deep analysis required. | Keep sonnet |
| `investigation-agent` | `agents/documentation/agents/investigation-agent.md` | sonnet | Worker | Explores codebase, validates/creates authoritative docs. Heavy research and writing. | Keep sonnet |
| `update-documentation-agent` | `agents/documentation/agents/update-documentation-agent.md` | sonnet | Worker | Identifies affected flows/docs, deletes stale content, updates/adds sections. Complex writing. | Keep sonnet |
| `fix-flow-orchestrator` | `agents/fix-flow/agents/fix-flow-orchestrator.md` | sonnet | Orchestrator | Runs 3 phases in strict sequence: spawns investigation-agent, setup-wizard, ralph-fix-and-push. Routing and sequencing only. Handles required-argument clarification via AskUserQuestion. | **Switch to haiku** |
| `debug-flow-agent` | `agents/fix-flow/agents/debug-flow-agent.md` | sonnet | Worker | Runs integration flow, waits, fetches logs, hands off to debugger-agent. Complex coordination and log analysis. Borderline — but reads and interprets logs. | Keep sonnet |
| `ralph-fix-and-push` | `agents/fix-flow/agents/ralph-fix-and-push.md` | sonnet | Orchestrator | Loops: trigger flow → spawn debugger-agent → spawn pr-agent → deploy. Sequencing and loop management; no debugging or PRs itself. Handles stuck-loop user interaction. | **Switch to haiku** |
| `setup-wizard` | `agents/fix-flow/agents/setup-wizard.md` | sonnet | Worker | Reads system document, generates trigger.sh, wait-for-completion.sh, fetch-logs.sh, deploy.sh. Actual script writing and reasoning. | Keep sonnet |
| `init-orchestrator-agent` | `agents/initialization/agents/init-orchestrator-agent.md` | sonnet | Orchestrator | Clones repo, sets bypassPermissions, invokes init-docs-agent, invokes pr-agent. Pure delegation with minimal logic. | **Switch to haiku** |
| `init-docs-agent` | `agents/initialization/agents/init-docs-agent.md` | sonnet | Worker | Discovers systems, discovers flows per system, invokes investigation-agent per flow, writes CLAUDE.md index. Heavy codebase exploration and writing. | Keep sonnet |
| `pr-agent` | `agents/pr/agents/pr-agent.md` | sonnet | Worker | Manages full PR lifecycle: builds PR body, opens PR, CI watch loop, comment resolution loop, spawns resolve-pr-issue. Complex multi-loop management with real reasoning about CI failures. | Keep sonnet |
| `resolve-pr-issue` | `agents/pr/agents/resolve-pr-issue.md` | sonnet | Worker | Resolves single PR issue (CI failure or review thread): reads issue, applies fix, pushes, resolves thread. Actual fix implementation. | Keep sonnet |
| `repair-agent` | `agents/repair/agents/repair-agent.md` | sonnet | Worker | Applies targeted changes, runs test suite, iteratively fixes failures up to 5 times. Actual implementation work. | Keep sonnet |
| `skill-update-agent` | `agents/skill-update/agents/skill-update-agent.md` | sonnet | Worker | Reviews completed work, identifies patterns, writes/updates skill files. Deep analysis and writing. | Keep sonnet |

### Summary of Changes

**Switch to haiku (6 agents):**
1. `feature-agent` — orchestrates planning phases and approval gates; no plan writing
2. `execution-agent` — sequences skeleton/testing/implementation; no code writing
3. `code-review-orchestrator-agent` — spawns parallel reviewers and loops resolver; no review reasoning
4. `fix-flow-orchestrator` — sequences 3 phases; no investigation/debugging/fixing
5. `ralph-fix-and-push` — loops debugger/pr-agent; no debugging or PR work itself
6. `init-orchestrator-agent` — clones repo, delegates to init-docs-agent and pr-agent; minimal logic

**Already haiku (2 agents):**
- `dark-factory-agent`
- `planning-agent`

**Stay sonnet (19 agents):**
All workers that write code, plans, docs, tests, scripts, or do deep reasoning/debugging/review.

## Stage Gate Tracker

- [ ] Stage 1 Mermaid approved
- [ ] Stage 2 Flows approved
- [ ] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

```mermaid
graph TD
  subgraph Orchestrators["Orchestrators — switch to haiku"]
    DFA["dark-factory-agent<br/>(already haiku)"]
    FA["feature-agent<br/>sonnet → haiku"]
    PA["planning-agent<br/>(already haiku)"]
    EA["execution-agent<br/>sonnet → haiku"]
    CROA["code-review-orchestrator-agent<br/>sonnet → haiku"]
    FFO["fix-flow-orchestrator<br/>sonnet → haiku"]
    RFAP["ralph-fix-and-push<br/>sonnet → haiku"]
    IOA["init-orchestrator-agent<br/>sonnet → haiku"]
  end

  subgraph Workers["Workers — stay on sonnet"]
    SPA["sub-planning-agent"]
    SKA["skeleton-agent"]
    TA["testing-agent"]
    IA["implementation-agent"]
    HLRA["high-level-review-agent"]
    LLRA["low-level-review-agent"]
    RA2["resolver-agent"]
    DA["debugger-agent"]
    DDA["detect-drift-agent"]
    INVA["investigation-agent"]
    UDA["update-documentation-agent"]
    DFA2["debug-flow-agent"]
    SW["setup-wizard"]
    IDA["init-docs-agent"]
    PRA["pr-agent"]
    RPRI["resolve-pr-issue"]
    REP["repair-agent"]
    SUA["skill-update-agent"]
  end

  DFA -->|routes to| FA
  FA -->|delegates phase| PA
  PA -->|delegates| SPA
  FA -->|invokes| EA
  EA -->|sequences| SKA
  EA -->|sequences| TA
  EA -->|sequences| IA
  DFA -->|invokes| CROA
  CROA -->|parallel| HLRA
  CROA -->|parallel| LLRA
  CROA -->|loops| RA2
  DFA -->|routes to| FFO
  FFO -->|phase 1| INVA
  FFO -->|phase 2| SW
  FFO -->|phase 3| RFAP
  RFAP -->|loops| DA
  RFAP -->|loops| PRA
  DFA -->|routes to| IOA
  IOA -->|delegates| IDA
  IOA -->|delegates| PRA

  classDef haiku fill:#a8e6a3,stroke:#2d7a2d,stroke-width:2px;
  classDef sonnet fill:#d3d3d3,stroke:#666,stroke-width:1px;
  classDef already fill:#c8f0c8,stroke:#2d7a2d,stroke-width:1px,stroke-dasharray:4;

  class FA,EA,CROA,FFO,RFAP,IOA haiku;
  class DFA,PA already;
  class SPA,SKA,TA,IA,HLRA,LLRA,RA2,DA,DDA,INVA,UDA,DFA2,SW,IDA,PRA,RPRI,REP,SUA sonnet;
```

## Flows

### Global Types

```txt
StandardError {
  message: string (human-readable description of what went wrong)
}
```

### Flow: `update-feature-agent`

- Test files: N/A (config change only — no logic change)
- Core files: `agents/featurework/agents/feature-agent.md`

#### Types

```txt
AgentModelChange {
  file: string (path to agent .md file)
  oldModel: "sonnet"
  newModel: "haiku"
}
```

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `update-feature-agent.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` in YAML front-matter | |

#### Pseudocode

```
Read agents/featurework/agents/feature-agent.md
Replace `model: sonnet` with `model: haiku` in YAML front-matter
Write updated file
```

### Flow: `update-execution-agent`

- Test files: N/A
- Core files: `agents/featurework/execution/agents/execution-agent.md`

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `update-execution-agent.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` | |

#### Pseudocode

```
Read agents/featurework/execution/agents/execution-agent.md
Replace `model: sonnet` with `model: haiku` in YAML front-matter
Write updated file
```

### Flow: `update-code-review-orchestrator-agent`

- Test files: N/A
- Core files: `agents/code-review/agents/code-review-orchestrator-agent.md`

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `update-code-review-orchestrator-agent.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` | |

#### Pseudocode

```
Read agents/code-review/agents/code-review-orchestrator-agent.md
Replace `model: sonnet` with `model: haiku` in YAML front-matter
Write updated file
```

### Flow: `update-fix-flow-orchestrator`

- Test files: N/A
- Core files: `agents/fix-flow/agents/fix-flow-orchestrator.md`

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `update-fix-flow-orchestrator.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` | |

#### Pseudocode

```
Read agents/fix-flow/agents/fix-flow-orchestrator.md
Replace `model: sonnet` with `model: haiku` in YAML front-matter
Write updated file
```

### Flow: `update-ralph-fix-and-push`

- Test files: N/A
- Core files: `agents/fix-flow/agents/ralph-fix-and-push.md`

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `update-ralph-fix-and-push.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` | |

#### Pseudocode

```
Read agents/fix-flow/agents/ralph-fix-and-push.md
Replace `model: sonnet` with `model: haiku` in YAML front-matter
Write updated file
```

### Flow: `update-init-orchestrator-agent`

- Test files: N/A
- Core files: `agents/initialization/agents/init-orchestrator-agent.md`

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `update-init-orchestrator-agent.success` | `AgentModelChange` | updated front-matter with `model: haiku` | happy path | Change `model: sonnet` to `model: haiku` | |

#### Pseudocode

```
Read agents/initialization/agents/init-orchestrator-agent.md
Replace `model: sonnet` with `model: haiku` in YAML front-matter
Write updated file
```

## Logs

N/A — this is a configuration-only change with no runtime logs.

## Deployment

- Mechanism: `local only`
- Deploy command: N/A (changes take effect immediately on next agent invocation)
- Notes: Model changes are read at agent spawn time. No restart or deploy needed.

## Handoff to Related Plan Reconciliation

No linked plans depend on agent model fields. No reconciliation needed.

## Test Plan

```
tests/test_docs_template_compliance.py PASSED
tests/test_generate_checklist.py PASSED
tests/test_hooks.py PASSED
tests/test_mermaid_to_image.py PASSED
tests/test_planning_approval_gate.py PASSED
tests/test_pre_tool_use_hook.py PASSED
tests/test_push_notification_declared.py PASSED
tests/test_update_metrics.py PASSED

============================== 82 passed in 1.11s ==============================
```

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
