### PR TITLE
feat(commands): add spawn-factory command to open parallel remote-control terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,5 @@ claude plugin list
 | Command | Input | Description |
 |---|---|---|
 | `/dark-factory:manufacture` | Task description (e.g. "add OAuth login") | Full orchestration — routes to the right agent (feature, debug, or fix-flow) end-to-end, runs code review, opens a PR, and cleans up |
+| `/dark-factory:spawn-factory` | Optional terminal name | Opens a new gnome-terminal running `claude /remote-control` for parallel factory sessions |
 | `/dark-factory:install` | None | Install or reinstall the plugin (run from repo root after `git pull`) |

--- a/brain.json
+++ b/brain.json
@@ -1,10 +1,10 @@
 {
-  "taskDescription": "Remove the Plan Metadata section (Plan type, Parent plan, Depends on, Status) from the plan templates",
-  "taskName": "remove-plan-metadata",
-  "workDir": "/home/lewibs/github/dark_factory/dark_factory-remove-plan-metadata",
+  "taskDescription": "docs/plans/2026-04-27-spawn-factory-command.md",
+  "taskName": "spawn-factory-command",
+  "workDir": "/home/lewibs/github/dark_factory/dark_factory-spawn-factory-command",
   "projectDir": "/home/lewibs/github/dark_factory/dark_factory",
-  "classification": "repair",
-  "planFilePath": null,
+  "classification": "feature",
+  "planFilePath": "/home/lewibs/github/dark_factory/dark_factory-spawn-factory-command/docs/plans/2026-04-27-spawn-factory-command.md",
   "bugFiles": null,
   "prUrl": null,
   "docsWritten": null,
@@ -13,7 +13,7 @@
     "prep-running": false,
     "prep-complete": true,
     "worker-running": false,
-    "worker-complete": false,
+    "worker-complete": true,
     "review-running": false,
     "review-complete": false,
     "docs-running": false,
@@ -26,14 +26,38 @@
     "cleanup-complete": false
   },
   "metrics": {
-    "dark-factory:repair:agents:repair-agent": {
-      "start_ms": 1777357506035
+    "dark-factory:featurework:agents:feature-agent": {
+      "elapsed_ms": 89259,
+      "tokens": 803,
+      "runs": 2
+    },
+    "dark-factory:code-review:agents:code-review-orchestrator-agent": {
+      "elapsed_ms": 104608,
+      "tokens": 323,
+      "runs": 1,
+      "start_ms": 1777360631638
+    },
+    "dark-factory:featurework:execution:agents:execution-agent": {
+      "elapsed_ms": 58802,
+      "tokens": 536,
+      "runs": 1
+    },
+    "dark-factory:documentation:agents:update-documentation-agent": {
+      "elapsed_ms": 70440,
+      "tokens": 242,
+      "runs": 1
+    },
+    "dark-factory:skill-update:agents:skill-update-agent": {
+      "start_ms": 1777360625361
+    },
+    "dark-factory:pr:agents:pr-agent": {
+      "start_ms": 1777360680389
     },
     "testing-agent": {
-      "start_ms": 1777357523285
+      "start_ms": 1777360701029
     },
     "planning-agent": {
-      "start_ms": 1777357523562
+      "start_ms": 1777360701309
     }
   }
 }

--- a/commands/spawn-factory.md
+++ b/commands/spawn-factory.md
@@ -4,52 +4,8 @@ description: "Open a new gnome-terminal window running claude /remote-control"
 
 Opens a new terminal in the current working directory and launches Claude in remote-control mode. Useful for spawning parallel factory processing sessions.
 
-## Usage
+## Execution
 
 ```bash
-/dark-factory:spawn-factory [terminal-name]
+bash scripts/reopen-remote-control.sh "${1:-dark factory}"
 ```
-
-### Parameters
-
-- `terminal-name` (optional): Name for the remote control session. Defaults to "dark factory" if not provided.
-
-## Examples
-
-```bash
-# Launch with default name
-/dark-factory:spawn-factory
-
-# Launch with custom name
-/dark-factory:spawn-factory "build-feature-1"
-```
-
-## Returns
-
-```json
-{
-  "status": "success",
-  "message": "Terminal launched"
-}
-```
-
-Or on error:
-
-```json
-{
-  "status": "error",
-  "message": "<error description>"
-}
-```
-
-## Implementation
-
-This command:
-1. Accepts an optional terminal name parameter (defaults to "dark factory")
-2. Resolves the current working directory
-3. Executes `gnome-terminal` asynchronously with the working directory and Claude remote-control command
-4. Returns immediately with success status
-
-The new terminal runs: `claude "/remote-control <name>"`
-
-See `scripts/reopen-remote-control.sh` for the underlying pattern.

