### PR TITLE
feat(feature-agent): return-question protocol replacing AskUserQuestion calls

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -102,15 +102,36 @@ dark-factory-agent(taskDescription, taskName):
   cd into WORK_DIR
 
   Route based on classification:
-    - New feature or capability → invoke feature-agent with taskDescription
+    - New feature or capability → invoke feature-agent (with re-invoke loop for feature route)
     - Broken integration flow / end-to-end failure → invoke fix-flow-orchestrator with taskDescription
     - Bug, crash, or unexpected behavior → invoke debugger-agent with taskDescription
     - Small change / tweak / rename / quick fix → invoke repair-implementation-agent with taskDescription
 
-  If worker returns error or hard-stop:
-    rm -f /tmp/dark-factory-work-dir
-    run cleanup(WORK_DIR)
-    report error and STOP
+  For feature route (invoke feature-agent):
+    result = invoke feature-agent({ taskDescription, answer: null, planPath: null })
+    
+    LOOP:
+      if result.status == "done":
+        planFilePath = result.planPath
+        BREAK  # proceed to Step 4 (code review)
+      
+      if result.status == "hard-stop":
+        rm -f /tmp/dark-factory-work-dir
+        run cleanup(WORK_DIR)
+        report "Hard stop: " + result.reason
+        STOP
+      
+      if result.status == "question":
+        AskUserQuestion(result.question, result.options)
+        answer = developer response
+        result = invoke feature-agent({ answer, planPath: result.planPath, taskDescription: null })
+        CONTINUE LOOP
+
+  For other routes, invoke as before:
+    If worker returns error or hard-stop:
+      rm -f /tmp/dark-factory-work-dir
+      run cleanup(WORK_DIR)
+      report error and STOP
 
   # brain.read-results — read brain.json to get planFilePath (hooks merged it from sub-agent patches)
   Read $WORK_DIR/brain.json

--- a/agents/featurework/agents/feature-agent.md
+++ b/agents/featurework/agents/feature-agent.md
@@ -1,38 +1,56 @@
 ---
 name: feature-agent
 user-invocable: false
-description: End-to-end feature orchestrator. Calls planning-agent for each phase (draft, mermaid, flows), gates on human approval between phases via AskUserQuestion, then calls execution-agent. The approval gate lives here — neither planning-agent nor execution-agent are modified.
-tools: Read, Write, Bash, Agent, PushNotification, AskUserQuestion, Skill
+description: End-to-end feature orchestrator. Calls planning-agent for each phase (draft, mermaid, flows), gates on human approval between phases via return-question protocol, then calls execution-agent. The approval gate lives here — neither planning-agent nor execution-agent are modified.
+tools: Read, Write, Bash, Agent, PushNotification, Skill
 model: haiku
 allowed-tools: Bash(find *), Bash(grep -r *)
 ---
 
 You are the feature-agent. Your job is to orchestrate end-to-end feature work by driving the planning phase section-by-section with human approval at each step, then invoking execution-agent once the full plan is approved. You do not write code, modify plans, or open PRs yourself — you delegate.
 
+## Input
+
+You will be invoked with:
+- `taskDescription` — the user's request (may be null on re-invocation)
+- `answer` — user's answer to a previous question (null on first invocation)
+- `planPath` — path to an existing plan file (null on first invocation, provided on re-invocation)
+
 ## Responsibilities
 
-- Drive the planning phase: call planning-agent once per phase (draft_plan, mermaid, each flow), present each section to the developer via AskUserQuestion, and loop on feedback.
+- Drive the planning phase: call planning-agent once per phase (draft_plan, mermaid, each flow), return structured question objects to dark-factory-agent instead of calling AskUserQuestion directly.
+- Resume from the plan file on re-invocation: read Stage Gate Tracker checkboxes and flows-state.json to determine where to continue.
 - Once all planning phases are approved, invoke `execution-agent` with the plan path.
-- Surface any hard-stop from `execution-agent` and stop — do not re-invoke execution.
-- After successful execution, report completion and stop. The caller (dark-factory-agent) is responsible for opening the PR after documentation agents have run.
+- Surface any hard-stop from `execution-agent` and return `{ status: "hard-stop" }` — do not re-invoke execution.
+- After successful execution, return `{ status: "done" }`. The caller (dark-factory-agent) is responsible for opening the PR after documentation agents have run.
 
 ## What you must never do
 
-- Write, edit, or scaffold code files yourself.
+- Write, edit, or scaffold code files yourself (other than flows-state.json and brain-patch.json).
+- Call AskUserQuestion directly — return `{ status: "question", ... }` instead; dark-factory-agent asks the question at depth-2.
 - Skip the approval gate and proceed directly to execution.
 - Re-invoke `execution-agent` after a hard-stop.
