### PR TITLE
fix(reopen-remote-control): close terminal tab via cgroup scope instead of kill -HUP

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/scripts/reopen-remote-control.sh
+++ b/scripts/reopen-remote-control.sh
@@ -48,11 +48,9 @@ if [ $TERMINAL_EXIT -ne 0 ]; then
     exit $TERMINAL_EXIT
 fi
 
-# Send SIGHUP to the parent shell (the terminal tab running this script).
-# SIGHUP is the "terminal closed" signal — bash/zsh respond to it and exit,
-# closing only the current tab.  If invoked from a non-terminal context (e.g.
-# Claude Code's bash tool), the parent will simply ignore the signal, which is
-# fine — it will silently fail.
-if [ -n "$PPID" ] && [ "$PPID" -gt 1 ]; then
-    kill -HUP "$PPID" 2>/dev/null || true
+# Find this terminal tab's vte-spawn scope from the cgroup
+SCOPE=$(grep -oP 'vte-spawn-[^/]+\.scope' /proc/$$/cgroup 2>/dev/null | head -1)
+
+if [ -n "$SCOPE" ]; then
+    systemctl --user stop "$SCOPE" 2>/dev/null || true
 fi

--- a/tests/test_reopen_remote_control.py
+++ b/tests/test_reopen_remote_control.py
@@ -39,73 +39,78 @@ def test_reopen_remote_control_error_handling():
         "Script should check terminal command exit status"
 
 
-def test_reopen_remote_control_sends_sighup_to_ppid():
-    """Verify the script sends SIGHUP to $PPID to close the current terminal tab"""
+def test_reopen_remote_control_uses_cgroup_scope_to_close_tab():
+    """Verify the script reads the vte-spawn scope from /proc/$$/cgroup to close the current tab"""
     script_path = "scripts/reopen-remote-control.sh"
 
     with open(script_path, "r") as f:
         content = f.read()
 
-    # Should use kill -HUP targeting $PPID
-    assert "kill -HUP" in content and "$PPID" in content, \
-        "Script should send SIGHUP to $PPID to close the current terminal tab"
+    # Should read cgroup to find the vte-spawn scope
+    assert "/proc/$$/cgroup" in content, \
+        "Script should read /proc/$$/cgroup to find the current tab's scope"
+    assert "vte-spawn-" in content, \
+        "Script should look for a vte-spawn-*.scope cgroup entry"
+    assert "systemctl --user stop" in content, \
+        "Script should stop the scope with systemctl --user stop"
 
 
-def test_reopen_remote_control_guards_ppid_gt_1():
-    """Verify the script only sends SIGHUP when PPID > 1"""
+def test_reopen_remote_control_skips_silently_without_scope():
+    """Verify the script skips closing the tab silently when no vte-spawn scope is found"""
     script_path = "scripts/reopen-remote-control.sh"
 
     with open(script_path, "r") as f:
         content = f.read()
 
-    # Should guard against sending SIGHUP to PID 1 or below
-    assert '"-gt 1"' in content or "\"$PPID\" -gt 1" in content or "$PPID\" -gt 1" in content, \
-        "Script should guard against sending SIGHUP when PPID <= 1"
+    # Should guard against empty SCOPE before stopping
+    assert '[ -n "$SCOPE" ]' in content, \
+        "Script should only stop the scope when SCOPE is non-empty (i.e. running in gnome-terminal)"
 
 
-def test_reopen_remote_control_sighup_only_on_success():
-    """Verify the script only sends SIGHUP after the new terminal opens successfully"""
+def test_reopen_remote_control_scope_stop_only_on_success():
+    """Verify the script only stops the scope after the new terminal opens successfully"""
     script_path = "scripts/reopen-remote-control.sh"
 
     with open(script_path, "r") as f:
         content = f.read()
 
-    # TERMINAL_EXIT check must appear before the kill -HUP
+    # TERMINAL_EXIT check must appear before the systemctl stop
     terminal_exit_idx = content.find("TERMINAL_EXIT")