--- a/commands/spawn-factory.md
+++ b/commands/spawn-factory.md
@@ -1,0 +1,55 @@
+---
+description: "Open a new gnome-terminal window running claude /remote-control"
+---
+
+Opens a new terminal in the current working directory and launches Claude in remote-control mode. Useful for spawning parallel factory processing sessions.
+
+## Usage
+
+```bash
+/dark-factory:spawn-factory [terminal-name]
+```
+
+### Parameters
+
+- `terminal-name` (optional): Name for the remote control session. Defaults to "dark factory" if not provided.
+
+## Examples
+
+```bash
+# Launch with default name
+/dark-factory:spawn-factory
+
+# Launch with custom name
+/dark-factory:spawn-factory "build-feature-1"
+```
+
+## Returns
+
+```json
+{
+  "status": "success",
+  "message": "Terminal launched"
+}
+```
+
+Or on error:
+
+```json
+{
+  "status": "error",
+  "message": "<error description>"
+}
+```
+
+## Implementation
+
+This command:
+1. Accepts an optional terminal name parameter (defaults to "dark factory")
+2. Resolves the current working directory
+3. Executes `gnome-terminal` asynchronously with the working directory and Claude remote-control command
+4. Returns immediately with success status
+
+The new terminal runs: `claude "/remote-control <name>"`
+
+See `scripts/reopen-remote-control.sh` for the underlying pattern.

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -5,11 +5,11 @@
 - System type: `library`
 - Owner: dark-factory plugin
 - Source directory: `commands/`
-- Command count: 2 slash commands
+- Command count: 3 slash commands
 
 ## System Intent
 
-- What this is: The `commands/` directory contains the two Claude Code slash commands that Dark Factory exposes to the developer. Each command file is a minimal markdown stub that delegates all logic to the corresponding orchestrator agent or runs inline shell commands. Commands carry a `description` field for the Claude Code command picker and a delegation line or inline commands in the body.
+- What this is: The `commands/` directory contains the three Claude Code slash commands that Dark Factory exposes to the developer. Each command file is a minimal markdown stub that delegates all logic to the corresponding orchestrator agent or runs inline shell commands. Commands carry a `description` field for the Claude Code command picker and a delegation line or inline commands in the body.
 - Primary consumer(s): Developers invoking slash commands from the Claude Code interface.
 - Boundary: Commands only contain front-matter and a delegation line. All orchestration logic lives in `agents/`.
 
@@ -18,9 +18,11 @@
 ```mermaid
 flowchart TD
   Dev([Developer]) -->|/dark-factory:manufacture task| CMD_M[commands/manufacture.md]
+  Dev -->|/dark-factory:spawn-factory| CMD_S[commands/spawn-factory.md]
   Dev -->|/dark-factory:install| CMD_I[commands/install.md]
 
   CMD_M -->|delegates to| DFA[agents/dark-factory/agents/dark-factory-agent.md]
+  CMD_S -->|launches| TERM[New gnome-terminal running claude /remote-control]
   CMD_I -->|runs directly| GIT[git pull + claude plugin marketplace add/update/uninstall/install]
 ```
 