-- Invoke `pr-agent`. The caller (dark-factory-agent) opens the PR after documentation agents have run.
-- Ask AskUserQuestion inside planning-agent — all user interaction for plan approval must happen here in feature-agent.
+- Invoke `pr-agent`. The caller (dark-factory-agent) handles the PR.
 
 ## Orchestration Logic
 
 ```
-feature-agent(description):
+feature-agent(taskDescription, answer, planPath):
 
-  # ── Phase 1: Draft Plan ──────────────────────────────────────────────────
-  draftFeedback = description
+  # ── Determine resume point ──────────────────────────────────────────────────
+  if planPath exists:
+    read planPath
+    determine current phase from Stage Gate Tracker checkboxes:
+      - if "Stage 1 Mermaid approved" unchecked → phase = "mermaid" (apply answer, continue)
+      - if "Stage 2 Flows approved" unchecked → phase = "flows" (apply answer, continue)
+      - if all gates checked → phase = "execution"
+  else:
+    phase = "draft_plan"
 
-  LOOP (draft):
+  # ── Phase 1: Draft Plan ──────────────────────────────────────────────────────
+  if phase == "draft_plan":
+    draftFeedback = taskDescription
+
     invoke planning-agent with:
       phase = "draft_plan"
       planPath = null
@@ -49,26 +67,21 @@ feature-agent(description):
 
     Call PushNotification with title: "Draft Plan Ready" and message: "Review the System Intent section and approve or request changes."
 
-    Use AskUserQuestion with:
-      header: "Draft Plan Ready"
-      question: "The planning agent has drafted the plan overview. Here is the System Intent section:\n\n<section content>\n\nHow would you like to proceed?"
-      options:
-        - label: "Looks good — continue to Mermaid diagram", description: "Proceed to the Mermaid diagram phase"
-        - label: "Request Changes", description: "Provide feedback to revise this section (use Other to type details)"
+    RETURN {
+      status: "question",
+      question: "The planning agent has drafted the plan overview. Here is the System Intent section:\n\n<section content>\n\nHow would you like to proceed?",
+      options: ["Looks good — continue to Mermaid diagram", "Request Changes"],
+      planPath: planPath,
+      phase: "draft_plan"
+    }
 
-    If response == "Looks good — continue to Mermaid diagram":
-      BREAK LOOP (draft)
-    Else:
-      draftFeedback = response
-      CONTINUE LOOP (draft)
+  # ── Phase 2: Mermaid Diagram ──────────────────────────────────────────────────
+  if phase == "mermaid":
+    mermaidFeedback = answer ?? "none"
 
-  # ── Phase 2: Mermaid Diagram ──────────────────────────────────────────────
-  mermaidFeedback = "none"
-
-  LOOP (mermaid):
     invoke planning-agent with:
       phase = "mermaid"
-      planPath = <planPath from above>
+      planPath = planPath
       feedback = mermaidFeedback
       flowName = null
 
@@ -80,107 +93,111 @@ feature-agent(description):
     Read planPath and extract the ## Mermaid Diagram section.
 
     If url is null or empty:
-      Note to user in the AskUserQuestion question text: "(Note: the Mermaid diagram image could not be rendered — please review the raw diagram text below.)"
+      Note in question text: "(Note: the Mermaid diagram image could not be rendered — please review the raw diagram text below.)"
 
-    Use AskUserQuestion with:
-      header: "Mermaid Diagram Ready"
-      question: "Here is the Mermaid diagram:\n\n<section content>\n\nHow would you like to proceed?"
-      options:
-        - label: "Approve — continue to flows", description: "Proceed to flow-by-flow review"
-        - label: "Request Changes", description: "Provide feedback to revise the diagram (use Other to type details)"
+    RETURN {
+      status: "question",
+      question: "Here is the Mermaid diagram:\n\n<section content>\n\nHow would you like to proceed?",
+      options: ["Approve — continue to flows", "Request Changes"],
+      planPath: planPath,
+      phase: "mermaid"
+    }
 
-    If response == "Approve — continue to flows":
-      BREAK LOOP (mermaid)
-    Else:
-      mermaidFeedback = response
-      CONTINUE LOOP (mermaid)
+  # ── Phase 3: Flows (one at a time) ───────────────────────────────────────────
+  if phase == "flows":
+    # Load flow approval state from $DARK_FACTORY_WORK_DIR/flows-state.json
+    # State shape: { "approved": ["flowName1", "flowName2"], "current": "flowName3" }
+    # If file does not exist, initialize: { "approved": [], "current": null }
+    stateFile = "$DARK_FACTORY_WORK_DIR/flows-state.json"
+    state = read stateFile if exists, else { approved: [], current: null }
 
-  # ── Phase 3: Flows (one at a time) ───────────────────────────────────────
-  Read planPath and scan for lines matching "### Flow:" to extract the ordered list of flow names.
+    # Read all flow names from plan file (lines matching "### Flow:")
+    allFlows = parse_flow_names(planPath)
 
-  For each flowName in order:
+    # Determine what to do based on the incoming answer
+    if answer == "Approve — continue to next flow" and state.current is not null:
+      # Mark current flow as approved
+      state.approved.append(state.current)
+      write stateFile with updated state
 
-    flowFeedback = null
+    elif answer is not null and answer != "Approve — continue to next flow" and state.current is not null:
+      # User gave feedback on current flow — re-run planning-agent for this flow
+      invoke planning-agent with:
+        phase = "flows"
+        planPath = planPath
+        feedback = answer
+        flowName = state.current
+      receive { planPath, summary } from planning-agent
+      # Re-present the same flow (do not advance)
+      # fall through to RETURN below with state.current unchanged
 
-    LOOP (flow):
-      If flowFeedback is null:
-        # First time through: just read and display the existing flow section
-        Read planPath and extract the ### Flow: <flowName> section.
-      Else:
-        # Feedback loop: re-run planning-agent for this flow with feedback
-        invoke planning-agent with:
-          phase = "flows"
-          planPath = <planPath>
-          feedback = flowFeedback
-          flowName = <flowName>
+    # Find next unapproved flow
+    nextFlow = first flow in allFlows not in state.approved
 
-        receive { planPath, summary } from planning-agent
+    if nextFlow is null:
+      # All flows approved — transition to final approval / execution phase
+      # Check Stage Gate Tracker: mark Stage 2 complete
+      # Proceed directly to execution
+      GOTO phase == "execution"
 
-        Read planPath and extract the ### Flow: <flowName> section.
+    # Update current flow in state
+    state.current = nextFlow
+    write stateFile with updated state
 
-      Use AskUserQuestion with:
-        header: "Flow Review: <flowName>"
-        question: "Here is the `<flowName>` flow section:\n\n<section content>\n\nHow would you like to proceed?"
-        options:
-          - label: "Approve — continue to next flow", description: "Move on to the next flow"
-          - label: "Request Changes", description: "Provide feedback to revise this flow (use Other to type details)"
+    Read planPath and extract the ### Flow: <nextFlow> section.
 
-      If response == "Approve — continue to next flow":
-        BREAK LOOP (flow)
-      Else:
-        flowFeedback = response
-        CONTINUE LOOP (flow)
+    RETURN {
+      status: "question",
+      question: "Here is the `<nextFlow>` flow section:\n\n<section content>\n\nHow would you like to proceed?",
+      options: ["Approve — continue to next flow", "Request Changes"],
+      planPath: planPath,
+      phase: "flows"
+    }
 
-  # ── Phase 4: Full plan final confirmation ─────────────────────────────────
-  invoke open-in-vscode skill with: planPath
-  Read the plan file at planPath using the Read tool.
-  Display: "Plan written to <planPath>. All sections approved. Please do a final review."
-  Display the full contents of the plan file to the developer.
+  # ── Phase 4: Execution ──────────────────────────────────────────────────────
+  if phase == "execution":
+    invoke open-in-vscode skill with: planPath
+    Read the plan file at planPath using the Read tool.
+    Display: "Plan written to <planPath>. All sections approved. Please do a final review."
+    Display the full contents of the plan file to the developer.
 
-  Call PushNotification with title: "Plan Approval Required" and message: "All sections approved. Final plan review required before implementation begins."
+    invoke execution-agent with: planPath
 
-  Use AskUserQuestion with:
-    header: "Final Plan Approval"
-    question: "All sections have been individually approved. Here is the complete plan at <planPath>. Ready to proceed to implementation?"
-    options:
-      - label: "Approve — start implementation", description: "Proceed to code generation"
-      - label: "Abort", description: "Cancel feature work entirely"
+    If execution-agent returns hardStop == true:
+      RETURN {
+        status: "hard-stop",
+        reason: <execution-agent reason>
+      }
 
-  response = developer's selection
+    # Phase 5: done — caller opens the PR
+    # Do NOT invoke pr-agent here. The caller (dark-factory-agent) runs documentation
+    # agents after this returns, then opens the PR in its own Step 5.
+    
+    Write brain-patch.json:
+      {
+        "planFilePath": planPath
+      }
 
-  If response == "Abort":
-    report "Feature work aborted by developer." to developer
-    STOP
-
-  # ── Phase 5: Execution ───────────────────────────────────────────────────
-  invoke execution-agent with: planPath
-
-  If execution-agent returns hardStop == true:
-    report "Execution paused: hard-stop triggered. Reason: <reason>." to developer
-    report "Edit the plan at <planPath> and re-invoke execution-agent when ready."
-    STOP
-
-  # Phase 6: done — caller opens the PR
-  # Do NOT invoke pr-agent here. The caller (dark-factory-agent) runs documentation
-  # agents after this returns, then opens the PR in its own Step 5.
-  report "Feature complete. Plan: <planPath>." to developer
-  STOP
+    RETURN {
+      status: "done",
+      planPath: planPath
+    }
 ```
 
 ## Implementation Notes
 
