### PR TITLE
fix(reopen-remote-control): walk process tree to kill closest terminal ancestor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/brain.json
+++ b/brain.json
@@ -1,10 +1,10 @@
 {
-  "taskDescription": "docs/plans/2026-04-27-spawn-factory-command.md",
-  "taskName": "spawn-factory-command",
-  "workDir": "/home/lewibs/github/dark_factory/dark_factory-spawn-factory-command",
+  "taskDescription": "Fix reopen-remote-control.sh to walk up the process tree and kill only the closest terminal emulator (gnome-terminal, xterm, konsole, etc.) — never more than one.",
+  "taskName": "fix-kill-terminal",
+  "workDir": "/home/lewibs/github/dark_factory/dark_factory-fix-kill-terminal",
   "projectDir": "/home/lewibs/github/dark_factory/dark_factory",
-  "classification": "feature",
-  "planFilePath": "/home/lewibs/github/dark_factory/dark_factory-spawn-factory-command/docs/plans/2026-04-27-spawn-factory-command.md",
+  "classification": "repair",
+  "planFilePath": null,
   "bugFiles": null,
   "prUrl": null,
   "docsWritten": null,
@@ -13,7 +13,7 @@
     "prep-running": false,
     "prep-complete": true,
     "worker-running": false,
-    "worker-complete": true,
+    "worker-complete": false,
     "review-running": false,
     "review-complete": false,
     "docs-running": false,
@@ -26,38 +26,18 @@
     "cleanup-complete": false
   },
   "metrics": {
-    "dark-factory:featurework:agents:feature-agent": {
-      "elapsed_ms": 89259,
-      "tokens": 803,
-      "runs": 2
+    "dark-factory:repair:agents:repair-agent": {
+      "elapsed_ms": 71807,
+      "tokens": 570,
+      "runs": 1
     },
     "dark-factory:code-review:agents:code-review-orchestrator-agent": {
-      "elapsed_ms": 104608,
-      "tokens": 323,
-      "runs": 1,
-      "start_ms": 1777360631638
-    },
-    "dark-factory:featurework:execution:agents:execution-agent": {
-      "elapsed_ms": 58802,
-      "tokens": 536,
+      "elapsed_ms": 49021,
+      "tokens": 464,
       "runs": 1
-    },
-    "dark-factory:documentation:agents:update-documentation-agent": {
-      "elapsed_ms": 70440,
-      "tokens": 242,
-      "runs": 1
-    },
-    "dark-factory:skill-update:agents:skill-update-agent": {
-      "start_ms": 1777360625361
     },
     "dark-factory:pr:agents:pr-agent": {
-      "start_ms": 1777360680389
-    },
-    "testing-agent": {
-      "start_ms": 1777360701029
-    },
-    "planning-agent": {
-      "start_ms": 1777360701309
+      "start_ms": 1777361241254
     }
   }
 }

--- a/scripts/reopen-remote-control.sh
+++ b/scripts/reopen-remote-control.sh
@@ -39,20 +39,53 @@ open_terminal() {
     return 1
 }
 
+# Walk up the process tree from the current script PID to find the nearest
+# ancestor whose name matches a known terminal emulator.  Kill only that one
+# process and stop immediately.  If no terminal emulator is found in the tree
+# (e.g. invoked from Claude Code's bash tool), skip silently.
+kill_terminal_ancestor() {
+    local known_terms="gnome-terminal gnome-terminal-server xterm konsole x-terminal-emulator"
+    local pid=$$
+
+    while true; do
+        # Obtain the parent PID of $pid; strip leading/trailing whitespace.
+        local ppid
+        ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+
+        # Stop if we hit an invalid/missing PPID or reach PID 1 or below.
+        if [ -z "$ppid" ] || [ "$ppid" -le 1 ] 2>/dev/null; then
+            break
+        fi
+
+        # Get the process name for this ancestor.
+        local pname
+        pname=$(ps -o comm= -p "$ppid" 2>/dev/null | tr -d ' ')
+
+        # Check whether pname matches any known terminal emulator.
+        for term in $known_terms; do
+            if [ "$pname" = "$term" ]; then
+                kill "$ppid" 2>/dev/null || {
+                    echo "Warning: Could not close the installer terminal (PID: $ppid)" >&2
+                }
+                return
+            fi
+        done
+
+        # Move one level up.
+        pid=$ppid
+    done
+
+    # No terminal emulator ancestor found — skip silently.
+}
+
 # Launch the new terminal with Claude in remote-control mode
 open_terminal
 TERMINAL_EXIT=$?
 
 # Verify the terminal was opened successfully before closing the installer terminal