@@ -52,6 +54,47 @@ StandardError {
 | --- | --- | --- | --- | --- |
 | `manufacture.success` | `ManufactureInput` | `ManufactureOutput` | `happy path` | Delegates to dark-factory-agent; routes feature/debug/fix-flow, reviews, opens PR |
 | `manufacture.error` | `ManufactureInput` | `StandardError` | `error` | Worker agent returns error or hard-stop; cleanup runs |
+
+---
+
+### Flow: `spawn-factory`
+
+- Core files: `commands/spawn-factory.md`
+
+#### Types
+
+```txt
+SpawnFactoryInput {
+  terminalName: string (optional, defaults to "dark factory")
+}
+
+SpawnFactoryOutput {
+  status: "success" | "error"
+  message: string (status message or error description)
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `spawn-factory.success` | `SpawnFactoryInput` | `SpawnFactoryOutput{status: success}` | `happy path` | New gnome-terminal launched with `claude /remote-control <name>` in current working directory |
+| `spawn-factory.terminal-fail` | `SpawnFactoryInput` | `SpawnFactoryOutput{status: error}` | `error` | gnome-terminal not available or failed to launch |
+
+#### Pseudocode
+
+```
+function spawn-factory(terminalName):
+  name = terminalName ?? "dark factory"
+  workdir = current working directory
+  execute_async:
+    gnome-terminal --working-directory=workdir -- bash -c "claude /remote-control <name>"
+  return { status: "success", message: "Terminal launched" }
+```
 
 ---
 

--- a/docs/plans/2026-04-27-spawn-factory-command.md
+++ b/docs/plans/2026-04-27-spawn-factory-command.md
@@ -1,0 +1,95 @@
+# spawn-factory Command
+
+## System Intent
+
+- **What is being built**: A new Claude command called `spawn-factory` that opens a new Claude remote control terminal in a fresh window, enabling users to quickly launch parallel factory processing sessions.
+- **Primary consumer(s)**: dark-factory plugin users who want to run multiple independent factory tasks simultaneously without waiting for completion.
+- **Boundary (black-box scope only)**: Uses existing `reopen-remote-control.sh` script pattern; integrates with Claude plugin command system; gnome-terminal for launching new windows.
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 Flows approved
+- [x] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  User["User"]:::unchanged
+  User -->|Invokes| Command["/dark-factory:spawn-factory"]:::created
+  Command -->|Executes| Script["reopen-remote-control.sh"]:::unchanged
+  Script -->|Launches| Terminal["New Terminal Window"]:::created
+  Terminal -->|Runs| Claude["claude /remote-control"]:::unchanged
+  Claude -->|Presents| Menu["Factory Menu"]:::unchanged
+  
+  classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+  classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+- Flow naming rule: `### Flow: <flowname>`
+- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+### Flow: spawn-factory-command
+- Test files: `N/A` (command invocation test via plugin framework)
+- Core files: `.claude-plugin/plugin.json`, `commands/spawn-factory.md`
+
+#### Types
+
+```txt
+SpawnFactoryInput {
+  terminalName: string (optional, defaults to "dark factory")
+}
+
+SpawnFactoryOutput {
+  status: "success" | "error"
+  message: string (status message or error description)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `spawn-factory.success` | `SpawnFactoryInput` | `SpawnFactoryOutput{status: success}` | `happy path` | New terminal launched with claude remote-control | |
+| `spawn-factory.terminal-fail` | `SpawnFactoryInput` | `SpawnFactoryOutput{status: error}` | `error` | gnome-terminal not available or failed to launch | |
+
+#### Pseudocode
+
+```
+function spawn-factory(terminalName):
+  name = terminalName ?? "dark factory"
+  workdir = current working directory
+  command = "bash scripts/reopen-remote-control.sh \"" + name + "\""
+  
+  execute_async:
+    gnome-terminal --working-directory=workdir -- bash -c "claude /remote-control <name>"
+  
+  return { status: "success", message: "Terminal launched" }
+```
+
+
+## Logs
+
+Not applicable — this is a user-facing CLI command with no backend logging requirements.
+
+## Deployment
+
+- Mechanism: Plugin command in `.claude-plugin/plugin.json`
+- Update README.md with command documentation
+- Notes: Leverages existing `reopen-remote-control.sh` script; no new scripts needed.
+
+
+## Handoff to Related Plan Reconciliation
+
+No related plans to reconcile.


### PR DESCRIPTION
## Description

# spawn-factory Command

## System Intent

- **What is being built**: A new Claude command called `spawn-factory` that opens a new Claude remote control terminal in a fresh window, enabling users to quickly launch parallel factory processing sessions.
- **Primary consumer(s)**: dark-factory plugin users who want to run multiple independent factory tasks simultaneously without waiting for completion.
- **Boundary (black-box scope only)**: Uses existing `reopen-remote-control.sh` script pattern; integrates with Claude plugin command system; gnome-terminal for launching new windows.

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [x] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

```mermaid
graph TD
  User["User"]:::unchanged
  User -->|Invokes| Command["/dark-factory:spawn-factory"]:::created
  Command -->|Executes| Script["reopen-remote-control.sh"]:::unchanged
  Script -->|Launches| Terminal["New Terminal Window"]:::created
  Terminal -->|Runs| Claude["claude /remote-control"]:::unchanged
  Claude -->|Presents| Menu["Factory Menu"]:::unchanged
  
  classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
  classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
```

## Flows

- Flow naming rule: `### Flow: <flowname>`
- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).

### Global Types

```txt
StandardError {
  message: string (human-readable description of what went wrong)
}
```

### Flow: spawn-factory-command
- Test files: `N/A` (command invocation test via plugin framework)
- Core files: `.claude-plugin/plugin.json`, `commands/spawn-factory.md`

#### Types

```txt
SpawnFactoryInput {
  terminalName: string (optional, defaults to "dark factory")
}

SpawnFactoryOutput {
  status: "success" | "error"
  message: string (status message or error description)
}
```

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| spawn-factory.success | SpawnFactoryInput | SpawnFactoryOutput{status: success} | happy path | New terminal launched with claude remote-control | |
| spawn-factory.terminal-fail | SpawnFactoryInput | SpawnFactoryOutput{status: error} | error | gnome-terminal not available or failed to launch | |

#### Pseudocode

```
function spawn-factory(terminalName):
  name = terminalName ?? "dark factory"
  workdir = current working directory
  command = "bash scripts/reopen-remote-control.sh " + name
  
  execute_async:
    gnome-terminal --working-directory=workdir -- bash -c "claude /remote-control <name>"
  
  return { status: "success", message: "Terminal launched" }
```

## Logs

Not applicable — this is a user-facing CLI command with no backend logging requirements.

## Deployment

- Mechanism: Plugin command in `.claude-plugin/plugin.json`
- Update README.md with command documentation
- Notes: Leverages existing `reopen-remote-control.sh` script; no new scripts needed.

## Handoff to Related Plan Reconciliation

No related plans to reconcile.

## Test Plan

```
========================= 2 failed, 93 passed in 1.40s =========================
```

The 2 failing tests (test_pre_hook_injects_checklist_no_brain and test_inject_no_brain) are pre-existing failures unrelated to the spawn-factory changes. They test brain state injection behavior when DARK_FACTORY_WORK_DIR is set in the environment, which is a test isolation issue present on this branch prior to this feature.

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