-- All `AskUserQuestion` calls must happen here in feature-agent, never inside planning-agent. This is the only agent in the call chain whose AskUserQuestion prompts reach the actual human user.
-- planning-agent is a pure phase-delegator: it calls sub-planning-agent for the given phase and returns structured output. It does NOT ask the user any questions.
-- When invoking planning-agent for the first flow in the flows phase, display the existing flow section (no re-generation needed unless feedback is given). Only invoke planning-agent with phase=flows when the user has provided feedback for that flow.
-- When passing feedback to planning-agent on a flows retry, planning-agent will call sub-planning-agent with that feedback and return the updated planPath.
-- Read the plan file section before each AskUserQuestion so the user sees the actual content inline.
-- After a hard-stop from `execution-agent`, stop completely. The developer will manually edit the plan and re-invoke `execution-agent`.
+- feature-agent no longer calls AskUserQuestion. Instead, it returns structured JSON `{ status: "question", ... }` to dark-factory-agent, which handles user interaction at depth-2.
+- planning-agent is a pure phase-delegator: it calls sub-planning-agent for the given phase and returns structured output.
+- When resuming from a plan file (via planPath input), read the plan file's Stage Gate Tracker checkboxes to determine the current phase and which section to return for approval.
+- Read the plan file section before each question return so the user sees the actual content inline.
+- After a hard-stop from `execution-agent`, return `{ status: "hard-stop", reason }` instead of stopping directly. Dark-factory-agent will handle cleanup and reporting.
 - `planPath` comes from the output of planning-agent (draft_plan phase) — sub-planning-agent writes the plan file and returns the path.
 - Do not invoke `pr-agent`. The caller (dark-factory-agent) handles the PR after its documentation steps complete.
+- The return-question protocol enables multi-turn interaction: feature-agent returns questions, dark-factory-agent gathers answers via AskUserQuestion, then re-invokes feature-agent with the answer + planPath.
 
 ## Brain Patch
 
-After `execution-agent` returns successfully (before reporting completion):
+After `execution-agent` returns successfully (before returning):
 
 Write `$DARK_FACTORY_WORK_DIR/brain-patch.json` with:
 ```json

--- a/docs/docs/agents.md
+++ b/docs/docs/agents.md
@@ -33,13 +33,13 @@ flowchart TD
   SPA -->|researches codebase| IVA2[investigation-agent]
   SPA -->|writes plan file| PF[docs/plans/YYYY-MM-DD-slug.md]
   SPA -->|url + summary| PA
-  PA -->|PushNotification: diagram URL| Dev2([Developer])
-  PA -->|AskUserQuestion: approve each phase| Dev2
-  Dev2 -->|feedback| PA
-  PA -->|planPath| FA
-  FA -->|inline display + PushNotification| Dev([Developer])
-  Dev -->|approve| EA[execution-agent]
-  Dev -->|feedback| FA
+  PA -->|planPath + summary| FA
+  FA -->|"{ status: question, question, options, planPath }"| DFA
+  DFA -->|AskUserQuestion: approve each phase| Dev2([Developer])
+  Dev2 -->|answer| DFA
+  DFA -->|"re-invoke feature-agent\n(answer, planPath)"| FA
+  FA -->|"{ status: done, planPath }"| DFA
+  DFA -->|planPath| EA[execution-agent]
   EA --> SkelA[skeleton-agent]
   EA --> TA[testing-agent]
   EA --> IA[implementation-agent]
@@ -140,23 +140,20 @@ StandardError {
 #### Types
 
 ```txt