-if [ $TERMINAL_EXIT -eq 0 ] && [ -n "$PPID" ] && [ "$PPID" -gt 0 ] 2>/dev/null; then
-    # Close the terminal that ran the install command.
-    # Kill the parent process (the terminal emulator) of this shell session.
-    kill "$PPID" 2>/dev/null || {
-        echo "Warning: Could not close the installer terminal (PID: $PPID)" >&2
-    }
+if [ $TERMINAL_EXIT -eq 0 ]; then
+    kill_terminal_ancestor
 else
-    if [ $TERMINAL_EXIT -ne 0 ]; then
-        echo "Error: Failed to open terminal (exit code: $TERMINAL_EXIT)" >&2
-        exit $TERMINAL_EXIT
-    fi
+    echo "Error: Failed to open terminal (exit code: $TERMINAL_EXIT)" >&2
+    exit $TERMINAL_EXIT
 fi

--- a/tests/test_reopen_remote_control.py
+++ b/tests/test_reopen_remote_control.py
@@ -39,20 +39,91 @@ def test_reopen_remote_control_error_handling():
         "Script should check terminal command exit status"
 
 
-def test_reopen_remote_control_ppid_validation():
-    """Verify proper PPID validation"""
+def test_reopen_remote_control_walks_process_tree():
+    """Verify the script walks the process tree to find the terminal emulator ancestor"""
     script_path = "scripts/reopen-remote-control.sh"
 
     with open(script_path, "r") as f:
         content = f.read()
 
-    # Should validate PPID existence and validity
-    assert "PPID" in content, "Script should reference PPID"
-    assert "$PPID" in content or "\\$PPID" in content, "Script should use PPID variable"
+    # Should use ps to query parent PIDs
+    assert "ps -o ppid=" in content, \
+        "Script should use 'ps -o ppid=' to walk the process tree"
 
-    # Should have proper validation (not just -n check)
-    assert "-gt 0" in content or "is_valid" in content.lower(), \
-        "Script should validate PPID is a positive number"
+    # Should use ps to get process name
+    assert "ps -o comm=" in content, \
+        "Script should use 'ps -o comm=' to get the ancestor process name"
+
+    # Should start the walk from $$ (current script PID)
+    assert "$$" in content, \
+        "Script should start the process tree walk from $$ (current script PID)"
+
+
+def test_reopen_remote_control_kills_only_first_terminal_ancestor():
+    """Verify the script stops after killing the first terminal emulator found"""
+    script_path = "scripts/reopen-remote-control.sh"
+
+    with open(script_path, "r") as f:
+        content = f.read()
+
+    # Should have a return/break immediately after killing, so it never continues
+    # walking after the first match.  The function must contain a kill followed
+    # by a return inside the match block.
+    assert "kill_terminal_ancestor" in content, \
+        "Script should define a kill_terminal_ancestor function"
+
+    # After the kill there should be a 'return' to stop walking
+    kill_idx = content.find('kill "$ppid"')
+    assert kill_idx != -1, "Script should kill the ancestor by PID variable"
+    after_kill = content[kill_idx:]
+    assert "return" in after_kill, \
+        "Script should return immediately after killing the first terminal ancestor"
+
+
+def test_reopen_remote_control_never_kills_pid_1_or_below():
+    """Verify the script never kills PID 1 or any PID <= 1"""
+    script_path = "scripts/reopen-remote-control.sh"
+
+    with open(script_path, "r") as f:
+        content = f.read()
+
+    # Should have a guard that stops the walk at PID 1 or below
+    assert "-le 1" in content or "<= 1" in content, \
+        "Script should guard against killing PID 1 or below"
+
+
+def test_reopen_remote_control_skips_silently_when_no_terminal_found():
+    """Verify the script skips silently when no terminal emulator is in the process tree"""
+    script_path = "scripts/reopen-remote-control.sh"
+
+    with open(script_path, "r") as f:
+        content = f.read()
+
+    # The function should simply return (or fall off the end) without printing
+    # an error when no terminal emulator ancestor is found.  There should NOT
+    # be an unconditional error message inside kill_terminal_ancestor after the
+    # loop ends.
+    func_start = content.find("kill_terminal_ancestor()")
+    assert func_start != -1, "Script should define kill_terminal_ancestor function"
+
+    # Find the closing brace of the function body
+    func_body_start = content.find("{", func_start)
+    # Count braces to find the matching closing brace
+    depth = 0
+    func_body_end = func_body_start
+    for i, ch in enumerate(content[func_body_start:], start=func_body_start):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                func_body_end = i
+                break
+
+    func_body = content[func_body_start:func_body_end + 1]
+    # The comment about skipping silently should be present
+    assert "silently" in func_body or "skip" in func_body.lower(), \
+        "Script should document that it skips silently when no terminal emulator is found"
 
 
 def test_reopen_remote_control_kill_error_handling():
