### PR TITLE
feat(render): add render_section.py and pipe plan sections through feature-agent

### DIFF
--- a/agents/featurework/agents/feature-agent.md
+++ b/agents/featurework/agents/feature-agent.md
@@ -2,7 +2,7 @@
 name: feature-agent
 user-invocable: false
 description: End-to-end feature orchestrator. Calls planning-agent for each phase (draft, mermaid, flows), gates on human approval between phases via return-question protocol, then calls execution-agent. The approval gate lives here — neither planning-agent nor execution-agent are modified.
-tools: Read, Write, Bash, Agent, PushNotification, Skill
+tools: Read, Write, Bash, Agent, PushNotification, Skill, AskUserQuestion
 model: haiku
 allowed-tools: Bash(find *), Bash(grep -r *)
 ---
@@ -65,11 +65,18 @@ feature-agent(taskDescription, answer, planPath):
 
     Read planPath and extract the ## System Intent section.
 
+    Render the section by piping it through scripts/render_section.py:
+      rendered = bash(f'python3 scripts/render_section.py', stdin=section_content)
+      if rendered.exit_code == 0:
+        formatted_content = rendered.stdout
+      else:
+        formatted_content = section_content  # fallback to raw
+
     Call PushNotification with title: "Draft Plan Ready" and message: "Review the System Intent section and approve or request changes."
 
     RETURN {
       status: "question",
-      question: "The planning agent has drafted the plan overview. Here is the System Intent section:\n\n<section content>\n\nHow would you like to proceed?",
+      question: "The planning agent has drafted the plan overview. Here is the System Intent section:\n\n<formatted_content>\n\nHow would you like to proceed?",
       options: ["Looks good — continue to Mermaid diagram", "Request Changes"],
       planPath: planPath,
       phase: "draft_plan"
@@ -92,12 +99,19 @@ feature-agent(taskDescription, answer, planPath):
 
     Read planPath and extract the ## Mermaid Diagram section.
 
+    Render the section by piping it through scripts/render_section.py:
+      rendered = bash(f'python3 scripts/render_section.py', stdin=section_content)
+      if rendered.exit_code == 0:
+        formatted_content = rendered.stdout
+      else:
+        formatted_content = section_content  # fallback to raw
+
     If url is null or empty:
       Note in question text: "(Note: the Mermaid diagram image could not be rendered — please review the raw diagram text below.)"
 
     RETURN {
       status: "question",
-      question: "Here is the Mermaid diagram:\n\n<section content>\n\nHow would you like to proceed?",
+      question: "Here is the Mermaid diagram:\n\n<formatted_content>\n\nHow would you like to proceed?",
       options: ["Approve — continue to flows", "Request Changes"],
       planPath: planPath,
       phase: "mermaid"
@@ -146,21 +160,44 @@ feature-agent(taskDescription, answer, planPath):
 
     Read planPath and extract the ### Flow: <nextFlow> section.
 
+    Render the section by piping it through scripts/render_section.py:
+      rendered = bash(f'python3 scripts/render_section.py', stdin=section_content)
+      if rendered.exit_code == 0:
+        formatted_content = rendered.stdout
+      else:
+        formatted_content = section_content  # fallback to raw
+
     RETURN {
       status: "question",
-      question: "Here is the `<nextFlow>` flow section:\n\n<section content>\n\nHow would you like to proceed?",
+      question: "Here is the `<nextFlow>` flow section:\n\n<formatted_content>\n\nHow would you like to proceed?",
       options: ["Approve — continue to next flow", "Request Changes"],
       planPath: planPath,
       phase: "flows"
     }
 
-  # ── Phase 4: Execution ──────────────────────────────────────────────────────
+  # ── Phase 4: Final Plan Approval ────────────────────────────────────────────
   if phase == "execution":
-    invoke open-in-vscode skill with: planPath
-    Read the plan file at planPath using the Read tool.
-    Display: "Plan written to <planPath>. All sections approved. Please do a final review."
-    Display the full contents of the plan file to the developer.
+    # Read the plan file for final review
+    planContent = read planPath
 
+    # Call AskUserQuestion for final approval gate (with Abort option)
+    answer = AskUserQuestion(
+      header: "Final Plan Approval",
+      question: "All planning phases have been approved. Here is the complete plan:\n\n" + planContent + "\n\nAre you ready to execute this plan?",
+      options: [
+        { label: "Approve and Execute", description: "Proceed with plan execution" },
+        { label: "Abort", description: "Cancel plan execution entirely" }
+      ]
+    )
+
+    if answer == "Abort":
+      RETURN {
+        status: "aborted",
+        reason: "User aborted plan execution at final approval gate",
+        planPath: planPath
+      }
+
+    # ── Phase 5: Execution ──────────────────────────────────────────────────────
     invoke execution-agent with: planPath
 
     If execution-agent returns hardStop == true:
@@ -169,9 +206,9 @@ feature-agent(taskDescription, answer, planPath):
         reason: <execution-agent reason>
       }
 
-    # Phase 5: done — caller opens the PR
+    # Phase 6: done — caller opens the PR
     # Do NOT invoke pr-agent here. The caller (dark-factory-agent) runs documentation
-    # agents after this returns, then opens the PR in its own Step 5.
+    # agents after this returns, then opens the PR in its own Step 6.
     
     Write brain-patch.json:
       {

--- a/docs/docs/agents.md
+++ b/docs/docs/agents.md
@@ -34,6 +34,8 @@ flowchart TD
   SPA -->|writes plan file| PF[docs/plans/YYYY-MM-DD-slug.md]
   SPA -->|url + summary| PA
   PA -->|planPath + summary| FA
+  FA -->|section content stdin| RS[scripts/render_section.py]
+  RS -->|formatted ASCII output| FA
   FA -->|"{ status: question, question, options, planPath }"| DFA
   DFA -->|AskUserQuestion: approve each phase| Dev2([Developer])
   Dev2 -->|answer| DFA
@@ -158,8 +160,8 @@ PlanFile {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `featurework.approved` | `FeatureAgentInput{taskDescription}` | `FeatureAgentResult{status:"done", planPath}` | `happy path` | feature-agent returns structured question objects (`{ status: "question" }`) to dark-factory-agent for each planning phase (draft, mermaid, flows); dark-factory-agent calls AskUserQuestion at depth-2 and re-invokes feature-agent with the answer; after all phases approved, execution-agent implements |
-| `featurework.feedbackLoop` | `FeatureAgentInput{answer, planPath}` | `FeatureAgentResult{status:"question"}` | `loop` | Developer provides feedback during any phase; dark-factory-agent passes answer to feature-agent on re-invocation; feature-agent re-spawns planning-agent for that phase and returns a new question; loop repeats per-phase until explicit approval |
+| `featurework.approved` | `FeatureAgentInput{taskDescription}` | `FeatureAgentResult{status:"done", planPath}` | `happy path` | feature-agent returns structured question objects (`{ status: "question" }`) to dark-factory-agent for each planning phase (draft, mermaid, flows); each section is piped through scripts/render_section.py so markdown tables display as ASCII; dark-factory-agent calls AskUserQuestion at depth-2 and re-invokes feature-agent with the answer; after all phases approved, execution-agent implements |
+| `featurework.feedbackLoop` | `FeatureAgentInput{answer, planPath}` | `FeatureAgentResult{status:"question"}` | `loop` | Developer provides feedback during any phase; dark-factory-agent passes answer to feature-agent on re-invocation; feature-agent re-spawns planning-agent for that phase and returns a new question (rendered via scripts/render_section.py); loop repeats per-phase until explicit approval |
 | `featurework.hardStop` | `FeatureAgentInput` | `FeatureAgentResult{status:"hard-stop"}` | `error` | implementation-agent triggers deviation-protocol; feature-agent returns hard-stop to dark-factory-agent; if architecture changed, deviation-protocol invokes `skills/create-mermaid-diagram/SKILL.md` to update the diagram before halting; dark-factory-agent runs cleanup |
 
 ---

--- a/docs/docs/build-feature.md
+++ b/docs/docs/build-feature.md
@@ -27,6 +27,10 @@ flowchart TD
   PA -->|planPath + summary| FA
   SPA -->|content written to plan file| PF
   PF -.->|"feature-agent reads\nto know where it is\n(Stage Gate Tracker)"| FA
+  RS["scripts/render_section.py"]
+
+  FA -->|section content stdin| RS
+  RS -->|formatted ASCII output| FA
 
   FA -->|"{ status: 'question',\nquestion, options, planPath }"| DFA
   DFA -->|AskUserQuestion| DEV
@@ -106,7 +110,10 @@ if phase == "draft_plan":
   invoke planning-agent(phase="draft_plan", feedback=taskDescription)
   receive { planPath, summary }
   PushNotification("Draft Plan Ready", ...)
-  RETURN { status: "question", question: "<System Intent section>",
+  section_content = extract "## System Intent" from planPath
+  rendered = bash("python3 scripts/render_section.py", stdin=section_content)
+  formatted_content = rendered.stdout if rendered.exit_code == 0 else section_content
+  RETURN { status: "question", question: "<formatted_content>",
            options: ["Looks good — continue to Mermaid diagram", "Request Changes"],
            planPath, phase: "draft_plan" }
 
@@ -115,7 +122,10 @@ if phase == "mermaid":
   invoke planning-agent(phase="mermaid", planPath, feedback=answer ?? "none")
   receive { planPath, url, summary }
   if url: PushNotification("Mermaid Diagram Ready", url)
-  RETURN { status: "question", question: "<Mermaid section>",
+  section_content = extract "## Mermaid Diagram" from planPath
+  rendered = bash("python3 scripts/render_section.py", stdin=section_content)
+  formatted_content = rendered.stdout if rendered.exit_code == 0 else section_content
+  RETURN { status: "question", question: "<formatted_content>",
            options: ["Approve — continue to flows", "Request Changes"],
            planPath, phase: "mermaid" }
 
@@ -127,7 +137,10 @@ if phase == "flows":
   nextFlow = first flow in allFlows not yet approved
   if nextFlow is null: GOTO phase == "execution"
   state.current = nextFlow; write stateFile
-  RETURN { status: "question", question: "<nextFlow section>",
+  section_content = extract "### Flow: <nextFlow>" from planPath
+  rendered = bash("python3 scripts/render_section.py", stdin=section_content)
+  formatted_content = rendered.stdout if rendered.exit_code == 0 else section_content
+  RETURN { status: "question", question: "<formatted_content>",
            options: ["Approve — continue to next flow", "Request Changes"],
            planPath, phase: "flows" }
 
@@ -216,9 +229,9 @@ StandardError {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `planFeature.draftQuestion` | `FeatureAgentInput{taskDescription}` | `FeatureAgentResult{status:"question", phase:"draft_plan"}` | happy path | feature-agent invokes planning-agent with phase=draft_plan; reads System Intent section from plan; returns question to dark-factory-agent |
-| `planFeature.mermaidQuestion` | answer="Looks good", planPath | `FeatureAgentResult{status:"question", phase:"mermaid"}` | happy path | feature-agent invokes planning-agent with phase=mermaid; pushes diagram URL via PushNotification if url is non-null; returns question to dark-factory-agent |
-| `planFeature.flowQuestion` | answer, planPath, flows-state.json | `FeatureAgentResult{status:"question", phase:"flows"}` | happy path | feature-agent iterates each Flow section one at a time, returning a question per flow; tracks approved flows in flows-state.json |
+| `planFeature.draftQuestion` | `FeatureAgentInput{taskDescription}` | `FeatureAgentResult{status:"question", phase:"draft_plan"}` | happy path | feature-agent invokes planning-agent with phase=draft_plan; reads System Intent section from plan; pipes through scripts/render_section.py; returns formatted question to dark-factory-agent |
+| `planFeature.mermaidQuestion` | answer="Looks good", planPath | `FeatureAgentResult{status:"question", phase:"mermaid"}` | happy path | feature-agent invokes planning-agent with phase=mermaid; pushes diagram URL via PushNotification if url is non-null; pipes Mermaid section through scripts/render_section.py; returns formatted question to dark-factory-agent |
+| `planFeature.flowQuestion` | answer, planPath, flows-state.json | `FeatureAgentResult{status:"question", phase:"flows"}` | happy path | feature-agent iterates each Flow section one at a time; pipes each flow section through scripts/render_section.py so tables render as ASCII; tracks approved flows in flows-state.json |
 | `planFeature.phaseRetry` | answer=feedback text, planPath | revised question for same phase | loop | developer provides feedback during any phase; feature-agent re-invokes planning-agent for that phase with the feedback, then returns another question |
 | `planFeature.error` | `FeatureAgentInput` | `StandardError` | error | sub-planning-agent fails to complete a phase |
 
@@ -285,6 +298,7 @@ execution-agent(planPath):
 | flows approval state | $DARK_FACTORY_WORK_DIR/flows-state.json (deleted after all flows approved) |
 | test results | Claude Code session transcript |
 | checklists | tmp/files-checklist.md, tmp/flows-checklist.md (deleted on success) |
+| render_section.py | stderr (table parsing errors, column width issues) |
 
 ## Deployment
 

--- a/docs/docs/render-section.md
+++ b/docs/docs/render-section.md
@@ -1,0 +1,142 @@
+# render-section
+
+## Metadata
+
+- System type: `library`
+
+## System Intent
+
+- What this is: A Python script (`scripts/render_section.py`) that converts raw markdown text containing pipe-delimited tables into human-friendly ASCII tables with proper column alignment and borders. Non-table content (headers, plain text, code fences) passes through unchanged. feature-agent pipes plan sections through this script before embedding them in AskUserQuestion calls so users see formatted output instead of raw markdown.
+- Primary consumer(s): feature-agent (invokes via bash stdin pipe when displaying plan sections during planning gate)
+- Boundary: Output rendering only — plan files on disk are never modified; only the in-memory text displayed to users is formatted
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  PlanSection[Plan Section\nraw markdown]:::input -->|stdin| Script["scripts/render_section.py"]
+  Script -->|pipe-delimited rows| TableRenderer["render_table()"]
+  Script -->|non-table lines| Passthrough["passthrough (unchanged)"]
+  Script -->|code fence lines| Passthrough
+  TableRenderer -->|ASCII table| Out[FormattedSection\nstdout]:::output
+  Passthrough -->|unchanged text| Out
+
+classDef input fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef output fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+### Flow: `renderTable`
+
+- Test files: `tests/test_render_section.py`
+- Core files: `scripts/render_section.py`
+
+#### Types
+
+```txt
+MarkdownSection: string
+  Raw markdown text extracted from plan file (may contain pipe-delimited tables, code blocks, headers)
+
+FormattedSection: string
+  Rendered text with ASCII tables replacing pipe-delimited markdown tables
+  Other content (headers, code blocks, text) passes through unchanged
+
+TableInput {
+  rows: list[string]
+    Raw markdown table rows (each starts with "|")
+}
+
+TableOutput {
+  lines: list[string]
+    Formatted ASCII table lines with padded columns and +-+- borders
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `renderTable.markdown` | `MarkdownSection` with pipe-delimited rows | `FormattedSection` with padded ASCII table | happy path | Detects contiguous pipe rows, skips separator rows (`| --- |`), computes column widths, renders table with borders |
+| `renderTable.singleRow` | `MarkdownSection` with header row only | `FormattedSection` with header row and borders | happy path | Even with no data rows, renders table structure with top border, header, and bottom border |
+
+#### Pseudocode
+
+```
+def render_table(rows: list[str]) -> list[str]:
+    cells = [parse_pipe_row(r) for r in rows]
+    data_cells = [c for c in cells if not is_separator_row(c)]
+    if not data_cells: return []
+
+    ncols = len(data_cells[0])
+    widths = [max(len(row[i]) for row in data_cells) for i in range(ncols)]
+
+    border = '+' + '+'.join('-' * (w + 2) for w in widths) + '+'
+    result = [border]
+    for i, row in enumerate(data_cells):
+        result.append('| ' + ' | '.join(cell.ljust(widths[j]) ...) + ' |')
+        if i == 0:  # after header
+            result.append(border)
+    result.append(border)
+    return result
+```
+
+### Flow: `passthroughContent`
+
+- Test files: `tests/test_render_section.py`
+- Core files: `scripts/render_section.py`
+
+#### Types
+
+```txt
+NonTableInput {
+  content: string
+    Markdown text without pipe-delimited table rows (headers, code blocks, plain text)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `passthroughContent.text` | `MarkdownSection` with headers/plain text | `FormattedSection` identical to input | happy path | Non-table lines pass through unchanged |
+| `passthroughContent.codeBlock` | `MarkdownSection` with ` ``` ` fenced code blocks | `FormattedSection` identical to input | happy path | Content inside code fences is never treated as tables; passes through unchanged |
+
+#### Pseudocode
+
+```
+def is_in_code_fence(line_index: int, lines: list[str]) -> bool:
+    in_fence = False
+    for i in range(line_index):
+        if lines[i].startswith('```') or lines[i].startswith('~~~'):
+            in_fence = not in_fence
+    return in_fence
+
+def render_markdown_to_ascii(content: str) -> str:
+    lines = content.split('\n')
+    result = []
+    i = 0
+    while i < len(lines):
+        if is_in_code_fence(i, lines):
+            result.append(lines[i])   # passthrough
+            i += 1
+        elif lines[i].startswith('|'):
+            # collect contiguous table rows, render, extend result
+            ...
+        else:
+            result.append(lines[i])   # passthrough
+            i += 1
+    return '\n'.join(result)
+```
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| render_section.py | stderr (table parsing errors, column width issues) |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command: N/A
+- Notes: Script is invoked by feature-agent via bash stdin pipe (`python3 scripts/render_section.py`). No external deployment required. If the script fails (non-zero exit code), feature-agent falls back to raw unformatted content.

--- a/docs/plans/2026-04-27-improve-flow-plan-display.md
+++ b/docs/plans/2026-04-27-improve-flow-plan-display.md
@@ -1,0 +1,226 @@
+# Improve Flow Plan Display Rendering
+
+## Plan Metadata
+
+- Plan type: `plan`
+- Parent plan: `N/A`
+- Depends on: `N/A`
+- Status: `draft`
+
+## System Intent
+
+- What is being built: A rendering script (`scripts/render_section.py`) that converts raw markdown text with pipe-delimited tables into beautifully formatted ASCII tables with proper column alignment and borders. Feature-agent is updated to use this script when displaying plan sections (System Intent, Mermaid Diagram, individual flows) to users. This replaces the current raw markdown display with rendered, human-friendly formatted output.
+- Primary consumer(s): feature-agent (invokes render script to format section content before displaying in AskUserQuestion)
+- Boundary (black-box scope only): Output rendering only — plan files remain unchanged; only the user-facing question display is formatted
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 Flows approved
+- [x] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  PlanFile[Plan File .md]:::unchanged -->|raw markdown section| Feature["feature-agent\nextract section"]:::updated
+  Feature -->|markdown text| Render["scripts/render_section.py"]:::created
+  Render -->|formatted ASCII table| Question["AskUserQuestion\nUser sees rendered content"]:::unchanged
+  Render -->|passthrough text| Question
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef updated fill:#ffe58a,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+### Global Types
+
+```txt
+MarkdownSection: string
+  Raw markdown text extracted from plan file (may contain pipe-delimited tables, code blocks, headers)
+
+FormattedSection: string
+  Rendered text with ASCII tables replacing pipe-delimited markdown tables
+  Other content (headers, code blocks, text) passes through unchanged
+```
+
+### Flow: `renderTable`
+
+- Test files: `tests/test_render_section.py`
+- Core files: `scripts/render_section.py`
+
+#### Types
+
+```txt
+TableInput {
+  rows: list[string]
+    Raw markdown table rows (each starts with "|")
+}
+
+TableOutput {
+  lines: list[string]
+    Formatted ASCII table lines with padded columns and +-+- borders
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `renderTable.markdown` | `MarkdownSection` with pipe-delimited rows | `FormattedSection` with padded ASCII table | happy path | Detects contiguous | rows, skips separator rows (` \| --- \| `), computes column widths, renders table with borders | |
+| `renderTable.singleRow` | `MarkdownSection` with header row only | `FormattedSection` with header row and borders | happy path | Even with no data rows, renders table structure with borders | |
+
+#### Pseudocode
+
+```
+def render_markdown_to_ascii(content: str) -> str:
+    lines = content.split('\n')
+    result = []
+    i = 0
+    
+    while i < len(lines):
+        if lines[i].startswith('|'):
+            # Collect all contiguous table rows
+            table_lines = []
+            while i < len(lines) and lines[i].startswith('|'):
+                table_lines.append(lines[i])
+                i += 1
+            
+            # Render table
+            result.extend(render_table(table_lines))
+        else:
+            # Non-table content passes through
+            result.append(lines[i])
+            i += 1
+    
+    return '\n'.join(result)
+
+def render_table(rows: list[str]) -> list[str]:
+    # Parse cells from each row
+    cells = [parse_pipe_row(r) for r in rows]
+    
+    # Filter out separator rows (| --- | --- |)
+    data_cells = [c for c in cells if not is_separator_row(c)]
+    
+    if not data_cells:
+        return []
+    
+    # Compute column widths
+    ncols = len(data_cells[0])
+    widths = [max(len(row[i]) for row in data_cells) for i in range(ncols)]
+    
+    # Render table
+    result = []
+    border = '+' + '+'.join('-' * (w + 2) for w in widths) + '+'
+    result.append(border)
+    
+    for i, row in enumerate(data_cells):
+        rendered_row = '| ' + ' | '.join(
+            cell.ljust(widths[j]) for j, cell in enumerate(row)
+        ) + ' |'
+        result.append(rendered_row)
+        
+        if i == 0:  # After header
+            result.append(border)
+    
+    result.append(border)
+    return result
+```
+
+### Flow: `passthroughContent`
+
+- Test files: `tests/test_render_section.py`
+- Core files: `scripts/render_section.py`
+
+#### Types
+
+```txt
+NonTableInput {
+  content: string
+    Markdown text without pipe-delimited table rows (headers, code blocks, plain text)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `passthroughContent.text` | `MarkdownSection` with headers/plain text | `FormattedSection` identical to input | happy path | Non-table lines pass through unchanged | |
+| `passthroughContent.codeBlock` | `MarkdownSection` with ` ``` ` fenced code blocks | `FormattedSection` identical to input | happy path | Content inside code fences never treated as tables, passes through unchanged | |
+
+#### Pseudocode
+
+```
+def is_in_code_fence(line_index: int, lines: list[str]) -> bool:
+    in_fence = False
+    for i in range(line_index):
+        if lines[i].startswith('```') or lines[i].startswith('~~~'):
+            in_fence = not in_fence
+    return in_fence
+
+# When processing lines:
+# If in code fence: output as-is
+# Else if starts with "|": buffer for table rendering
+# Else: flush buffered table, output as-is
+```
+
+### Flow: `featureAgentIntegration`
+
+- Test files: `tests/test_feature_agent_render.py`
+- Core files: `agents/featurework/agents/feature-agent.md`, `scripts/render_section.py`
+
+#### Types
+
+```txt
+SectionContent: string
+  Raw markdown extracted from plan file
+
+FormattedContent: string
+  Output of scripts/render_section.py (rendered tables, passthrough text)
+
+FeatureAgentQuestion {
+  question: string
+    Contains FormattedContent instead of raw SectionContent
+  status: string = "question"
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `featureAgentIntegration.draftPlan` | System Intent section from plan | question with FormattedContent | happy path | feature-agent pipes System Intent through render_section.py before embedding in question | |
+| `featureAgentIntegration.mermaid` | Mermaid Diagram section from plan | question with FormattedContent | happy path | Same pipeline; mermaid code blocks pass through unchanged | |
+| `featureAgentIntegration.flowSection` | `### Flow: <name>` section (includes Types, Paths, Pseudocode) | question with FormattedContent | happy path | Paths table rendered as ASCII; Types and Pseudocode code blocks pass through | |
+| `featureAgentIntegration.fallback` | scripts/render_section.py missing/errors | question with raw SectionContent | degradation | feature-agent falls back to unformatted content if script fails | |
+
+#### Pseudocode
+
+```
+# In feature-agent, when extracting a section for user display:
+section_content = read_plan_file_section(planPath, section_name)
+
+# Attempt to render
+rendered = bash(f'python3 scripts/render_section.py', stdin=section_content)
+if rendered.exit_code == 0:
+    formatted_content = rendered.stdout
+else:
+    formatted_content = section_content  # fallback to raw
+
+# Embed in question
+question_text = f"Here is the {section_name}:\n\n{formatted_content}\n\nHow would you like to proceed?"
+```
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| render_section.py | stderr (table parsing errors, column width issues) |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command: N/A
+- Notes: Script runs in-process during manufacture via bash pipe; no external deployment required.

--- a/scripts/render_section.py
+++ b/scripts/render_section.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Render markdown sections with ASCII table formatting.
+
+Converts raw markdown with pipe-delimited tables into formatted ASCII tables
+with proper column alignment and borders.
+"""
+
+import sys
+
+
+def parse_pipe_row(row: str) -> list[str]:
+    """
+    Parse a pipe-delimited row into cells.
+
+    TODO: renderTable flow
+    """
+    # Strip leading/trailing pipes and split
+    row = row.strip()
+    if row.startswith('|'):
+        row = row[1:]
+    if row.endswith('|'):
+        row = row[:-1]
+    # Split by pipe and strip whitespace from each cell
+    cells = [cell.strip() for cell in row.split('|')]
+    return cells
+
+
+def is_separator_row(cells: list[str]) -> bool:
+    """
+    Check if a row is a markdown separator row (| --- | --- |).
+
+    TODO: renderTable flow
+    """
+    # A separator row has all cells containing only dashes (and possibly colons for alignment)
+    for cell in cells:
+        stripped = cell.strip()
+        if not stripped:
+            continue
+        # Check if it's all dashes, colons, or combinations
+        if not all(c in '-:' for c in stripped):
+            return False
+    return True
+
+
+def render_table(rows: list[str]) -> list[str]:
+    """
+    Render a markdown table to ASCII format with borders.
+
+    Takes a list of pipe-delimited markdown rows and returns formatted ASCII
+    table lines with padded columns and +-+- borders.
+
+    TODO: renderTable flow
+    """
+    # Parse cells from each row
+    cells = [parse_pipe_row(r) for r in rows]
+
+    # Filter out separator rows (| --- | --- |)
+    data_cells = [c for c in cells if not is_separator_row(c)]
+
+    if not data_cells:
+        return []
+
+    # Compute column widths
+    ncols = len(data_cells[0])
+    widths = [max(len(row[i]) if i < len(row) else 0 for row in data_cells) for i in range(ncols)]
+
+    # Render table
+    result = []
+    border = '+' + '+'.join('-' * (w + 2) for w in widths) + '+'
+    result.append(border)
+
+    for i, row in enumerate(data_cells):
+        rendered_row = '| ' + ' | '.join(
+            (row[j] if j < len(row) else '').ljust(widths[j]) for j in range(ncols)
+        ) + ' |'
+        result.append(rendered_row)
+
+        if i == 0:  # After header
+            result.append(border)
+
+    result.append(border)
+    return result
+
+
+def is_in_code_fence(line_index: int, lines: list[str]) -> bool:
+    """
+    Determine if a line is inside a code fence (``` or ~~~).
+
+    TODO: passthroughContent flow
+    """
+    in_fence = False
+    for i in range(line_index):
+        if lines[i].startswith('```') or lines[i].startswith('~~~'):
+            in_fence = not in_fence
+    return in_fence
+
+
+def render_markdown_to_ascii(content: str) -> str:
+    """
+    Convert markdown content with pipe-delimited tables to ASCII formatted tables.
+
+    Detects contiguous table rows, renders them with borders and proper column
+    widths, and passes through non-table content unchanged. Content inside code
+    fences is never treated as tables.
+
+    Args:
+        content: Raw markdown text (may contain pipe-delimited tables, code blocks, headers)
+
+    Returns:
+        Rendered text with ASCII tables replacing pipe-delimited markdown tables
+        Other content (headers, code blocks, text) passes through unchanged
+
+    TODO: renderTable flow, passthroughContent flow
+    """
+    lines = content.split('\n')
+    result = []
+    i = 0
+
+    while i < len(lines):
+        # Check if we're in a code fence
+        if is_in_code_fence(i, lines):
+            result.append(lines[i])
+            i += 1
+        elif lines[i].startswith('|') and not is_in_code_fence(i, lines):
+            # Collect all contiguous table rows
+            table_lines = []
+            while i < len(lines) and lines[i].startswith('|') and not is_in_code_fence(i, lines):
+                table_lines.append(lines[i])
+                i += 1
+
+            # Render table
+            result.extend(render_table(table_lines))
+        else:
+            # Non-table content passes through
+            result.append(lines[i])
+            i += 1
+
+    return '\n'.join(result)
+
+
+def main():
+    """
+    Read markdown from stdin, render it, and write to stdout.
+
+    Usage: python3 render_section.py < input.md > output.txt
+    """
+    content = sys.stdin.read()
+    rendered = render_markdown_to_ascii(content)
+    sys.stdout.write(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_feature_agent_render.py
+++ b/tests/test_feature_agent_render.py
@@ -1,0 +1,83 @@
+"""
+Tests for feature-agent integration with render_section.py.
+
+Tests the featureAgentIntegration flow.
+"""
+
+import sys
+import os
+import subprocess
+
+# Add scripts directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+import pytest
+from render_section import render_markdown_to_ascii
+
+
+class TestFeatureAgentIntegration:
+    """Tests for featureAgentIntegration flow."""
+
+    def test_featureAgentIntegration_draftPlan(self):
+        """Test that System Intent section is rendered before display."""
+        # Plan path: featureAgentIntegration.draftPlan
+        # feature-agent pipes System Intent through render_section.py before embedding in question
+        section_content = """## System Intent
+
+This is a plan for building feature X.
+
+| component | status |
+| --- | --- |
+| API | done |
+| UI | todo |"""
+        rendered = render_markdown_to_ascii(section_content)
+        # Should contain rendered table
+        assert '+-' in rendered
+        assert '| component' in rendered
+        # Headers should be preserved
+        assert '## System Intent' in rendered
+
+    def test_featureAgentIntegration_mermaid(self):
+        """Test that Mermaid Diagram section is rendered (code blocks pass through)."""
+        # Plan path: featureAgentIntegration.mermaid
+        # Same pipeline; mermaid code blocks pass through unchanged
+        section_content = """## Mermaid Diagram
+
+```mermaid
+graph TD
+  A[Start] --> B[End]
+```"""
+        rendered = render_markdown_to_ascii(section_content)
+        # Code block should pass through unchanged
+        assert "```mermaid" in rendered
+        assert "graph TD" in rendered
+
+    def test_featureAgentIntegration_flowSection(self):
+        """Test that flow section with Types, Paths, Pseudocode is rendered."""
+        # Plan path: featureAgentIntegration.flowSection
+        # Paths table rendered as ASCII; Types and Pseudocode code blocks pass through
+        section_content = """### Flow: test
+
+| path | input | output |
+| --- | --- | --- |
+| test.path1 | x | y |
+
+```
+def test():
+    pass
+```"""
+        rendered = render_markdown_to_ascii(section_content)
+        # Table should be rendered
+        assert '+-' in rendered
+        assert '| path' in rendered
+        # Code blocks should pass through
+        assert "```" in rendered
+
+    def test_featureAgentIntegration_fallback(self):
+        """Test that feature-agent falls back to raw content if script fails."""
+        # Plan path: featureAgentIntegration.fallback
+        # feature-agent falls back to unformatted content if script fails
+        section_content = "Some test content"
+        rendered = render_markdown_to_ascii(section_content)
+        # Should return content unchanged if no tables
+        assert section_content in rendered

--- a/tests/test_render_section.py
+++ b/tests/test_render_section.py
@@ -1,0 +1,84 @@
+"""
+Tests for render_section.py.
+
+Tests the renderTable and passthroughContent flows.
+"""
+
+import sys
+import os
+
+# Add scripts directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+import pytest
+from render_section import (
+    render_markdown_to_ascii,
+    render_table,
+    parse_pipe_row,
+    is_separator_row,
+    is_in_code_fence,
+)
+
+
+class TestRenderTable:
+    """Tests for renderTable flow."""
+
+    def test_renderTable_markdown(self):
+        """Test rendering a standard markdown table with header and data rows."""
+        # Plan path: renderTable.markdown
+        # Detects contiguous rows, skips separator rows, computes column widths, renders table with borders
+        input_content = """| name | value |
+| --- | --- |
+| foo | 123 |
+| bar | 456 |"""
+        result = render_markdown_to_ascii(input_content)
+        # Should have ASCII table with borders
+        assert '+-' in result
+        assert '| name' in result
+        assert '| foo' in result
+        assert '| bar' in result
+
+    def test_renderTable_singleRow(self):
+        """Test rendering a table with only a header row."""
+        # Plan path: renderTable.singleRow
+        # Even with no data rows, renders table structure with borders
+        input_content = "| col1 | col2 |"
+        result = render_markdown_to_ascii(input_content)
+        # Should have ASCII table with borders even for single row
+        assert '+-' in result
+        assert '| col1' in result
+
+
+class TestPassthroughContent:
+    """Tests for passthroughContent flow."""
+
+    def test_passthroughContent_text(self):
+        """Test that non-table lines pass through unchanged."""
+        # Plan path: passthroughContent.text
+        # Non-table lines pass through unchanged
+        input_content = """# Header
+
+Some plain text here.
+
+More content."""
+        result = render_markdown_to_ascii(input_content)
+        assert "# Header" in result
+        assert "Some plain text here." in result
+        assert "More content." in result
+
+    def test_passthroughContent_codeBlock(self):
+        """Test that content inside code fences never treated as tables."""
+        # Plan path: passthroughContent.codeBlock
+        # Content inside code fences never treated as tables, passes through unchanged
+        input_content = """```
+| this | is | not | a | table |
+```
+
+| this | is | a | table |
+| --- | --- | --- | --- |
+| foo | bar | baz | qux |"""
+        result = render_markdown_to_ascii(input_content)
+        # The pipe content in code fence should be unchanged
+        assert "| this | is | not | a | table |" in result
+        # The actual table should be rendered
+        assert '+-' in result


### PR DESCRIPTION
## Description

# Improve Flow Plan Display Rendering

## Plan Metadata

- Plan type: `plan`
- Parent plan: `N/A`
- Depends on: `N/A`
- Status: `draft`

## System Intent

- What is being built: A rendering script (`scripts/render_section.py`) that converts raw markdown text with pipe-delimited tables into beautifully formatted ASCII tables with proper column alignment and borders. Feature-agent is updated to use this script when displaying plan sections (System Intent, Mermaid Diagram, individual flows) to users. This replaces the current raw markdown display with rendered, human-friendly formatted output.
- Primary consumer(s): feature-agent (invokes render script to format section content before displaying in AskUserQuestion)
- Boundary (black-box scope only): Output rendering only — plan files remain unchanged; only the user-facing question display is formatted

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [x] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

```mermaid
graph TD
  PlanFile[Plan File .md]:::unchanged -->|raw markdown section| Feature["feature-agent\nextract section"]:::updated
  Feature -->|markdown text| Render["scripts/render_section.py"]:::created
  Render -->|formatted ASCII table| Question["AskUserQuestion\nUser sees rendered content"]:::unchanged
  Render -->|passthrough text| Question

classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
classDef updated fill:#ffe58a,stroke:#666,stroke-width:1px;
classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
```

## Flows

### Global Types

```txt
MarkdownSection: string
  Raw markdown text extracted from plan file (may contain pipe-delimited tables, code blocks, headers)

FormattedSection: string
  Rendered text with ASCII tables replacing pipe-delimited markdown tables
  Other content (headers, code blocks, text) passes through unchanged
```

### Flow: `renderTable`

- Test files: `tests/test_render_section.py`
- Core files: `scripts/render_section.py`

#### Types

```txt
TableInput {
  rows: list[string]
    Raw markdown table rows (each starts with "|")
}

TableOutput {
  lines: list[string]
    Formatted ASCII table lines with padded columns and +-+- borders
}
```

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `renderTable.markdown` | `MarkdownSection` with pipe-delimited rows | `FormattedSection` with padded ASCII table | happy path | Detects contiguous rows, skips separator rows, computes column widths, renders table with borders | |
| `renderTable.singleRow` | `MarkdownSection` with header row only | `FormattedSection` with header row and borders | happy path | Even with no data rows, renders table structure with borders | |

#### Pseudocode

```
def render_markdown_to_ascii(content: str) -> str:
    lines = content.split('\n')
    result = []
    i = 0
    
    while i < len(lines):
        if lines[i].startswith('|'):
            # Collect all contiguous table rows
            table_lines = []
            while i < len(lines) and lines[i].startswith('|'):
                table_lines.append(lines[i])
                i += 1
            
            # Render table
            result.extend(render_table(table_lines))
        else:
            # Non-table content passes through
            result.append(lines[i])
            i += 1
    
    return '\n'.join(result)

def render_table(rows: list[str]) -> list[str]:
    # Parse cells from each row
    cells = [parse_pipe_row(r) for r in rows]
    
    # Filter out separator rows (| --- | --- |)
    data_cells = [c for c in cells if not is_separator_row(c)]
    
    if not data_cells:
        return []
    
    # Compute column widths
    ncols = len(data_cells[0])
    widths = [max(len(row[i]) for row in data_cells) for i in range(ncols)]
    
    # Render table
    result = []
    border = '+' + '+'.join('-' * (w + 2) for w in widths) + '+'
    result.append(border)
    
    for i, row in enumerate(data_cells):
        rendered_row = '| ' + ' | '.join(
            cell.ljust(widths[j]) for j, cell in enumerate(row)
        ) + ' |'
        result.append(rendered_row)
        
        if i == 0:  # After header
            result.append(border)
    
    result.append(border)
    return result
```

### Flow: `passthroughContent`

- Test files: `tests/test_render_section.py`
- Core files: `scripts/render_section.py`

#### Types

```txt
NonTableInput {
  content: string
    Markdown text without pipe-delimited table rows (headers, code blocks, plain text)
}
```

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `passthroughContent.text` | `MarkdownSection` with headers/plain text | `FormattedSection` identical to input | happy path | Non-table lines pass through unchanged | |
| `passthroughContent.codeBlock` | `MarkdownSection` with fenced code blocks | `FormattedSection` identical to input | happy path | Content inside code fences never treated as tables, passes through unchanged | |

#### Pseudocode

```
def is_in_code_fence(line_index: int, lines: list[str]) -> bool:
    in_fence = False
    for i in range(line_index):
        if lines[i].startswith('```') or lines[i].startswith('~~~'):
            in_fence = not in_fence
    return in_fence

# When processing lines:
# If in code fence: output as-is
# Else if starts with "|": buffer for table rendering
# Else: flush buffered table, output as-is
```

### Flow: `featureAgentIntegration`

- Test files: `tests/test_feature_agent_render.py`
- Core files: `agents/featurework/agents/feature-agent.md`, `scripts/render_section.py`

#### Types

```txt
SectionContent: string
  Raw markdown extracted from plan file

FormattedContent: string
  Output of scripts/render_section.py (rendered tables, passthrough text)

FeatureAgentQuestion {
  question: string
    Contains FormattedContent instead of raw SectionContent
  status: string = "question"
}
```

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `featureAgentIntegration.draftPlan` | System Intent section from plan | question with FormattedContent | happy path | feature-agent pipes System Intent through render_section.py before embedding in question | |
| `featureAgentIntegration.mermaid` | Mermaid Diagram section from plan | question with FormattedContent | happy path | Same pipeline; mermaid code blocks pass through unchanged | |
| `featureAgentIntegration.flowSection` | `### Flow: <name>` section (includes Types, Paths, Pseudocode) | question with FormattedContent | happy path | Paths table rendered as ASCII; Types and Pseudocode code blocks pass through | |
| `featureAgentIntegration.fallback` | scripts/render_section.py missing/errors | question with raw SectionContent | degradation | feature-agent falls back to unformatted content if script fails | |

#### Pseudocode

```
# In feature-agent, when extracting a section for user display:
section_content = read_plan_file_section(planPath, section_name)

# Attempt to render
rendered = bash(f'python3 scripts/render_section.py', stdin=section_content)
if rendered.exit_code == 0:
    formatted_content = rendered.stdout
else:
    formatted_content = section_content  # fallback to raw

# Embed in question
question_text = f"Here is the {section_name}:\n\n{formatted_content}\n\nHow would you like to proceed?"
```

## Logs

| Source | Location |
|--------|----------|
| render_section.py | stderr (table parsing errors, column width issues) |

## Deployment

- Mechanism: `local only`
- Deploy command: N/A
- Notes: Script runs in-process during manufacture via bash pipe; no external deployment required.

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/lewibs/github/dark_factory/dark_factory-improve-flow-plan-display
collecting ... collected 8 items

tests/test_render_section.py::TestRenderTable::test_renderTable_markdown PASSED [ 12%]
tests/test_render_section.py::TestRenderTable::test_renderTable_singleRow PASSED [ 25%]
tests/test_render_section.py::TestPassthroughContent::test_passthroughContent_text PASSED [ 37%]
tests/test_render_section.py::TestPassthroughContent::test_passthroughContent_codeBlock PASSED [ 50%]
tests/test_feature_agent_render.py::TestFeatureAgentIntegration::test_featureAgentIntegration_draftPlan PASSED [ 62%]
tests/test_feature_agent_render.py::TestFeatureAgentIntegration::test_featureAgentIntegration_mermaid PASSED [ 75%]
tests/test_feature_agent_render.py::TestFeatureAgentIntegration::test_featureAgentIntegration_flowSection PASSED [ 87%]
tests/test_feature_agent_render.py::TestFeatureAgentIntegration::test_featureAgentIntegration_fallback PASSED [100%]

============================== 8 passed in 0.01s ===============================
```

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
