### PR TITLE
fix(sub-planning-agent): always return mermaid URL with SKIP_VALIDATE and inline fallback

### DIFF
--- a/agents/featurework/planning/agents/sub-planning-agent.md
+++ b/agents/featurework/planning/agents/sub-planning-agent.md
@@ -46,11 +46,18 @@ When `phase == "mermaid"`:
 
 1. Read the plan file at `planPath`.
 2. If `feedback` is not "none": apply the changes indicated by `feedback` to the Mermaid diagram section and write the updated plan file.
-3. Run the mermaid image script:
+3. Run the mermaid image script with validation skipped so the URL is always generated:
    ```bash
-   python3 scripts/mermaid_to_image.py <planPath>
+   MERMAID_SKIP_VALIDATE=1 python3 scripts/mermaid_to_image.py <planPath>
    ```
-   Capture stdout as `url`. If the script exits with a non-zero exit code, produces no output, or produces only whitespace, set `url = null`. Do not treat stderr output as a failure on its own — check the exit code.
+   Capture stdout as `url`. If the script exits with a non-zero exit code, produces no output, or produces only whitespace, fall back to generating the URL inline:
+   ```python
+   import base64
+   # extract the raw mermaid diagram text from the plan file (content between ```mermaid and ```)
+   encoded = base64.urlsafe_b64encode(mermaid_string.encode("utf-8")).decode("utf-8")
+   url = f"https://mermaid.ink/img/{encoded}"
+   ```
+   Only set `url = null` if both the script and the inline fallback fail (e.g., no mermaid block found in the plan). Do not treat stderr output as a failure on its own — check the exit code.
 5. Return:
    ```json
    {

--- a/brain.json
+++ b/brain.json
@@ -1,7 +1,7 @@
 {
-  "taskDescription": "let's delete the init command and the workflow for it.  I would rather have the docs get written as the agent learns then the other way around.",
-  "taskName": "delete-init-command",
-  "workDir": "/home/lewibs/github/dark_factory/dark_factory-delete-init-command",
+  "taskDescription": "The planning agent doesn't always return a URL for the mermaid diagram whenever it's in the mermaid phase. can you please make sure that's still always occurs. favor that over opening VS code because it's nice to look at the image",
+  "taskName": "mermaid-url-always",
+  "workDir": "/home/lewibs/github/dark_factory/dark_factory-mermaid-url-always",
   "projectDir": "/home/lewibs/github/dark_factory/dark_factory",
   "classification": "repair",
   "planFilePath": null,
@@ -27,13 +27,13 @@
   },
   "metrics": {
     "dark-factory:repair:agents:repair-agent": {
-      "start_ms": 1777352141800
+      "start_ms": 1777357917852
     },
     "testing-agent": {
-      "start_ms": 1777352166097
+      "start_ms": 1777357950756
     },
     "planning-agent": {
-      "start_ms": 1777352166816
+      "start_ms": 1777357951015
     }
   }
 }

--- a/docs/docs/mermaid-to-image.md
+++ b/docs/docs/mermaid-to-image.md
@@ -114,6 +114,51 @@ generate_mermaid_ink_url(mermaid_string: str) -> str:
 
 ---
 
+### Flow: `validateMermaidSyntax`
+
+- Test files: `N/A`
+- Core files: `scripts/mermaid_to_image.py`
+
+#### Types
+
+```txt
+ValidateInput {
+  mermaid_string: string   (raw Mermaid diagram text)
+}
+
+ValidateOutput {
+  is_valid: bool
+  error: string            (empty string on success; error message from mmdc on failure)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `validateMermaidSyntax.valid` | `ValidateInput` (syntactically correct mermaid) | `ValidateOutput{is_valid=true, error=""}` | `happy path` | mmdc exits 0; diagram is valid |
+| `validateMermaidSyntax.invalid` | `ValidateInput` (bad mermaid syntax) | `ValidateOutput{is_valid=false, error=<mmdc stderr>}` | `error` | mmdc exits non-zero; error contains mmdc stderr/stdout |
+| `validateMermaidSyntax.timeout` | `ValidateInput` (mmdc hangs >60s) | `ValidateOutput{is_valid=false, error="mmdc timed out"}` | `error` | subprocess timeout |
+| `validateMermaidSyntax.npx-missing` | mmdc/npx not installed | `ValidateOutput{is_valid=false, error="npx not found — cannot validate mermaid syntax"}` | `error` | FileNotFoundError from subprocess |
+
+#### Pseudocode
+
+```
+validate_mermaid_syntax(mermaid_string: str) -> (bool, str):
+  write mermaid_string to tmp .mmd file
+  write puppeteer config json to tmp .json file
+  run: npx --yes @mermaid-js/mermaid-cli -i <tmp_in> -o <tmp_out> -p <tmp_cfg> --quiet (timeout=60s)
+  if returncode != 0: return False, stderr or stdout
+  return True, ""
+  # always clean up tmp files in finally block
+```
+
+#### Notes
+
+This flow is only invoked by `cliEntryPoint` when the `MERMAID_SKIP_VALIDATE` environment variable is not set. When `MERMAID_SKIP_VALIDATE=1` is set, this flow is bypassed entirely and the URL is always generated from the extracted mermaid block.
+
+---
+
 ### Flow: `cliEntryPoint`
 
 - Test files: `tests/test_mermaid_to_image.py`
@@ -136,11 +181,13 @@ CliOutput {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `cliEntryPoint.success-default` | valid plan file path, no `--block` arg | URL printed to stdout, exit 0 | `happy path` | defaults to block 1; extract + URL generation succeed |
+| `cliEntryPoint.success-default` | valid plan file path, no `--block` arg | URL printed to stdout, exit 0 | `happy path` | defaults to block 1; extract + URL generation succeed; validation skipped if `MERMAID_SKIP_VALIDATE=1` |
 | `cliEntryPoint.success-block-n` | valid plan file path, `--block N` | URL printed to stdout, exit 0 | `happy path` | extracts Nth block; URL printed |
+| `cliEntryPoint.skip-validate` | valid plan file path, `MERMAID_SKIP_VALIDATE=1` set | URL printed to stdout, exit 0 | `happy path` | mmdc validation step is bypassed entirely; URL always generated if mermaid block exists |
 | `cliEntryPoint.no-block` | plan file with no mermaid block | error message to stderr, exit 1 | `error` | ValueError from extractMermaidFromPlan |
 | `cliEntryPoint.index-out-of-range` | plan file, block_index > number of blocks | error message to stderr, exit 1 | `error` | ValueError from extractMermaidFromPlan |
 | `cliEntryPoint.file-missing` | non-existent file path | error message to stderr, exit 1 | `error` | FileNotFoundError from extractMermaidFromPlan |
+| `cliEntryPoint.validation-failure` | valid plan file, mermaid syntax invalid, `MERMAID_SKIP_VALIDATE` not set | error message to stderr, exit 1 | `error` | mmdc validation reports failure; URL not generated |
 
 #### Pseudocode
 
@@ -150,6 +197,11 @@ cli (argparse):
   arg: --block (type=int; default=1)
   try:
     mermaid_string = extract_mermaid_from_plan(plan_file_path, block_index)
+    if not MERMAID_SKIP_VALIDATE env var:
+      valid, err = validate_mermaid_syntax(mermaid_string)
+      if not valid:
+        print(f"Error: mermaid diagram failed validation: {err}", file=sys.stderr)
+        sys.exit(1)
     url = generate_mermaid_ink_url(mermaid_string)
     print(url)
     sys.exit(0)
@@ -178,20 +230,26 @@ PlanningAgentUrlStep {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `planningAgentPushesUrl.success` | plan written with mermaid block | PushNotification with tappable URL sent | `happy path` | After writing plan, agent calls script; URL pushed to phone |
-| `planningAgentPushesUrl.no-mermaid` | plan has no mermaid block | skip URL step, continue | `branch` | If no mermaid block exists, skip silently |
-| `planningAgentPushesUrl.script-failure` | script exits non-zero | log warning, continue without URL | `branch` | Does not block plan approval gate |
+| `planningAgentPushesUrl.success` | plan written with mermaid block | PushNotification with tappable URL sent | `happy path` | sub-planning-agent calls script with `MERMAID_SKIP_VALIDATE=1`; URL always generated if mermaid block exists; pushed to phone |
+| `planningAgentPushesUrl.inline-fallback` | script exits non-zero but mermaid block exists | PushNotification with inline-generated URL sent | `happy path` | sub-planning-agent generates URL via inline Python base64 fallback; URL pushed to phone |
+| `planningAgentPushesUrl.no-mermaid` | plan has no mermaid block and fallback also fails | skip URL step, continue | `branch` | url = null; does not block plan approval gate |
 
 #### Pseudocode
 
 ```
-planning-agent (after writing plan file and invoking open-in-vscode):
-  run: python3 scripts/mermaid_to_image.py <plan_file_path>
+sub-planning-agent (mermaid phase — URL generation):
+  run: MERMAID_SKIP_VALIDATE=1 python3 scripts/mermaid_to_image.py <plan_file_path>
   capture stdout as url
-  if exit code == 0 and url is non-empty:
-    call PushNotification with message: "Plan diagram: <url>"
-  else:
-    log warning — skip URL push, continue to approval gate
+  if exit_code != 0 or url is empty/whitespace:
+    # inline Python fallback
+    extract mermaid_string from plan file
+    if mermaid_string found:
+      encoded = base64.urlsafe_b64encode(mermaid_string.encode("utf-8")).decode("utf-8")
+      url = f"https://mermaid.ink/img/{encoded}"
+    else:
+      url = null
+  return url in SubPlanningAgentOutput
+  # orchestrator (planning-agent) pushes url via PushNotification if url is non-null
 ```
 
 ---

--- a/docs/docs/sub-planning-agent.md
+++ b/docs/docs/sub-planning-agent.md
@@ -113,8 +113,8 @@ SubPlanningAgentOutput {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `mermaidPhase.success` | `SubPlanningAgentInput (phase=mermaid)` | `SubPlanningAgentOutput (url=non-null)` | happy path | applies feedback to Mermaid Diagram section if feedback != "none"; runs `python3 scripts/mermaid_to_image.py <planPath>`; captures stdout as url |
-| `mermaidPhase.noUrl` | `SubPlanningAgentInput (phase=mermaid)` | `SubPlanningAgentOutput (url=null)` | graceful degradation | script exits non-zero, produces no output, or produces only whitespace; url = null; sub-agent still returns success |
+| `mermaidPhase.success` | `SubPlanningAgentInput (phase=mermaid)` | `SubPlanningAgentOutput (url=non-null)` | happy path | applies feedback to Mermaid Diagram section if feedback != "none"; runs script with `MERMAID_SKIP_VALIDATE=1`; captures stdout as url; falls back to inline base64 Python if script fails |
+| `mermaidPhase.noUrl` | `SubPlanningAgentInput (phase=mermaid)` | `SubPlanningAgentOutput (url=null)` | graceful degradation | both script and inline fallback fail (e.g., no mermaid block in plan); url = null |
 | `mermaidPhase.noFeedback` | `SubPlanningAgentInput (feedback="none")` | `SubPlanningAgentOutput` | happy path | skips diagram edit, only runs script and returns url |
 
 #### Pseudocode
@@ -125,9 +125,16 @@ sub-planning-agent (phase=mermaid):
   if feedback != "none":
     apply feedback changes to ## Mermaid Diagram section
     write updated plan file
-  run: python3 scripts/mermaid_to_image.py <planPath>
+  run: MERMAID_SKIP_VALIDATE=1 python3 scripts/mermaid_to_image.py <planPath>
   capture stdout as url
-  if exit_code != 0 or url is empty/whitespace: url = null
+  if exit_code != 0 or url is empty/whitespace:
+    # inline Python fallback
+    extract mermaid_string from plan file (content between ```mermaid and ```)
+    if mermaid_string found:
+      encoded = base64.urlsafe_b64encode(mermaid_string.encode("utf-8")).decode("utf-8")
+      url = f"https://mermaid.ink/img/{encoded}"
+    else:
+      url = null
   return { planPath, url, summary }
 ```
 

--- a/skills/generate-mermaid-ink-url/SKILL.md
+++ b/skills/generate-mermaid-ink-url/SKILL.md
@@ -29,3 +29,25 @@ When you need to share or display a Mermaid diagram as an image URL — for exam
 - The script at `scripts/mermaid_to_image.py` implements this pattern; import or call it rather than re-implementing inline.
 - `mermaid.ink` is treated as an external black box — do not depend on its availability for correctness tests; unit tests should only assert the URL structure (`startswith("https://mermaid.ink/img/")`).
 - Padding characters (`=`) from base64 output are harmless in the URL for `mermaid.ink`, but if a future service requires padding-free encoding, strip them with `.rstrip("=")`.
+
+## Calling the script from agents
+
+When invoking `scripts/mermaid_to_image.py` from an agent (e.g. sub-planning-agent), always set `MERMAID_SKIP_VALIDATE=1`:
+
+```bash
+MERMAID_SKIP_VALIDATE=1 python3 scripts/mermaid_to_image.py <planPath>
+```
+
+**Why:** By default the script calls `mmdc` (via `npx @mermaid-js/mermaid-cli`) to validate syntax before generating the URL. In agent/CI environments `npx` may be unavailable or slow, causing the script to exit non-zero even though the diagram content is valid and the URL could be generated. `MERMAID_SKIP_VALIDATE=1` bypasses this validation step and proceeds directly to URL generation.
+
+## Inline fallback if the script fails
+
+If the script exits non-zero or produces no output even with `MERMAID_SKIP_VALIDATE=1`, fall back to generating the URL inline using Python. Extract the raw mermaid diagram text from the plan file (content between ` ```mermaid ` and the closing ` ``` `), then:
+
+```python
+import base64
+encoded = base64.urlsafe_b64encode(mermaid_string.encode("utf-8")).decode("utf-8")
+url = f"https://mermaid.ink/img/{encoded}"
+```
+
+Only set `url = null` if both the script and the inline fallback fail (e.g., no mermaid block is found in the plan file).


### PR DESCRIPTION
## Description

Fix: ensure mermaid diagram URL is always returned in sub-planning-agent mermaid phase. Added MERMAID_SKIP_VALIDATE=1 flag and Python base64 inline fallback so URL generation never silently fails when npx/mmdc is unavailable.

## Test Plan

```
$ python3 -m pytest tests/ -v
...
FAILED tests/test_generate_checklist.py::test_pre_hook_injects_checklist_no_brain
FAILED tests/test_hooks.py::TestPreHookInjectsBrainState::test_inject_no_brain
FAILED tests/test_planning_approval_gate.py::TestPlanningApprovalGateOwnership::test_feature_agent_declares_ask_user_question_in_tools
FAILED tests/test_planning_approval_gate.py::TestPlanningApprovalGateOwnership::test_feature_agent_has_final_plan_approval_gate
========================= 4 failed, 83 passed in 1.21s =========================
```

Note: the 4 failing tests are pre-existing failures unrelated to this change (they concern feature-agent AskUserQuestion tooling and hook brain state, not mermaid URL generation).

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
