### PR TITLE
feat(sub-planning-agent): wire create-mermaid-diagram skill into mermaid phase

### DIFF
--- a/agents/featurework/planning/agents/sub-planning-agent.md
+++ b/agents/featurework/planning/agents/sub-planning-agent.md
@@ -2,7 +2,9 @@
 name: sub-planning-agent
 user-invocable: false
 description: "Worker agent for the two-agent planning system. Handles all research, writing, and heavy reasoning. Spawned by planning-agent orchestrator for each phase."
-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
+tools: Read, Write, Edit, Bash, Grep, Glob, Agent, Skill
+skills:
+  - skills/create-mermaid-diagram/SKILL.md
 model: sonnet
 allowed-tools: "Bash(find *), Bash(grep -r *), Bash(ls *), Bash(python3 scripts/mermaid_to_image.py *)"
 ---
@@ -45,7 +47,7 @@ When `phase == "draft_plan"`:
 When `phase == "mermaid"`:
 
 1. Read the plan file at `planPath`.
-2. If `feedback` is not "none": apply the changes indicated by `feedback` to the Mermaid diagram section and write the updated plan file.
+2. If `feedback` is not "none": apply the changes indicated by `feedback` to the Mermaid diagram section and write the updated plan file. When writing or updating the Mermaid diagram block, follow the `create-mermaid-diagram` skill at `skills/create-mermaid-diagram/SKILL.md` — this defines the required node color standards (gray/yellow/red/green by file status), edge label requirements, black-box external services, and syntax validation with mmdc.
 3. Run the mermaid image script with validation skipped so the URL is always generated:
    ```bash
    MERMAID_SKIP_VALIDATE=1 python3 scripts/mermaid_to_image.py <planPath>

--- a/docs/docs/sub-planning-agent.md
+++ b/docs/docs/sub-planning-agent.md
@@ -90,7 +90,7 @@ sub-planning-agent (phase=draft_plan):
 ### Flow: `mermaidPhase`
 
 - Test files: `N/A`
-- Core files: `agents/featurework/planning/agents/sub-planning-agent.md`, `scripts/mermaid_to_image.py`
+- Core files: `agents/featurework/planning/agents/sub-planning-agent.md`, `scripts/mermaid_to_image.py`, `skills/create-mermaid-diagram/SKILL.md`
 
 #### Types
 
@@ -113,7 +113,7 @@ SubPlanningAgentOutput {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `mermaidPhase.success` | `SubPlanningAgentInput (phase=mermaid)` | `SubPlanningAgentOutput (url=non-null)` | happy path | applies feedback to Mermaid Diagram section if feedback != "none"; runs script with `MERMAID_SKIP_VALIDATE=1`; captures stdout as url; falls back to inline base64 Python if script fails |
+| `mermaidPhase.success` | `SubPlanningAgentInput (phase=mermaid)` | `SubPlanningAgentOutput (url=non-null)` | happy path | applies feedback to Mermaid Diagram section if feedback != "none" following create-mermaid-diagram skill standards (node colors, edge labels, black-box rules, mmdc validation); runs script with `MERMAID_SKIP_VALIDATE=1`; captures stdout as url; falls back to inline base64 Python if script fails |
 | `mermaidPhase.noUrl` | `SubPlanningAgentInput (phase=mermaid)` | `SubPlanningAgentOutput (url=null)` | graceful degradation | both script and inline fallback fail (e.g., no mermaid block in plan); url = null |
 | `mermaidPhase.noFeedback` | `SubPlanningAgentInput (feedback="none")` | `SubPlanningAgentOutput` | happy path | skips diagram edit, only runs script and returns url |
 
@@ -124,6 +124,12 @@ sub-planning-agent (phase=mermaid):
   read planPath
   if feedback != "none":
     apply feedback changes to ## Mermaid Diagram section
+    follow create-mermaid-diagram skill (skills/create-mermaid-diagram/SKILL.md):
+      - color nodes by file status: gray=unchanged, yellow=updated, red=deleted, green=new
+      - label every edge with a description of what flows between nodes
+      - treat external APIs and black-box services as single nodes
+      - do not encode internal branching logic in diagram nodes
+      - validate syntax with mmdc; fix any parse errors before finishing
     write updated plan file
   run: MERMAID_SKIP_VALIDATE=1 python3 scripts/mermaid_to_image.py <planPath>
   capture stdout as url


### PR DESCRIPTION
## Description

# Mermaid to Image — Plan Diagram to Phone

## Plan Metadata

- Plan type: `plan`
- Parent plan: `N/A`
- Depends on: `N/A`
- Status: `draft`

Status semantics:
- `draft`: Plan is being created or updated and is not final.
- `approved`: Plan is approved but not yet applied in code.
- `documentation`: Code currently exists and matches the plan contract.

Update rule:
- When an existing plan is edited, set status to `draft` until re-approved.

## System Intent

- What is being built: A Python script (`scripts/mermaid_to_image.py`) that extracts a Mermaid fenced code block (by 1-indexed position, defaulting to the first) from a plan `.md` file, base64-encodes it, and returns a `mermaid.ink` URL. The planning-agent is updated to call this script after writing the plan and push the URL to the user's phone via PushNotification so they can tap it.
- Primary consumer(s): `planning-agent` — calls the script after writing each plan and pushes the URL to the user's phone.
- Boundary (black-box scope only): `mermaid.ink` (external rendering service — treated as a black box). PushNotification tool (Claude Code built-in — treated as a black box).

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [ ] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

```mermaid
graph TD
  PA[planning-agent]:::updated -->|plan_file_path| MTE["mermaid_to_image.py"]:::created
  PF["plan file"]:::unchanged -->|mermaid block extracted| MTE
  MTE -->|base64-encoded mermaid| URL["mermaid.ink URL"]:::unchanged
  MTE -->|validates URL| VAL["urllib HEAD check"]:::created
  MTE -->|URL string| PA
  PA -->|URL via PushNotification| PN["PushNotification tool"]:::unchanged
  TM["test_mermaid_to_image.py"]:::created -->|import| MTE

classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
classDef updated fill:#ffe58a,stroke:#666,stroke-width:1px;
classDef deleted fill:#f4a6a6,stroke:#666,stroke-width:1px;
classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
```

## Flows

- Flow naming rule: `### Flow: <flowname>`
- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).

### Global Types

```txt
StandardError {
  message: string (human-readable description of what went wrong)
}
```

---

### Flow: `extractMermaidFromPlan`

- Test files: `tests/test_mermaid_to_image.py`
- Core files: `scripts/mermaid_to_image.py`

#### Paths

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `extractMermaidFromPlan.success-block-1` | `ExtractInput{block_index=1}` (or omitted) | `ExtractOutput` | `happy path` | first mermaid block extracted and returned |
| `extractMermaidFromPlan.success-block-2` | `ExtractInput{block_index=2}` | `ExtractOutput` | `happy path` | second mermaid block extracted and returned |
| `extractMermaidFromPlan.not-found` | `ExtractInput` (no mermaid block) | `StandardError` | `error` | raises ValueError: "No mermaid block found in path" |
| `extractMermaidFromPlan.index-out-of-range` | `ExtractInput{block_index=N}` where N > number of blocks | `StandardError` | `error` | raises ValueError: "Block index N out of range" |
| `extractMermaidFromPlan.file-missing` | `ExtractInput` (bad path) | `StandardError` | `error` | raises FileNotFoundError |

---

### Flow: `generateMermaidInkUrl`

- Test files: `tests/test_mermaid_to_image.py`
- Core files: `scripts/mermaid_to_image.py`

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `generateMermaidInkUrl.success` | `UrlInput` | `UrlOutput` | `happy path` | mermaid string base64-encoded; URL returned |
| `generateMermaidInkUrl.empty-input` | `UrlInput{mermaid_string=""}` | `StandardError` | `error` | raises ValueError: "empty mermaid input" |

---

### Flow: `cliEntryPoint`

- Test files: `tests/test_mermaid_to_image.py`
- Core files: `scripts/mermaid_to_image.py`

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `cliEntryPoint.success-default` | valid plan file path, no block arg | URL printed to stdout, exit 0 | `happy path` | defaults to block 1 |
| `cliEntryPoint.success-block-n` | valid plan file path, `--block N` | URL printed to stdout, exit 0 | `happy path` | extracts Nth block |
| `cliEntryPoint.no-block` | plan file with no mermaid block | error message to stderr, exit 1 | `error` | ValueError from extractMermaidFromPlan |
| `cliEntryPoint.file-missing` | non-existent file path | error message to stderr, exit 1 | `error` | FileNotFoundError from extractMermaidFromPlan |

---

### Flow: `planningAgentPushesUrl`

- Test files: `N/A`
- Core files: `agents/featurework/planning/agents/planning-agent.md`

| path | input | output | path-type | notes |
| --- | --- | --- | --- | --- |
| `planningAgentPushesUrl.success` | plan written with mermaid block | PushNotification with tappable URL sent | `happy path` | After writing plan, agent calls script; URL pushed to phone |
| `planningAgentPushesUrl.no-mermaid` | plan has no mermaid block | skip URL step, continue | `branch` | If no mermaid block exists yet, skip silently |
| `planningAgentPushesUrl.script-failure` | script exits non-zero | log warning, continue without URL | `branch` | Do not block plan approval gate on script failure |

Closes #104

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