@@ -83,6 +154,26 @@ def test_reopen_remote_control_terminal_emulator_fallback():
 
     assert found_terminals > 0, \
         "Script should support at least one terminal emulator"
+
+
+def test_reopen_remote_control_known_terminals_in_ancestor_check():
+    """Verify all known terminal emulators are checked during the ancestor walk"""
+    script_path = "scripts/reopen-remote-control.sh"
+
+    with open(script_path, "r") as f:
+        content = f.read()
+
+    # All terminals listed in the task description must appear in the known-terms list
+    required_terms = [
+        "gnome-terminal",
+        "gnome-terminal-server",
+        "xterm",
+        "konsole",
+        "x-terminal-emulator",
+    ]
+    for term in required_terms:
+        assert term in content, \
+            f"Script should check for '{term}' as a known terminal emulator ancestor"
 
 
 def test_reopen_remote_control_accepts_name_argument():


### PR DESCRIPTION
## Description

Fixed reopen-remote-control.sh to walk the process tree upward and kill only the closest terminal emulator ancestor (gnome-terminal, xterm, konsole, etc.) instead of blindly killing $PPID. Never kills more than one process, never kills PID 1, skips silently when not running in a terminal. Updated tests.

### Changes

**`scripts/reopen-remote-control.sh`**

Replaced the old logic that blindly killed `$PPID` with a new `kill_terminal_ancestor()` function that:

- Starts at `$$` (the current script PID) and walks the process tree upward using `ps -o ppid=` at each level.
- At each ancestor, reads the process name with `ps -o comm=` and checks it against a known list of terminal emulators: `gnome-terminal`, `gnome-terminal-server`, `xterm`, `konsole`, `x-terminal-emulator`.
- Kills the first matching ancestor and returns immediately — never kills more than one process.
- Guards against killing PID 1 or any PID <= 1.
- When no terminal emulator ancestor is found (e.g. invoked from Claude Code's bash tool), skips silently without printing an error.

**`tests/test_reopen_remote_control.py`**

Replaced the old `test_reopen_remote_control_ppid_validation` test with new tests:

- `test_reopen_remote_control_walks_process_tree` — verifies `ps -o ppid=` and `ps -o comm=` are used and the walk starts from `$$`.
- `test_reopen_remote_control_kills_only_first_terminal_ancestor` — verifies a `return` immediately follows the `kill` inside the function.
- `test_reopen_remote_control_never_kills_pid_1_or_below` — verifies the `-le 1` guard is present.
- `test_reopen_remote_control_skips_silently_when_no_terminal_found` — verifies no unconditional error is emitted from the function body.
- `test_reopen_remote_control_known_terminals_in_ancestor_check` — verifies all five required terminal names appear in the script.

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/lewibs/github/dark_factory/dark_factory-fix-kill-terminal
collecting ... collected 12 items

tests/test_reopen_remote_control.py::test_reopen_remote_control_script_exists PASSED [  8%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_has_shebang PASSED [ 16%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_error_handling PASSED [ 25%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_walks_process_tree PASSED [ 33%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_kills_only_first_terminal_ancestor PASSED [ 41%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_never_kills_pid_1_or_below PASSED [ 50%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_skips_silently_when_no_terminal_found PASSED [ 58%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_kill_error_handling PASSED [ 66%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_terminal_emulator_fallback PASSED [ 75%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_known_terminals_in_ancestor_check PASSED [ 83%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_accepts_name_argument PASSED [ 91%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_uses_pwd PASSED [100%]

============================== 12 passed in 0.02s ==============================
```

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