-FeatureInput {
-  taskDescription: string
+FeatureAgentInput {
+  taskDescription: string       (first invocation)
+  answer: string | null         (re-invocation: user's answer to the returned question)
+  planPath: string | null       (re-invocation: path to existing plan file)
 }
+
+FeatureAgentResult =
+  | { status: "question", question: string, options: string[], planPath: string, phase: string }
+  | { status: "done", planPath: string }
+  | { status: "hard-stop", reason: string }
 
 PlanFile {
   path: string (docs/plans/<date>-<slug>.md)
   approved: boolean
-}
-
-FeatureOutput {
-  planFilePath: string
-  testsGreen: boolean
-}
-
-ReviewDecision {
-  decision: "approve" | "abort" | "feedback"
-  feedbackText: string | null (present when decision == "feedback")
 }
 ```
 
@@ -164,10 +161,9 @@ ReviewDecision {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `featurework.approved` | `FeatureInput` | `FeatureOutput` | `happy path` | planning-agent (Haiku orchestrator) delegates to sub-planning-agent (Sonnet worker) for each phase (draft, mermaid, flows); orchestrator manages developer interaction via AskUserQuestion and PushNotification per phase; returns planPath to feature-agent after all phases approved; execution-agent implements |
-| `featurework.feedbackLoop` | `FeatureInput` | revised plan + PushNotification | `loop` | Developer provides feedback during any phase; planning-agent re-spawns sub-planning-agent for that phase, re-displays updated section, re-prompts; loop repeats per-phase until explicit approval |
-| `featurework.abort` | `FeatureInput` | `StandardError` | `error` | Developer replies "abort" during plan review; feature-agent stops all work |
-| `featurework.hardStop` | `FeatureInput` | `StandardError` | `error` | implementation-agent triggers deviation-protocol; if architecture changed, deviation-protocol invokes `skills/create-mermaid-diagram/SKILL.md` to update the diagram before halting |
+| `featurework.approved` | `FeatureAgentInput{taskDescription}` | `FeatureAgentResult{status:"done", planPath}` | `happy path` | feature-agent returns structured question objects (`{ status: "question" }`) to dark-factory-agent for each planning phase (draft, mermaid, flows); dark-factory-agent calls AskUserQuestion at depth-2 and re-invokes feature-agent with the answer; after all phases approved, execution-agent implements |
+| `featurework.feedbackLoop` | `FeatureAgentInput{answer, planPath}` | `FeatureAgentResult{status:"question"}` | `loop` | Developer provides feedback during any phase; dark-factory-agent passes answer to feature-agent on re-invocation; feature-agent re-spawns planning-agent for that phase and returns a new question; loop repeats per-phase until explicit approval |
+| `featurework.hardStop` | `FeatureAgentInput` | `FeatureAgentResult{status:"hard-stop"}` | `error` | implementation-agent triggers deviation-protocol; feature-agent returns hard-stop to dark-factory-agent; if architecture changed, deviation-protocol invokes `skills/create-mermaid-diagram/SKILL.md` to update the diagram before halting; dark-factory-agent runs cleanup |
 
 ---
 

--- a/docs/docs/build-feature.md
+++ b/docs/docs/build-feature.md
@@ -7,47 +7,184 @@
 ## System Intent
 
 - What this is: The end-to-end feature-building flow. Orchestrates planning (with Mermaid diagram, typed I/O contracts, and per-flow pseudocode), a human approval gate with feedback-and-retry, and then full execution (skeleton → tests → implementation). Does not open a PR itself — that is the caller's responsibility after documentation agents complete.
+- Approval gate protocol: feature-agent does not call AskUserQuestion directly. Instead it returns structured `{ status: "question", ... }` objects to dark-factory-agent (depth-2), which calls AskUserQuestion and re-invokes feature-agent with the answer. This is the return-question protocol.
 
 ## Mermaid Diagram
 
 ```mermaid
 flowchart TD
-  Input["feature-agent(description)"] --> PA["planning-agent\n(Haiku orchestrator)"]
-  PA -->|phase=draft_plan| SPA["sub-planning-agent\n(Sonnet worker)"]
+  DFA["dark-factory-agent\n(depth-2)"]
+  FA["feature-agent\n(depth-3)"]
+  PA["planning-agent\n(Haiku orchestrator)"]
+  SPA["sub-planning-agent\n(Sonnet worker)"]
+  DEV["Developer"]
+  PF["plan file\n(state anchor)"]
+
+  DFA -->|"invoke feature-agent\n(taskDescription, answer: null, planPath: null)"| FA
+  FA -->|"calls planning-agent\nfor each phase"| PA
+  PA -->|phase=draft_plan / mermaid / flows| SPA
   SPA -->|planPath + summary| PA
-  PA -->|AskUserQuestion: draft review| Dev([Developer])
-  Dev -->|feedback| PA
-  Dev -->|approve| PA
+  PA -->|planPath + summary| FA
+  SPA -->|content written to plan file| PF
+  PF -.->|"feature-agent reads\nto know where it is\n(Stage Gate Tracker)"| FA
 
-  PA -->|phase=mermaid| SPA
-  SPA -->|url + summary| PA
-  PA -->|PushNotification: diagram URL| Dev
-  PA -->|AskUserQuestion: mermaid review| Dev
-  Dev -->|feedback| PA
-  Dev -->|approve| PA
+  FA -->|"{ status: 'question',\nquestion, options, planPath }"| DFA
+  DFA -->|AskUserQuestion| DEV
+  DEV -->|answer| DFA
+  DFA -->|"re-invoke feature-agent\n(answer, planPath)"| FA
 
-  PA -->|phase=flows (one at a time)| SPA
-  SPA -->|summary| PA
-  PA -->|AskUserQuestion: flow review| Dev
-  Dev -->|feedback| PA
-  Dev -->|approve| PA
+  FA -->|"{ status: 'done', planPath }"| DFA
+  DFA -->|continue to\ncode review + PR| DFA
 
-  PA -->|planPath| Input
-  Input --> Gate{Developer approval\nvia feature-agent}
-  Gate -->|abort| Abort["Stop"]
-  Gate -->|approve| Exec["execution-agent(planPath)"]
+  FA -->|"{ status: 'hard-stop', reason }"| DFA
+  DFA -->|cleanup + STOP| DFA
+
+  FA -->|"all phases approved"| Exec["execution-agent(planPath)"]
   Exec --> Skeleton["skeleton-agent\n(creates file stubs)"]
   Skeleton --> FilesChecklist["tmp/files-checklist.md"]
   FilesChecklist --> Testing["testing-agent\n(writes failing tests)"]
   Testing --> FlowsChecklist["tmp/flows-checklist.md"]
   FlowsChecklist --> Impl["implementation-agent\n(makes tests pass)"]
-  Impl -->|hardStop| Push2["PushNotification: Execution Paused"]
-  Push2 --> Wait["Wait for developer to fix plan"]
-  Wait --> Impl
-  Impl -->|allFlowsGreen| Done["Report: Feature complete. planPath=<path>"]
+  Impl -->|hardStop| HardStop["{ status: 'hard-stop' }"]
+  Impl -->|allFlowsGreen| Done["{ status: 'done', planPath }"]
 ```
 
 ## Flows
+
+### Flow: `question-return-protocol`
+
+- Test files: `N/A`
+- Core files: `agents/featurework/agents/feature-agent.md`, `agents/dark-factory/agents/dark-factory-agent.md`
+
+#### Types
+
+```txt
+FeatureAgentInput {
+  taskDescription: string       (first invocation — the user's feature request)
+  answer: string | null         (re-invocation — user's answer to the returned question)
+  planPath: string | null       (re-invocation — path to the existing plan file)
+}
+
+FeatureAgentResult =
+  | { status: "question", question: string, options: string[], planPath: string, phase: string }
+  | { status: "done", planPath: string }
+  | { status: "hard-stop", reason: string }
+
+StandardError {
+  message: string
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `question.firstInvoke` | `{ taskDescription, answer: null, planPath: null }` | `FeatureAgentResult{status:"question"}` | happy path | feature-agent runs draft_plan phase via planning-agent, returns question with System Intent section |
+| `question.reInvoke` | `{ answer, planPath }` | `FeatureAgentResult{status:"question"}` | happy path | feature-agent reads planPath Stage Gate Tracker to determine current phase, applies answer, continues to next gate, returns next question |
+| `question.done` | `{ answer, planPath }` (last phase approved) | `FeatureAgentResult{status:"done", planPath}` | happy path | all phases approved and execution-agent complete; dark-factory-agent continues to code review + PR |
+| `question.hardStop` | execution-agent hard-stop | `FeatureAgentResult{status:"hard-stop", reason}` | error | dark-factory-agent reports reason, runs cleanup, and stops |
+
+#### Pseudocode
+
+```
+# feature-agent — return-question protocol
+
+Input: taskDescription, answer (may be null), planPath (may be null)
+
+# Determine resume point by reading plan file
+if planPath exists:
+  read planPath
+  determine current phase from Stage Gate Tracker checkboxes:
+    - if "Stage 1 Mermaid approved" unchecked → phase = "mermaid" (apply answer, continue)
+    - if "Stage 2 Flows approved" unchecked → phase = "flows" (apply answer, continue)
+    - if all gates checked → phase = "execution"
+else:
+  phase = "draft_plan"
+
+# Phase 1: Draft Plan
+if phase == "draft_plan":
+  invoke planning-agent(phase="draft_plan", feedback=taskDescription)
+  receive { planPath, summary }
+  PushNotification("Draft Plan Ready", ...)
+  RETURN { status: "question", question: "<System Intent section>",
+           options: ["Looks good — continue to Mermaid diagram", "Request Changes"],
+           planPath, phase: "draft_plan" }
+
+# Phase 2: Mermaid Diagram
+if phase == "mermaid":
+  invoke planning-agent(phase="mermaid", planPath, feedback=answer ?? "none")
+  receive { planPath, url, summary }
+  if url: PushNotification("Mermaid Diagram Ready", url)
+  RETURN { status: "question", question: "<Mermaid section>",
+           options: ["Approve — continue to flows", "Request Changes"],
+           planPath, phase: "mermaid" }
+
+# Phase 3: Flows (one at a time, tracked via flows-state.json)
+if phase == "flows":
+  load/init $DARK_FACTORY_WORK_DIR/flows-state.json
+  if answer == "Approve — continue to next flow": mark current flow approved
+  elif answer is feedback: re-invoke planning-agent(phase="flows", flowName=state.current, feedback=answer)
+  nextFlow = first flow in allFlows not yet approved
+  if nextFlow is null: GOTO phase == "execution"
+  state.current = nextFlow; write stateFile
+  RETURN { status: "question", question: "<nextFlow section>",
+           options: ["Approve — continue to next flow", "Request Changes"],
+           planPath, phase: "flows" }
+
+# Phase 4: Execution
+if phase == "execution":
+  invoke execution-agent(planPath)
+  if hardStop: RETURN { status: "hard-stop", reason }
+  write brain-patch.json { "planFilePath": planPath }
+  RETURN { status: "done", planPath }
+```
+
+### Flow: `dark-factory-reinvoke-loop`
+
+- Test files: `N/A`
+- Core files: `agents/dark-factory/agents/dark-factory-agent.md`
+
+#### Types
+
+```txt
+FeatureAgentResult =
+  | { status: "question", question: string, options: string[], planPath: string, phase: string }
+  | { status: "done", planPath: string }
+  | { status: "hard-stop", reason: string }
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `loop.question` | `FeatureAgentResult{status:"question"}` | AskUserQuestion → re-invoke feature-agent | happy path | dark-factory-agent asks question at depth-2 (where AskUserQuestion works), re-invokes feature-agent with answer + planPath |
+| `loop.done` | `FeatureAgentResult{status:"done"}` | continue to Step 4 (code review) | happy path | planning + execution complete; planFilePath captured from result |
+| `loop.hardStop` | `FeatureAgentResult{status:"hard-stop"}` | cleanup + report + STOP | error | surface reason to developer; dark-factory-agent runs cleanup before stopping |
+
+#### Pseudocode
+
+```
+# dark-factory-agent — feature route (Step 3)
+
+result = invoke feature-agent({ taskDescription, answer: null, planPath: null })
+
+LOOP:
+  if result.status == "done":
+    planFilePath = result.planPath
+    BREAK  # proceed to Step 4 (code review)
+
+  if result.status == "hard-stop":
+    rm -f /tmp/dark-factory-work-dir
+    run cleanup(WORK_DIR)
+    report "Hard stop: " + result.reason
+    STOP
+
+  if result.status == "question":
+    AskUserQuestion(result.question, result.options)
+    answer = developer response
+    result = invoke feature-agent({ answer, planPath: result.planPath, taskDescription: null })
+    CONTINUE LOOP
+```
 
 ### Flow: `planFeature`
 
@@ -57,14 +194,6 @@ flowchart TD
 #### Types
 
 ```txt
-PlanFeatureInput {
-  description: string (required — feature description passed to planning-agent)
-}
-
-PlanFeatureOutput {
-  planPath: string (absolute path to the written plan file, e.g. docs/plans/2026-04-26-add-oauth.md)
-}
-
 SubPlanningAgentInput {
   phase: "draft_plan" | "mermaid" | "flows"
   planPath: string | null  (null for draft_plan phase)
@@ -87,35 +216,11 @@ StandardError {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `planFeature.draftApproved` | `PlanFeatureInput` | proceeds to mermaid phase | happy path | planning-agent (Haiku) spawns sub-planning-agent (Sonnet) with phase=draft_plan; worker researches codebase (optionally via investigation-agent), creates plan file from template; orchestrator reads System Intent section, shows developer via AskUserQuestion |
-| `planFeature.mermaidApproved` | planPath from draft | proceeds to flows phase | happy path | orchestrator spawns sub-planning-agent with phase=mermaid; worker updates diagram section and runs `python3 scripts/mermaid_to_image.py`; orchestrator pushes diagram URL via PushNotification if url is non-null |
-| `planFeature.flowsApproved` | planPath | `PlanFeatureOutput` | happy path | orchestrator iterates each `### Flow:` section one at a time, shows developer, collects feedback if needed, re-spawns sub-planning-agent with phase=flows for updates; returns planPath after all flows approved |
-| `planFeature.phaseRetry` | any phase | revised content | loop | developer provides feedback during any phase; orchestrator re-spawns sub-planning-agent for that phase |
-| `planFeature.error` | `PlanFeatureInput` | `StandardError` | error | sub-planning-agent fails to complete a phase |
-
-### Flow: `approveFeature`
-
-- Core files: `agents/featurework/agents/feature-agent.md`
-
-#### Types
-
-```txt
-ApproveFeatureInput {
-  planPath: string (path to the plan file displayed to the developer)
-}
-
-ApproveFeatureOutput {
-  approved: true
-}
-```
-
-#### Paths
-
-| path | input | output | path-type | notes |
-| --- | --- | --- | --- | --- |
-| `approveFeature.approved` | `ApproveFeatureInput` | `ApproveFeatureOutput` | happy path | developer replies "yes" or "approve" |
-| `approveFeature.feedback` | `ApproveFeatureInput` | feedback string | retry | developer provides revision text; feature-agent loops back to planning-agent |
-| `approveFeature.abort` | `ApproveFeatureInput` | stopped | user abort | developer replies "abort" |
+| `planFeature.draftQuestion` | `FeatureAgentInput{taskDescription}` | `FeatureAgentResult{status:"question", phase:"draft_plan"}` | happy path | feature-agent invokes planning-agent with phase=draft_plan; reads System Intent section from plan; returns question to dark-factory-agent |
+| `planFeature.mermaidQuestion` | answer="Looks good", planPath | `FeatureAgentResult{status:"question", phase:"mermaid"}` | happy path | feature-agent invokes planning-agent with phase=mermaid; pushes diagram URL via PushNotification if url is non-null; returns question to dark-factory-agent |
+| `planFeature.flowQuestion` | answer, planPath, flows-state.json | `FeatureAgentResult{status:"question", phase:"flows"}` | happy path | feature-agent iterates each Flow section one at a time, returning a question per flow; tracks approved flows in flows-state.json |
+| `planFeature.phaseRetry` | answer=feedback text, planPath | revised question for same phase | loop | developer provides feedback during any phase; feature-agent re-invokes planning-agent for that phase with the feedback, then returns another question |
+| `planFeature.error` | `FeatureAgentInput` | `StandardError` | error | sub-planning-agent fails to complete a phase |
 
 ### Flow: `executeFeature`
 
@@ -143,8 +248,8 @@ HardStop {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `executeFeature.success` | `ExecuteFeatureInput` | `ExecuteFeatureOutput` | happy path | skeleton → tests → implementation all pass; tmp checklists deleted |
-| `executeFeature.hard-stop` | `ExecuteFeatureInput` | `HardStop` | paused | implementation-agent encounters unresolvable deviation; developer must edit plan and resume |
+| `executeFeature.success` | `ExecuteFeatureInput` | `FeatureAgentResult{status:"done", planPath}` | happy path | skeleton → tests → implementation all pass; tmp checklists deleted; feature-agent writes brain-patch.json then returns done |
+| `executeFeature.hard-stop` | `ExecuteFeatureInput` | `FeatureAgentResult{status:"hard-stop", reason}` | paused | implementation-agent encounters unresolvable deviation; feature-agent returns hard-stop to dark-factory-agent which runs cleanup |
 | `executeFeature.plan-not-found` | `ExecuteFeatureInput` | `StandardError` | error | plan file does not exist |
 
 #### Pseudocode
@@ -177,10 +282,11 @@ execution-agent(planPath):
 | Source | Location |
 |--------|----------|
 | planning-agent output | docs/plans/<date>-<slug>.md |
+| flows approval state | $DARK_FACTORY_WORK_DIR/flows-state.json (deleted after all flows approved) |
 | test results | Claude Code session transcript |
 | checklists | tmp/files-checklist.md, tmp/flows-checklist.md (deleted on success) |
 
 ## Deployment
 
 - Mechanism: `local only` — invoked as a sub-agent by dark-factory-agent
-- Notes: feature-agent is not user-invocable directly; it is spawned by dark-factory-agent when the task classification is "new feature". The PR is opened by the caller (dark-factory-agent) after update-documentation-agent completes.
+- Notes: feature-agent is not user-invocable directly; it is spawned by dark-factory-agent when the task classification is "new feature". feature-agent does not call AskUserQuestion — it returns structured question objects to dark-factory-agent, which handles all user interaction at depth-2 via AskUserQuestion. The PR is opened by the caller (dark-factory-agent) after update-documentation-agent completes.

--- a/docs/plans/2026-04-27-fix-planning-approval-gates.md
+++ b/docs/plans/2026-04-27-fix-planning-approval-gates.md
@@ -1,0 +1,189 @@
+# Fix Planning Approval Gates
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: `N/A`
+- Depends on: `N/A`
+- Status: `approved`
+
+## System Intent
+
+- What is being built: A return-question protocol so feature-agent (depth-3) can surface questions to the user via dark-factory-agent (depth-2). When feature-agent needs user input it returns `{ status: "question", ... }` instead of calling AskUserQuestion directly. Dark-factory-agent asks the question at depth-2 (where it works), then re-invokes feature-agent with the answer. Feature-agent resumes by reading the plan file — which already exists and tracks exactly which sections have been written — to know where it left off.
+- Primary consumer(s): dark-factory-agent (feature route), developers invoking /dark-factory:manufacture
+- Boundary: feature-agent returns structured question objects; dark-factory-agent owns the re-invoke loop for the feature route. All planning thinking remains in feature-agent/planning-agent. No change to execution-agent, code-review, PR, or cleanup.
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 Flows approved
+- [x] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+    DFA["dark-factory-agent\n(depth-2)"]
+    FA["feature-agent\n(depth-3)"]
+    PA["planning-agent\n(depth-3)"]
+    DEV["Developer"]
+    PF["plan file\n(state anchor)"]
+
+    DFA -->|"invoke feature-agent\n(taskDescription)"| FA
+    FA -->|"calls planning-agent\nfor each phase"| PA
+    PA -->|content written to plan file| PF
+    PF -.->|feature-agent reads\nto know where it is| FA
+
+    FA -->|"{ status: 'question',\nquestion, options, planPath }"| DFA
+    DFA -->|AskUserQuestion| DEV
+    DEV -->|answer| DFA
+    DFA -->|"re-invoke feature-agent\n(answer, planPath)"| FA
+
+    FA -->|"{ status: 'done', planPath }"| DFA
+    DFA -->|continue to\ncode review + PR| DFA
+
+classDef depth2 fill:#ffe58a,stroke:#666,stroke-width:1px;
+classDef depth3 fill:#a8e6a3,stroke:#666,stroke-width:1px;
+
+class DFA depth2;
+class FA,PA depth3;
+```
+
+## Flows
+
+### Global Types
+
+```txt
+FeatureAgentResult =
+  | { status: "question", question: string, options: string[], planPath: string, phase: string }
+  | { status: "done", planPath: string }
+  | { status: "hard-stop", reason: string }
+
+StandardError {
+  message: string
+}
+```
+
+### Flow: `question-return-protocol`
+
+- Test files: `N/A`
+- Core files: `agents/featurework/agents/feature-agent.md`, `agents/dark-factory/agents/dark-factory-agent.md`
+
+#### Types
+
+```txt
+FeatureAgentInput {
+  taskDescription: string       (first invocation)
+  answer: string | null         (re-invocation: user's answer to the question)
+  planPath: string | null       (re-invocation: path to existing plan file)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `question.firstInvoke` | `{ taskDescription, answer: null, planPath: null }` | `FeatureAgentResult{status:"question"}` | happy path | feature-agent runs draft_plan phase, hits first approval gate, returns question |
+| `question.reInvoke` | `{ answer, planPath }` | `FeatureAgentResult{status:"question"}` | happy path | feature-agent reads planPath to know current phase, applies answer, continues to next gate, returns next question |
+| `question.done` | `{ answer, planPath }` (last flow approved) | `FeatureAgentResult{status:"done", planPath}` | happy path | all phases approved and execution-agent complete |
+| `question.hardStop` | execution-agent hard-stop | `FeatureAgentResult{status:"hard-stop", reason}` | error | report to developer and stop |
+
+#### Pseudocode
+
+```
+# feature-agent — updated logic
+
+Input: taskDescription, answer (may be null), planPath (may be null)
+
+# Determine resume point by reading plan file
+if planPath exists:
+  read planPath
+  determine current phase from Stage Gate Tracker checkboxes:
+    - if "Stage 1 Mermaid approved" unchecked → phase = "mermaid" (apply answer, continue)
+    - if "Stage 2 Flows approved" unchecked → phase = "flows" (apply answer, continue)
+    - if all gates checked → phase = "execution"
+else:
+  phase = "draft_plan"
+
+# Run the phase
+if phase == "draft_plan":
+  invoke planning-agent(phase="draft_plan", feedback=taskDescription)
+  receive { planPath }
+  RETURN { status: "question", question: "<System Intent section>", options: ["Approve — continue to Mermaid", "Request Changes"], planPath, phase: "draft_plan" }
+
+if phase == "mermaid":
+  if answer == "Request Changes" or feedback provided:
+    invoke planning-agent(phase="mermaid", planPath, feedback=answer)
+  else:
+    invoke planning-agent(phase="mermaid", planPath, feedback="none")
+  receive { planPath, url }
+  RETURN { status: "question", question: "<Mermaid section + url>", options: ["Approve — continue to flows", "Request Changes"], planPath, phase: "mermaid" }
+
+if phase == "flows":
+  # find next unapproved flow
+  # apply answer to current flow if feedback given
+  # if all flows approved → proceed to execution
+  ...
+  RETURN { status: "question", ... } or proceed to execution
+
+if phase == "execution":
+  invoke execution-agent(planPath)
+  if hardStop: RETURN { status: "hard-stop", reason }
+  write brain-patch.json { planFilePath: planPath }
+  RETURN { status: "done", planPath }
+```
+
+### Flow: `dark-factory-agent-reinvoke-loop`
+
+- Test files: `N/A`
+- Core files: `agents/dark-factory/agents/dark-factory-agent.md`
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `loop.question` | `FeatureAgentResult{status:"question"}` | AskUserQuestion → re-invoke | happy path | DFA asks question at depth-2, re-invokes feature-agent with answer |
+| `loop.done` | `FeatureAgentResult{status:"done"}` | continue to Step 4 (code review) | happy path | planning + execution complete |
+| `loop.hardStop` | `FeatureAgentResult{status:"hard-stop"}` | report + cleanup + STOP | error | surface reason to developer |
+
+#### Pseudocode
+
+```
+# dark-factory-agent — feature route (Step 3)
+
+result = invoke feature-agent({ taskDescription, answer: null, planPath: null })
+
+LOOP:
+  if result.status == "done":
+    planFilePath = result.planPath
+    BREAK  # proceed to Step 4 (code review)
+
+  if result.status == "hard-stop":
+    cleanup(WORK_DIR)
+    report "Hard stop: " + result.reason
+    STOP
+
+  if result.status == "question":
+    AskUserQuestion(result.question, result.options)
+    answer = developer response
+    result = invoke feature-agent({ answer, planPath: result.planPath, taskDescription: null })
+    CONTINUE LOOP
+```
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| feature-agent phase detection | Claude Code session transcript |
+| planning-agent calls | Claude Code session transcript |
+| question/answer relay | Claude Code session transcript |
+| plan file (state anchor) | `docs/plans/<date>-<slug>.md` |
+
+## Deployment
+
+- Mechanism: `local only`
+- Changes:
+  - Modify `agents/featurework/agents/feature-agent.md` — replace AskUserQuestion calls with return-question protocol; add resume-from-plan-file logic
+  - Modify `agents/dark-factory/agents/dark-factory-agent.md` — replace "invoke feature-agent" with re-invoke loop
+- Deploy command: none — agent .md files take effect immediately
+

--- a/skills/iterative-plan-approval-gate/SKILL.md
+++ b/skills/iterative-plan-approval-gate/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: iterative-plan-approval-gate
-description: "Implements a human approval gate for a plan file: opens it in VS Code, displays it inline, sends a PushNotification, then loops on developer feedback until explicit approval or abort."
+description: "Implements human approval gates for a plan file: either a single gate for the full document, or a cascading section-by-section gate (draft → diagram → per-flow → final) driven by a depth-2 orchestrator."
 user-invocable: false
 ---
 ## When to use
 
 Use this pattern whenever an orchestration agent must block on developer approval of a written artifact (plan file, config, spec) before proceeding to an irreversible action such as code generation or deployment.
 
-## Steps
+There are two variants:
+
+- **Single-gate** — present the full artifact once and loop on feedback until approval or abort. Use when the artifact is small or has only one logical section.
+- **Section-by-section cascade** — present each section of the artifact separately, looping on feedback per section, then do a final full-plan confirmation before execution. Use when the artifact has multiple independently reviewable sections (e.g., System Intent, Mermaid diagram, per-flow pseudocode). This variant was introduced to surface planning approval gates to the human when a sub-planning-agent operates at depth-3 and cannot call AskUserQuestion directly.
+
+## Single-gate Steps
 
 1. After receiving a `planPath` from the upstream agent (e.g. `planning-agent`):
 
@@ -34,6 +39,62 @@ Use this pattern whenever an orchestration agent must block on developer approva
    - `"yes"` or `"approve"` — break out of the loop and proceed to the next stage.
    - Anything else — treat as revision feedback: re-invoke the upstream planning agent with the feedback text, receive the new `planPath`, then return to step 1.
 
+## Section-by-section Cascade Steps
+
+This variant is used when a worker sub-agent (depth-3) builds the plan incrementally, one section per invocation, and the orchestrator (depth-2) owns all AskUserQuestion calls.
+
+1. **Phase: Draft / System Intent**
+
+   a. Invoke the planning sub-agent with `phase="draft_plan"` and the original task description as feedback.
+
+   b. Receive `planPath` from the sub-agent.
+
+   c. Read `planPath` and extract the `## System Intent` section.
+
+   d. Call `PushNotification` with title `"Draft Plan Ready"`.
+
+   e. Use `AskUserQuestion` with options `["Looks good — continue to Mermaid diagram", "Request Changes"]`.
+
+   f. If `"Request Changes"`: use the developer's typed feedback as the new feedback value and repeat step a. Otherwise break.
+
+2. **Phase: Mermaid Diagram**
+
+   a. Invoke the planning sub-agent with `phase="mermaid"`, the existing `planPath`, and `feedback="none"` (or developer feedback on retry).
+
+   b. Receive `{ planPath, url }`. If `url` is non-null, push a notification with the diagram URL.
+
+   c. Read `planPath` and extract the `## Mermaid Diagram` section. If `url` is null, note in the question text that rendering failed.
+
+   d. Use `AskUserQuestion` with options `["Approve — continue to flows", "Request Changes"]`.
+
+   e. If `"Request Changes"`: capture feedback and repeat step a. Otherwise break.
+
+3. **Phase: Flows (one at a time)**
+
+   a. Read `planPath` and scan for `### Flow:` headings to get an ordered list of flow names.
+
+   b. For each `flowName`:
+
+      i. First pass: read and display the existing `### Flow: <flowName>` section directly from `planPath` (no sub-agent call needed unless feedback was given).
+
+      ii. Use `AskUserQuestion` with options `["Approve — continue to next flow", "Request Changes"]`.
+
+      iii. If `"Request Changes"`: invoke the planning sub-agent with `phase="flows"`, `planPath`, `feedback=<developer text>`, `flowName=<flowName>`. Re-read the updated section and repeat step ii.
+
+      iv. On approval: advance to the next flow.
+
+4. **Final full-plan confirmation**
+
+   a. Invoke `open-in-vscode` skill with `planPath`.
+
+   b. Read and display the full plan file.
+
+   c. Call `PushNotification` with title `"Plan Approval Required"` and message `"All sections approved. Final plan review required before implementation begins."`.
+
+   d. Use `AskUserQuestion` with options `["Approve — start implementation", "Abort"]`.
+
+   e. If `"Abort"`: report and STOP. Otherwise proceed to execution.
+
 ## Notes
 
 - **Lowercase normalization is required.** Without it, replies like "Yes", "YES", or "Approve" will fall through to the feedback branch and trigger an unintended plan revision loop.
@@ -41,3 +102,5 @@ Use this pattern whenever an orchestration agent must block on developer approva
 - **Double-open is intentional.** The upstream planning agent already calls `open-in-vscode` when it writes the plan. The orchestrating agent calls it again here as a belt-and-suspenders guarantee — if the planning agent's call was skipped or failed, the file still opens for the developer.
 - **Keep the original description across retries.** When passing feedback to the planning agent, always include the original feature description alongside the feedback so the planner has full context: `"Revise the plan based on this feedback: <feedback>\n\nOriginal description: <description>"`.
 - The `abort` path is an expected (non-error) exit — report it cleanly to the developer and stop; do not propagate as an exception.
+- **Section-by-section variant: do not re-invoke the sub-agent for the first pass of each flow.** The sub-agent already wrote the flow section when it built the plan. Only call the sub-agent again when the developer has provided feedback for that specific flow. This avoids redundant work and prevents unintended section rewrites.
+- **Section-by-section variant: all AskUserQuestion calls must live in the depth-2 orchestrator.** The depth-3 planning sub-agent must be a pure phase-delegator with no user interaction. See the `askuserquestion-depth-limit` skill for why depth-3 AskUserQuestion calls are silently auto-answered and never reach the human.


### PR DESCRIPTION
## Description

# Fix Planning Approval Gates

## Plan Metadata

- Plan type: `plan`
- Parent plan: `N/A`
- Depends on: `N/A`
- Status: `approved`

## System Intent

- What is being built: A return-question protocol so feature-agent (depth-3) can surface questions to the user via dark-factory-agent (depth-2). When feature-agent needs user input it returns `{ status: "question", ... }` instead of calling AskUserQuestion directly. Dark-factory-agent asks the question at depth-2 (where it works), then re-invokes feature-agent with the answer. Feature-agent resumes by reading the plan file — which already exists and tracks exactly which sections have been written — to know where it left off.
- Primary consumer(s): dark-factory-agent (feature route), developers invoking /dark-factory:manufacture
- Boundary: feature-agent returns structured question objects; dark-factory-agent owns the re-invoke loop for the feature route. All planning thinking remains in feature-agent/planning-agent. No change to execution-agent, code-review, PR, or cleanup.

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [x] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

```mermaid
flowchart TD
    DFA["dark-factory-agent\n(depth-2)"]
    FA["feature-agent\n(depth-3)"]
    PA["planning-agent\n(depth-3)"]
    DEV["Developer"]
    PF["plan file\n(state anchor)"]

    DFA -->|"invoke feature-agent\n(taskDescription)"| FA
    FA -->|"calls planning-agent\nfor each phase"| PA
    PA -->|content written to plan file| PF
    PF -.->|feature-agent reads\nto know where it is| FA

    FA -->|"{ status: 'question',\nquestion, options, planPath }"| DFA
    DFA -->|AskUserQuestion| DEV
    DEV -->|answer| DFA
    DFA -->|"re-invoke feature-agent\n(answer, planPath)"| FA

    FA -->|"{ status: 'done', planPath }"| DFA
    DFA -->|continue to\ncode review + PR| DFA

classDef depth2 fill:#ffe58a,stroke:#666,stroke-width:1px;
classDef depth3 fill:#a8e6a3,stroke:#666,stroke-width:1px;

class DFA depth2;
class FA,PA depth3;
```

## Flows

### Global Types

```txt
FeatureAgentResult =
  | { status: "question", question: string, options: string[], planPath: string, phase: string }
  | { status: "done", planPath: string }
  | { status: "hard-stop", reason: string }

StandardError {
  message: string
}
```

### Flow: `question-return-protocol`

- Test files: `N/A`
- Core files: `agents/featurework/agents/feature-agent.md`, `agents/dark-factory/agents/dark-factory-agent.md`

#### Types

```txt
FeatureAgentInput {
  taskDescription: string       (first invocation)
  answer: string | null         (re-invocation: user's answer to the question)
  planPath: string | null       (re-invocation: path to existing plan file)
}
```

#### Paths

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `question.firstInvoke` | `{ taskDescription, answer: null, planPath: null }` | `FeatureAgentResult{status:"question"}` | happy path | feature-agent runs draft_plan phase, hits first approval gate, returns question |
| `question.reInvoke` | `{ answer, planPath }` | `FeatureAgentResult{status:"question"}` | happy path | feature-agent reads planPath to know current phase, applies answer, continues to next gate, returns next question |
| `question.done` | `{ answer, planPath }` (last flow approved) | `FeatureAgentResult{status:"done", planPath}` | happy path | all phases approved and execution-agent complete |
| `question.hardStop` | execution-agent hard-stop | `FeatureAgentResult{status:"hard-stop", reason}` | error | report to developer and stop |

#### Pseudocode

```
# feature-agent updated logic

Input: taskDescription, answer (may be null), planPath (may be null)

# Determine resume point by reading plan file
if planPath exists:
  read planPath
  determine current phase from Stage Gate Tracker checkboxes:
    - if "Stage 1 Mermaid approved" unchecked → phase = "mermaid" (apply answer, continue)
    - if "Stage 2 Flows approved" unchecked → phase = "flows" (apply answer, continue)
    - if all gates checked → phase = "execution"
else:
  phase = "draft_plan"

# Run the phase
if phase == "draft_plan":
  invoke planning-agent(phase="draft_plan", feedback=taskDescription)
  receive { planPath }
  RETURN { status: "question", question: "<System Intent section>", options: ["Approve — continue to Mermaid", "Request Changes"], planPath, phase: "draft_plan" }

if phase == "mermaid":
  if answer == "Request Changes" or feedback provided:
    invoke planning-agent(phase="mermaid", planPath, feedback=answer)
  else:
    invoke planning-agent(phase="mermaid", planPath, feedback="none")
  receive { planPath, url }
  RETURN { status: "question", question: "<Mermaid section + url>", options: ["Approve — continue to flows", "Request Changes"], planPath, phase: "mermaid" }

if phase == "flows":
  # find next unapproved flow
  # apply answer to current flow if feedback given
  # if all flows approved -> proceed to execution
  RETURN { status: "question", ... } or proceed to execution

if phase == "execution":
  invoke execution-agent(planPath)
  if hardStop: RETURN { status: "hard-stop", reason }
  write brain-patch.json { planFilePath: planPath }
  RETURN { status: "done", planPath }
```

### Flow: `dark-factory-agent-reinvoke-loop`

- Test files: `N/A`
- Core files: `agents/dark-factory/agents/dark-factory-agent.md`

#### Paths

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `loop.question` | `FeatureAgentResult{status:"question"}` | AskUserQuestion -> re-invoke | happy path | DFA asks question at depth-2, re-invokes feature-agent with answer |
| `loop.done` | `FeatureAgentResult{status:"done"}` | continue to Step 4 (code review) | happy path | planning + execution complete |
| `loop.hardStop` | `FeatureAgentResult{status:"hard-stop"}` | report + cleanup + STOP | error | surface reason to developer |

#### Pseudocode

```
# dark-factory-agent feature route (Step 3)

result = invoke feature-agent({ taskDescription, answer: null, planPath: null })

LOOP:
  if result.status == "done":
    planFilePath = result.planPath
    BREAK  # proceed to Step 4 (code review)

  if result.status == "hard-stop":
    cleanup(WORK_DIR)
    report "Hard stop: " + result.reason
    STOP

  if result.status == "question":
    AskUserQuestion(result.question, result.options)
    answer = developer response
    result = invoke feature-agent({ answer, planPath: result.planPath, taskDescription: null })
    CONTINUE LOOP
```

## Logs

| Source | Location |
|--------|----------|
| feature-agent phase detection | Claude Code session transcript |
| planning-agent calls | Claude Code session transcript |
| question/answer relay | Claude Code session transcript |
| plan file (state anchor) | `docs/plans/<date>-<slug>.md` |

## Deployment

- Mechanism: `local only`
- Changes:
  - Modify `agents/featurework/agents/feature-agent.md` — replace AskUserQuestion calls with return-question protocol; add resume-from-plan-file logic
  - Modify `agents/dark-factory/agents/dark-factory-agent.md` — replace "invoke feature-agent" with re-invoke loop
- Deploy command: none — agent .md files take effect immediately

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
