### PR TITLE
fix(reopen-remote-control): kill claude ancestor process after scope stop

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/scripts/reopen-remote-control.sh
+++ b/scripts/reopen-remote-control.sh
@@ -54,3 +54,16 @@ SCOPE=$(grep -oP 'vte-spawn-[^/]+\.scope' /proc/$$/cgroup 2>/dev/null | head -1)
 if [ -n "$SCOPE" ]; then
     systemctl --user stop "$SCOPE" 2>/dev/null || true
 fi
+
+# Also kill the claude process so the old session fully terminates
+pid=$$
+while [ "$pid" -gt 1 ]; do
+    ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    name=$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ')
+    if [ "$name" = "claude" ]; then
+        kill "$pid" 2>/dev/null || true
+        break
+    fi
+    [ -z "$ppid" ] || [ "$ppid" -le 1 ] && break
+    pid=$ppid
+done

--- a/tests/test_reopen_remote_control.py
+++ b/tests/test_reopen_remote_control.py
@@ -175,6 +175,76 @@ def test_reopen_remote_control_uses_pwd():
         "Script should use the current working directory"
 
 
+def test_reopen_remote_control_kills_claude_process_after_scope_stop():
+    """Verify the script walks the process tree and kills the first ancestor named 'claude'"""
+    script_path = "scripts/reopen-remote-control.sh"
+
+    with open(script_path, "r") as f:
+        content = f.read()
+
+    # Should walk up the process tree from $$
+    assert 'pid=$$' in content, \
+        "Script should start the process-tree walk from $$"
+
+    # Should use ps to get parent PID and process name
+    assert 'ppid=$(ps -o ppid=' in content, \
+        "Script should retrieve the parent PID with ps -o ppid="
+    assert 'name=$(ps -o comm=' in content, \
+        "Script should retrieve the process name with ps -o comm="
+
+    # Should compare against the literal name 'claude'
+    assert '"claude"' in content, \
+        "Script should check whether the process name equals 'claude'"
+
+    # Should kill the found process with silent failure
+    assert 'kill "$pid"' in content, \
+        "Script should kill the process when its name matches 'claude'"
+
+
+def test_reopen_remote_control_kills_claude_only_after_scope_stop():
+    """Verify the claude-kill logic comes after the systemctl scope stop"""
+    script_path = "scripts/reopen-remote-control.sh"
+
+    with open(script_path, "r") as f:
+        content = f.read()
+
+    scope_stop_idx = content.find("systemctl --user stop")
+    kill_claude_idx = content.find('kill "$pid"')
+
+    assert scope_stop_idx != -1, "Script should contain systemctl --user stop"
+    assert kill_claude_idx != -1, "Script should contain the claude kill logic"
+    assert scope_stop_idx < kill_claude_idx, \
+        "Claude kill logic must appear after the systemctl scope stop"
+
+
+def test_reopen_remote_control_never_kills_pid_1_or_below():
+    """Verify the loop guard prevents killing PID 1 or below"""
+    script_path = "scripts/reopen-remote-control.sh"
+
+    with open(script_path, "r") as f:
+        content = f.read()
+
+    # The while condition must guard against PID <= 1
+    assert '[ "$pid" -gt 1 ]' in content, \
+        "Script should guard the loop with [ \"$pid\" -gt 1 ] to never kill PID 1 or below"
+
+    # The inner break should also guard against ppid <= 1
+    assert '"$ppid" -le 1' in content, \
+        "Script should break when ppid drops to 1 or below"
+
+
+def test_reopen_remote_control_claude_kill_silent_failure():
+    """Verify the kill command uses silent failure so the script never aborts"""
+    script_path = "scripts/reopen-remote-control.sh"
+
+    with open(script_path, "r") as f:
+        content = f.read()
+
+    # kill line must have both 2>/dev/null and || true
+    assert 'kill "$pid" 2>/dev/null || true' in content, \
+        "kill command must suppress errors with 2>/dev/null and use || true for silent failure"
+
+
 if __name__ == "__main__":
     # Run tests
     import pytest


### PR DESCRIPTION
## Description

After closing the terminal window via systemctl scope stop, the script now also walks the process tree to find and kill the claude ancestor process, fully terminating the old session. Only kills the first match, never PID 1, silent on failure.

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/lewibs/github/dark_factory/dark_factory-fix-kill-claude-process
collecting ... collected 16 items

tests/test_reopen_remote_control.py::test_reopen_remote_control_script_exists PASSED [  6%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_has_shebang PASSED [ 12%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_error_handling PASSED [ 18%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_uses_cgroup_scope_to_close_tab PASSED [ 25%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_skips_silently_without_scope PASSED [ 31%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_scope_stop_only_on_success PASSED [ 37%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_scope_stop_silently_fails_in_non_terminal PASSED [ 43%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_scope_stop_error_handling PASSED [ 50%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_terminal_emulator_fallback PASSED [ 56%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_supported_terminal_emulators PASSED [ 62%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_accepts_name_argument PASSED [ 68%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_uses_pwd PASSED [ 75%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_kills_claude_process_after_scope_stop PASSED [ 81%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_kills_claude_only_after_scope_stop PASSED [ 87%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_never_kills_pid_1_or_below PASSED [ 93%]
tests/test_reopen_remote_control.py::test_reopen_remote_control_claude_kill_silent_failure PASSED [100%]

============================== 16 passed in 0.02s ==============================
```

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