-    kill_hup_idx = content.find("kill -HUP")
+    scope_stop_idx = content.find("systemctl --user stop")
     assert terminal_exit_idx != -1, "Script should check TERMINAL_EXIT"
-    assert kill_hup_idx != -1, "Script should contain kill -HUP"
-    assert terminal_exit_idx < kill_hup_idx, \
-        "Script should check TERMINAL_EXIT before sending SIGHUP"
+    assert scope_stop_idx != -1, "Script should contain systemctl --user stop"
+    assert terminal_exit_idx < scope_stop_idx, \
+        "Script should check TERMINAL_EXIT before stopping the scope"
 
 
-def test_reopen_remote_control_sighup_silently_fails_in_non_terminal():
-    """Verify the script silently ignores errors when SIGHUP is not accepted (non-terminal context)"""
+def test_reopen_remote_control_scope_stop_silently_fails_in_non_terminal():
+    """Verify the script silently ignores errors when not running in a gnome-terminal"""
     script_path = "scripts/reopen-remote-control.sh"
 
     with open(script_path, "r") as f:
         content = f.read()
 
-    # kill -HUP should have error suppression so it fails silently in non-terminal contexts
+    # systemctl stop should have error suppression so it fails silently in non-gnome-terminal contexts
     assert "2>/dev/null" in content, \
-        "Script should suppress kill errors so it fails silently in non-terminal contexts"
+        "Script should suppress systemctl errors so it fails silently when not in gnome-terminal"
     assert "|| true" in content, \
-        "Script should use '|| true' so a failing kill does not abort the script"
+        "Script should use '|| true' so a failing systemctl stop does not abort the script"
 
 
-def test_reopen_remote_control_kill_error_handling():
-    """Verify kill command has error handling"""
+def test_reopen_remote_control_scope_stop_error_handling():
+    """Verify the scope stop command has error handling"""
     script_path = "scripts/reopen-remote-control.sh"
 
     with open(script_path, "r") as f:
         content = f.read()
 
-    # Should have error handling around kill
-    assert "kill" in content, "Script should contain kill command"
+    # Should stop at most one scope (head -1 limits output to one line)
+    assert "head -1" in content, \
+        "Script should use head -1 to ensure only one scope is stopped"
 
-    # Should handle kill errors gracefully (2>/dev/null or error handling)
+    # Should handle stop errors gracefully
     assert "2>/dev/null" in content or "||" in content, \
-        "Script should handle potential kill errors gracefully"
+        "Script should handle potential systemctl stop errors gracefully"
 
 
 def test_reopen_remote_control_terminal_emulator_fallback():


### PR DESCRIPTION
## Description

Fixed reopen-remote-control.sh to close the current terminal tab by reading its vte-spawn-*.scope from /proc/$$/cgroup and stopping it with `systemctl --user stop`. Every gnome-terminal tab has a unique scope so this closes exactly the right tab. Skips silently in non-gnome-terminal environments. Replaces the unreliable kill -HUP approach.

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/lewibs/github/dark_factory/dark_factory-fix-kill-terminal-cgroup
collecting ... collected 12 items

tests/test_reopen_remote_control.py::test_reopen_remote_control_script_exists PASSED [  8%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_has_shebang PASSED [ 16%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_error_handling PASSED [ 25%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_uses_cgroup_scope_to_close_tab PASSED [ 33%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_skips_silently_without_scope PASSED [ 41%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_scope_stop_only_on_success PASSED [ 50%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_scope_stop_silently_fails_in_non_terminal PASSED [ 58%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_scope_stop_error_handling PASSED [ 66%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_terminal_emulator_fallback PASSED [ 75%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_supported_terminal_emulators PASSED [ 83%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_accepts_name_argument PASSED [ 91%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_uses_pwd PASSED [100%]

============================== 12 passed in 0.02s ==============================
```

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
