### PR TITLE
fix(destroy-factories): kill terminals via vte-cgroup scope and self-close

### DIFF
--- a/scripts/destroy-factories.sh
+++ b/scripts/destroy-factories.sh
@@ -140,10 +140,20 @@ _log "destroy-factories" "entry" "name=$NAME"
 KILLED=0
 for pid in $(find_claude_terminals); do
     _log "destroy-factories" "kill" "pid=$pid"
-    kill "$pid" 2>/dev/null || {
-        echo "Warning: could not kill terminal PID $pid" >&2
-        _log "destroy-factories" "kill_failed" "pid=$pid"
-    }
+    SCOPE=$(grep -oP 'vte-spawn-[^/]+\.scope' /proc/"$pid"/cgroup 2>/dev/null | head -1)
+    if [ -n "$SCOPE" ]; then
+        _log "destroy-factories" "stop_scope" "pid=$pid scope=$SCOPE"
+        systemctl --user stop "$SCOPE" 2>/dev/null || {
+            echo "Warning: could not stop scope $SCOPE for terminal PID $pid" >&2
+            _log "destroy-factories" "kill_failed" "pid=$pid scope=$SCOPE"
+        }
+    else
+        _log "destroy-factories" "no_scope_fallback" "pid=$pid"
+        kill "$pid" 2>/dev/null || {
+            echo "Warning: could not kill terminal PID $pid" >&2
+            _log "destroy-factories" "kill_failed" "pid=$pid"
+        }
+    fi
     KILLED=$((KILLED + 1))
 done
 
@@ -158,3 +168,24 @@ open_terminal || {
 }
 
 _log "destroy-factories" "done" "terminals_killed=$KILLED"
+
+# ── Step 4: Self-close this terminal ──────────────────────────────────────────
+_log "destroy-factories" "self_close" "pid=$$"
+
+SELF_SCOPE=$(grep -oP 'vte-spawn-[^/]+\.scope' /proc/"$$"/cgroup 2>/dev/null | head -1)
+if [ -n "$SELF_SCOPE" ]; then
+    systemctl --user stop "$SELF_SCOPE" 2>/dev/null || true
+fi
+
+# Also kill any claude ancestor process so the old session fully terminates
+self_pid=$$
+while [ "$self_pid" -gt 1 ]; do
+    self_ppid=$(ps -o ppid= -p "$self_pid" 2>/dev/null | tr -d ' ')
+    self_name=$(ps -o comm= -p "$self_pid" 2>/dev/null | tr -d ' ')
+    if [ "$self_name" = "claude" ]; then
+        kill "$self_pid" 2>/dev/null || true
+        break
+    fi
+    ([ -z "$self_ppid" ] || [ "$self_ppid" -le 1 ]) && break
+    self_pid=$self_ppid
+done

--- a/skills/kill-gnome-terminal-via-vte-cgroup/SKILL.md
+++ b/skills/kill-gnome-terminal-via-vte-cgroup/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: kill-gnome-terminal-via-vte-cgroup
+description: "How to cleanly close a GNOME terminal tab or window from a bash script by stopping its vte-spawn cgroup scope via systemctl --user, with a fallback to plain kill for non-GNOME environments."
+user-invocable: false
+---
+## When to use
+
+Any time a bash script needs to programmatically close a GNOME terminal window or tab — either the calling terminal (self-close) or another terminal identified by PID. This pattern appears in:
+- Scripts that reopen a session in a fresh terminal and must close the installer/caller terminal afterward.
+- Scripts that destroy all factory terminals before spawning a new one.
+
+## Steps
+
+### Closing another terminal (by PID)
+
+1. Read the vte-spawn scope name from the target process's cgroup file:
+   ```bash
+   SCOPE=$(grep -oP 'vte-spawn-[^/]+\.scope' /proc/"$pid"/cgroup 2>/dev/null | head -1)
+   ```
+2. If a scope was found, stop it via systemctl:
+   ```bash
+   if [ -n "$SCOPE" ]; then
+       systemctl --user stop "$SCOPE" 2>/dev/null || {
+           echo "Warning: could not stop scope $SCOPE for PID $pid" >&2
+       }
+   else
+       # Fallback for non-GNOME environments (xterm, konsole, etc.)
+       kill "$pid" 2>/dev/null || echo "Warning: could not kill PID $pid" >&2
+   fi
+   ```
+
+### Self-closing (closing the current terminal)
+
+1. Read the current process's own scope:
+   ```bash
+   SELF_SCOPE=$(grep -oP 'vte-spawn-[^/]+\.scope' /proc/"$$"/cgroup 2>/dev/null | head -1)
+   if [ -n "$SELF_SCOPE" ]; then
+       systemctl --user stop "$SELF_SCOPE" 2>/dev/null || true
+   fi
+   ```
+2. After stopping the scope, also kill the ancestor `claude` process so the session fully terminates (the scope stop closes the terminal but the claude process may linger):
+   ```bash
+   pid=$$
+   while [ "$pid" -gt 1 ]; do
+       ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+       name=$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ')
+       if [ "$name" = "claude" ]; then
+           kill "$pid" 2>/dev/null || true
+           break
+       fi
+       ([ -z "$ppid" ] || [ "$ppid" -le 1 ]) && break
+       pid=$ppid
+   done
+   ```
+
+## Notes
+
+- The `vte-spawn-*.scope` cgroup entry only exists on GNOME/VTE-based terminals (gnome-terminal). Other emulators (xterm, konsole, x-terminal-emulator) will not have this entry, so the plain `kill` fallback is required for portability.
+- `systemctl --user stop <scope>` sends SIGTERM to all processes in the cgroup and waits for them to exit — cleaner than a raw `kill` on the terminal PID, which may leave child processes orphaned.
+- Stopping the cgroup scope closes the terminal window but does not necessarily terminate the `claude` process that was running inside it. Always follow up with the process-tree walk to kill the `claude` ancestor when a full session teardown is needed.
+- The grep pattern `vte-spawn-[^/]+\.scope` is anchored to extract only the scope name segment regardless of the full cgroup path format, which varies between kernel versions.
+- Both `destroy-factories.sh` and `reopen-remote-control.sh` use this exact pattern — treat those files as authoritative references.


