### PR TITLE
chore(feature-agent): remove VS Code auto-open on plan generation

### DIFF
--- a/agents/featurework/agents/feature-agent.md
+++ b/agents/featurework/agents/feature-agent.md
@@ -156,7 +156,6 @@ feature-agent(taskDescription, answer, planPath):
 
   # ── Phase 4: Execution ──────────────────────────────────────────────────────
   if phase == "execution":
-    invoke open-in-vscode skill with: planPath
     Read the plan file at planPath using the Read tool.
     Display: "Plan written to <planPath>. All sections approved. Please do a final review."
     Display the full contents of the plan file to the developer.


### PR DESCRIPTION
## Description

Removed the `invoke open-in-vscode skill with: planPath` line from feature-agent.md Phase 4 (Execution). Plans no longer auto-open in VS Code when generated — the plan path is still displayed to the user so they can open it manually.

Closes #111

## Test Plan

```
$ python3 -m pytest tests/ -v
...
========================= 2 failed, 85 passed in 1.13s =========================
```

Note: The 2 failures (`test_feature_agent_declares_ask_user_question_in_tools`, `test_feature_agent_has_final_plan_approval_gate`) are pre-existing and not related to this change — confirmed by running the same tests against the parent commit.

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