### PR DESCRIPTION
## Description

# Add `destroy-factories` Command

## System Intent

- What is being built: A new slash command `destroy-factories` that terminates all other running Claude / dark-factory terminal sessions and spawns one fresh factory terminal, leaving the user with exactly one active terminal.
- Primary consumer(s): Developers who want to reset all running dark-factory sessions back to a single clean state. Invoked via `/dark-factory:destroy-factories`.
- Boundary (black-box scope only):
  - `commands/destroy-factories.md` — the slash command entrypoint
  - `scripts/destroy-factories.sh` — the shell script that finds Claude terminals, kills them, and spawns a fresh one
  - Safety constraint: only terminals running `claude` processes are targeted; unrelated terminals are never touched.
  - Platform: Linux (same as `reopen-remote-control.sh`); documents supported platforms explicitly.

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [ ] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

> Use the skill at `skills/create-mermaid-diagram/SKILL.md` to generate this diagram.

```mermaid
graph TD
  User["User: /dark-factory:destroy-factories"]:::unchanged -->|"bash scripts/destroy-factories.sh"| Script["destroy-factories.sh"]:::created
  Script --> FindClaude["find_claude_terminals(): scan terminal PIDs for claude ancestor"]:::created
  FindClaude -->|"claude terminals found"| KillAll["kill each terminal (SIGTERM)"]:::created
  FindClaude -->|"none found"| SpawnOnly["skip kill step"]:::unchanged
  KillAll --> SpawnFresh["open_terminal(): spawn new claude /remote-control"]:::unchanged
  SpawnOnly --> SpawnFresh
  SpawnFresh -->|"success"| Done["User has exactly one fresh factory terminal"]:::unchanged
  SpawnFresh -->|"failure"| Error["echo error to stderr, exit non-zero"]:::unchanged

classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
```

## Flows

- Flow naming rule: `### Flow: <flowname>`
- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).

### Global Types

```txt
StandardError {
  message: string (human-readable description of what went wrong)
}
```

### Flow: `destroy-factories`
- Test files: `tests/test_destroy_factories.py`
- Core files: `commands/destroy-factories.md`, `scripts/destroy-factories.sh`

#### Types

```txt
DestroyFactoriesInput {
  name: string (optional, default: "dark factory" — remote-control session name for the new terminal)
}

DestroyFactoriesOutput {
  void (side effects: all Claude terminals killed, one new factory terminal spawned)
}

StandardError {
  message: string (written to stderr)
}
```

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `destroy-factories.success` | `DestroyFactoriesInput` | `DestroyFactoriesOutput` | `happy path` | All Claude terminals found and killed; new factory terminal spawned successfully | |
| `destroy-factories.none-found` | `DestroyFactoriesInput` | `DestroyFactoriesOutput` | `happy path` | No other Claude terminals found; new factory terminal spawned (no kills needed) | |
| `destroy-factories.kill-failed` | `DestroyFactoriesInput` | `StandardError` | `degraded` | One or more terminals could not be killed (permission error); warns to stderr, continues to spawn | |
| `destroy-factories.spawn-failed` | `DestroyFactoriesInput` | `StandardError` | `error` | New terminal could not be opened (no terminal emulator found or emulator returned non-zero); exits non-zero | |

#### Pseudocode

```
NAME = argv[1] ?? "dark factory"

find_claude_terminals():
  own_ancestor_pid = find_terminal_ancestor($$)
  for each terminal_pid in all_terminal_emulator_pids():
    if terminal_pid == own_ancestor_pid: skip
    if has_claude_descendant(terminal_pid):
      yield terminal_pid

for pid in find_claude_terminals():
  kill pid || warn("could not kill PID $pid")

open_terminal(NAME) || { echo error; exit 1 }
```

## Logs

| Source | Location |
|--------|----------|
| script stderr | terminal session running the destroy-factories command |

## Deployment

- Mechanism: `local only`
- Deploy command:
  ```bash
  bash scripts/destroy-factories.sh "dark factory"
  ```
- Notes: Linux only. Requires at least one of: gnome-terminal, x-terminal-emulator, xterm, or konsole. The script is safe by design — it only kills terminals whose process tree contains a `claude` descendant.

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/lewibs/github/dark_factory/dark_factory-fix-destroy-factories-kill
collecting ... collected 9 items

tests/test_destroy_factories.py::test_destroy_factories_success PASSED   [ 11%]
tests/test_destroy_factories.py::test_destroy_factories_none_found PASSED [ 22%]
tests/test_destroy_factories.py::test_destroy_factories_kill_failed PASSED [ 33%]
tests/test_destroy_factories.py::test_destroy_factories_spawn_failed PASSED [ 44%]
tests/test_destroy_factories.py::test_destroy_factories_excludes_own_ancestor PASSED [ 55%]
tests/test_destroy_factories.py::test_destroy_factories_script_exists_and_executable PASSED [ 66%]
tests/test_destroy_factories.py::test_destroy_factories_has_shebang PASSED [ 77%]
tests/test_destroy_factories.py::test_destroy_factories_accepts_name_argument PASSED [ 88%]
tests/test_destroy_factories.py::test_destroy_factories_only_kills_claude_terminals PASSED [100%]

============================== 9 passed in 0.01s ===============================
```

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
