### PR TITLE
feat(fix-flow): accumulate fixes on single branch and create one PR

### DIFF
--- a/agents/fix-flow/agents/fix-flow-orchestrator.md
+++ b/agents/fix-flow/agents/fix-flow-orchestrator.md
@@ -43,11 +43,12 @@ Spawn a sub-agent using the instructions in ralph-fix-and-push.
 
 Pass it:
 - Paths to all generated scripts from Phase 2
+- branchName (e.g., "feature/fix-flow-single-branch")
 
-Wait for it to finish. It will return all the PRs that it made.
+Wait for it to finish. It will return a single PR with all accumulated fixes.
 
 ## Completion
 
 When ralph-fix-and-push returns all-green:
-1. Report success to the developer with the list of PR URLs
+1. Report success to the developer with the PR URL
 2. Note that `docs/plans/system-diagram.md` and any `docs/bugs/` files are kept as persistent project documentation.

--- a/agents/fix-flow/agents/ralph-fix-and-push.md
+++ b/agents/fix-flow/agents/ralph-fix-and-push.md
@@ -1,44 +1,82 @@
 ---
 name: ralph-fix-and-push
-description: Owns the bug-fixing loop for fix-flow-orchestrator. Spawns debugger-agent and pr-agent repeatedly until the integration flow passes green. Use after setup-wizard has generated the scripts.
+description: Owns the bug-fixing loop for fix-flow-orchestrator. Spawns debugger-agent repeatedly until the integration flow passes green, accumulating all fixes as commits on a single feature branch. Creates one PR for all accumulated fixes at the end. Use after setup-wizard has generated the scripts.
 tools: Read, Bash, Agent, PushNotification, AskUserQuestion
 model: haiku
 user-invocable: false
-allowed-tools: Bash(bash *), Bash(find *)
+allowed-tools: Bash(bash *), Bash(find *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *)
 ---
 
-You are ralph-fix-and-push. You own the fix loop. Your job is to keep iterating — trigger the flow, debug failures, ship fixes as PRs — until the flow passes green.
+You are ralph-fix-and-push. You own the fix loop. Your job is to keep iterating — trigger the flow, debug failures, commit fixes locally — until the flow passes green, then create a single PR with all accumulated commits.
+
+## Input
+
+You receive:
+- `scriptPaths` — paths to trigger.sh, wait-for-completion.sh, fetch-logs.sh, and optional deploy.sh
+- `previousBugDocs` — list of all previous docs/bugs/*.md file paths (may be empty on first call)
+- `branchName` — the feature branch to commit to (e.g. `feature/fix-flow-single-branch`)
 
 ## Your task
 
-1. Receive the script paths from the orchestrator.
-2. Run the loop:
-
 ```
+bugDocPaths = []
+
 loop:
-  a. Spawn debugger-agent with script paths + list of all previous bug-explanation files
+  a. Spawn debugger-agent with scriptPaths + previousBugDocs
   b. debugger-agent writes docs/bugs/bug-explanation-<N>.md (N = iteration number)
-  c. If the bug was resolved, exit loop
-  d. Spawn pr-agent with docs/bugs/bug-explanation-<N>.md
-  e. Receive back: { pr_url, merged: true }
+  c. Store the bugDocPath from debugger-agent result
+     bugDocPaths.append(bugDocPath)
+  d. Commit the fix locally on branchName
+     - if debugResult.fixed == true:
+       * git add -A
+       * git commit -m "fix: resolve bug from docs/bugs/$(basename $bugDocPath)"
+       * break loop (flow passed)
+     - if debugResult.fixed == false:
+       * git add -A
+       * git commit -m "fix: attempt fix from docs/bugs/$(basename $bugDocPath)"
+       * previousBugDocs.append(bugDocPath)
+       * continue loop
+  e. If debugResult.stuck (same root cause repeats with no progress):
+     * Call PushNotification with title "Debugging Stuck — Input Required" and message "The debugger-agent is stuck on a repeated root cause and needs your guidance to proceed."
+     * Use AskUserQuestion to ask user for guidance or to abort
+     * Do not re-attempt the same fix
   f. If deploy.sh exists → run it to get the fix live
   g. Go back to step a
+
+# After loop exits (flow passed), create single PR with all accumulated commits
+bugFileLinks = format_pr_body(bugDocPaths)  # Format as markdown links
+
+prResult = spawn pr-agent(
+  planFilePath = null,
+  taskDescription = "Fix integration flow: accumulated fixes from: " + bugFileLinks,
+  prBody = "## Fixes\n\nThis PR accumulates all bug fixes for the integration flow:\n" + bugFileLinks
+)
+
+return { 
+  pr_url: prResult.pr_url,
+  merged: prResult.merged,
+  bugFiles: bugDocPaths,
+  allGreen: true
+}
 ```
 
-3. Return `{ all_green: true, pr_urls: [...] }` to the orchestrator.
+## Stopping conditions
+
+- Flow passes (exit_code 0 from debugger-agent) → commit, then create single PR with all accumulated commits
+- Debugger-agent is stuck (same root cause appears in the new bug-explanation as in a previous one, with no new progress) → call PushNotification with title: "Debugging Stuck — Input Required" and message: "The debugger-agent is stuck on a repeated root cause and needs your guidance to proceed." Then use AskUserQuestion with header "Debugging Stuck", question "Debugger is stuck on the same root cause. How would you like to proceed?", and options: "Provide new direction (use Other to type guidance)" and "Abort — stop the fix loop". Do not re-attempt the same fix.
+
+## Output
+
+Return `{ pr_url: "...", merged: true, bugFiles: [...], allGreen: true }` to the orchestrator.
 
 ## Rules
 
 - Never debug yourself. Always delegate to debugger-agent.
 - Never touch GitHub yourself. Always delegate to pr-agent.
-- Track all PR URLs across iterations and include them all in the final result.
-- If debugger-agent returns exit_code 0, skip pr-agent and return immediately.
+- Do NOT create a PR on each iteration. Only create ONE PR after all bugs are fixed.
+- Track all bug doc file paths across iterations and include them all in the final PR body.
+- If debugger-agent returns exit_code 0, commit the fix, then create the single PR and return immediately.
 - If deploy.sh does not exist, skip the deploy step.
-
-## Stopping conditions
-
-- Flow passes (exit_code 0 from debugger-agent) → return all-green
-- Debugger-agent is stuck (same root cause appears in the new bug-explanation as in a previous one, with no new progress) → call PushNotification with title: "Debugging Stuck — Input Required" and message: "The debugger-agent is stuck on a repeated root cause and needs your guidance to proceed." Then use AskUserQuestion with header "Debugging Stuck", question "Debugger is stuck on the same root cause. How would you like to proceed?", and options: "Provide new direction (use Other to type guidance)" and "Abort — stop the fix loop". Do not re-attempt the same fix.
 
 ## Bug explanation files
 

--- a/docs/docs/fix-broken-flow.md
+++ b/docs/docs/fix-broken-flow.md
@@ -19,8 +19,10 @@ flowchart TD
   SystemDiagram --> Phase2["Phase 2: setup-wizard(system-diagram.md)"]
   Phase2 --> Scripts["/tmp/fix-flow-orchestrator/scripts/\ntrigger.sh\nwait-for-completion.sh\nfetch-logs.sh\n[deploy.sh]"]
   Scripts --> Phase3["Phase 3: ralph-fix-and-push(scriptPaths)"]
-  Phase3 --> DebugLoop["Loop:\n1. debugger-agent(scripts + prev bugs)\n2. pr-agent(bug file)\n3. deploy.sh (if exists)\n4. repeat until green"]
-  DebugLoop -->|all green| Done["Report: all-green. PR URLs: [...]"]
+  Phase3 --> DebugLoop["Loop:\n1. debugger-agent(scripts + prev bugs)\n2. git commit fix locally\n3. deploy.sh (if exists)\n4. repeat until green"]
+  DebugLoop -->|all green| Accumulate["Collect all docs/bugs/*.md files\nformat as PR body links"]
+  Accumulate --> CreatePR["pr-agent: create 1 PR\nwith all accumulated commits"]
+  CreatePR --> Done["Report: all-green. Single PR URL"]
   DebugLoop -->|stuck| Push2["PushNotification: Debugging Stuck\nAsk developer how to proceed"]
 ```
 
@@ -39,7 +41,8 @@ FixBrokenFlowInput {
 
 FixBrokenFlowOutput {
   all_green: true
-  pr_urls: string[] (all PRs merged during the fix loop)
+  pr_url: string (single PR containing all accumulated fixes)
+  bugFiles: string[] (all docs/bugs/*.md files created during the fix loop)
 }
 
 StandardError {
@@ -70,26 +73,37 @@ fix-flow-orchestrator(flowName):
   → writes /tmp/fix-flow-orchestrator/scripts/{trigger,wait-for-completion,fetch-logs,[deploy]}.sh
   assert all required scripts exist and are executable before proceeding
 
-  # Phase 3 — fix loop
+  # Phase 3 — fix loop (accumulate fixes on single branch)
   ralph-fix-and-push(scriptPaths):
-    previousBugFiles = []
+    bugDocPaths = []
     loop:
       debugger-agent(scriptPaths, previousBugFiles)
       → writes docs/bugs/bug-explanation-<N>.md
-      previousBugFiles.append(bugFile)
+      bugDocPath = result.bugDocPath
+      bugDocPaths.append(bugDocPath)
 
-      if resolved: break
-
-      pr-agent(bugFile)
-      → { pr_url, status: "ready" }
-      merge PR (caller responsibility)
-      prUrls.append(pr_url)
+      if resolved (fixed == true):
+        git add -A
+        git commit -m "fix: resolve bug from docs/bugs/$(basename $bugDocPath)"
+        break loop
+      else:
+        git add -A
+        git commit -m "fix: attempt fix from docs/bugs/$(basename $bugDocPath)"
+        previousBugFiles.append(bugDocPath)
 
       if deploy.sh exists: run deploy.sh
 
-    return { all_green: true, pr_urls }
+    # All bugs fixed — create single PR with all accumulated commits
+    bugFileLinks = format_pr_body(bugDocPaths)
+    pr-agent(
+      taskDescription = "Fix integration flow: accumulated fixes from: " + bugFileLinks,
+      prBody = "## Fixes\n\nThis PR accumulates all bug fixes for the integration flow:\n" + bugFileLinks
+    )
+    → { pr_url, merged }
 
-  report success with all PR URLs
+    return { all_green: true, pr_url, bugFiles: bugDocPaths }
+
+  report success with single PR URL
 ```
 
 ### Flow: `setupScripts`

--- a/docs/plans/2026-04-28-fix-flow-single-branch.md
+++ b/docs/plans/2026-04-28-fix-flow-single-branch.md
@@ -1,0 +1,207 @@
+# Fix-Flow Single-Branch Accumulation
+
+## System Intent
+
+- **What is being built**: Restructure the dark-factory fix flow to accumulate all bug fixes on a single feature branch as commits, rather than creating a new PR for each bug. All fixes accumulate in one branch / one PR, with the PR description automatically linking to every `docs/bugs/*.md` file produced during the fix work.
+  
+- **Primary consumer(s)**: Dark-factory development process. When bugs are discovered during feature validation or integration testing, fixes should be committed to the same feature branch and accumulated in one PR rather than spawning multiple PRs.
+
+- **Boundary (black-box scope only)**:
+  - The fix-flow agents (`agents/fix-flow/`) that orchestrate bug discovery, planning, and implementation
+  - The pr-agent integration that accepts multi-file input and creates single PR
+  - PR generation logic that collects all `docs/bugs/*.md` files produced and links them in the PR description
+  - Commit message formatting to indicate these are fixes on the current feature branch
+  - No changes to fundamental planning/execution architecture; only the fix-flow subprocess model
+
+## Stage Gate Tracker
+
+- [ ] Stage 1 Mermaid approved
+- [ ] Stage 2 Flows approved
+- [ ] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+> Use the skill at `skills/create-mermaid-diagram/SKILL.md` to generate this diagram.
+
+```mermaid
+graph TD
+  User["Feature Work in Progress"]:::unchanged -->|"Bug Discovered During Execution"| DiscoverBug["Bug identified by integration test"]:::unchanged
+  DiscoverBug --> CreateBugDoc["Create docs/bugs/<date>-<slug>.md"]:::created
+  CreateBugDoc --> InvokeFix["Invoke fix-flow"]:::created
+  InvokeFix --> PlanFix["Plan the fix"]:::created
+  PlanFix --> ImplementFix["Implement fix (ralph-fix-and-push)"]:::created
+  ImplementFix --> CommitFix["git add --all + git commit"]:::created
+  CommitFix --> RecordBug["Add path to accumulated_bug_files list"]:::created
+  RecordBug -->|"More bugs?"| DiscoverBug
+  RecordBug -->|"Integration test green"| CollectDocs["Collect all accumulated_bug_files"]:::created
+  CollectDocs --> BuildPRDesc["Build PR description with bug links"]:::created
+  BuildPRDesc --> InvokeRalphPR["Spawn pr-agent with accumulated files"]:::created
+  InvokeRalphPR --> CreatePR["Create single PR to main"]:::created
+  CreatePR --> Done["Feature PR submitted with bug docs linked"]:::unchanged
+
+  classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+  classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Flows
+
+- Flow naming rule: `### Flow: <flowname>`
+- `N/A` for test files means no test file required.
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+### Flow: `ralph-commit-per-fix`
+
+**File:** `agents/fix-flow/agents/ralph-fix-and-push.md`
+
+**Test files:** N/A (agent instruction file, tested end-to-end)
+
+**Current loop (to replace):**
+```
+loop N:
+  a. Spawn debugger-agent → writes docs/bugs/bug-explanation-N.md
+  b. If exit_code 0 (flow passed), break
+  c. Spawn pr-agent(docs/bugs/bug-explanation-N.md) → { pr_url, status: "ready" }
+  d. Optionally run deploy.sh
+```
+
+**New loop:**
+```
+loop N:
+  a. Spawn debugger-agent → writes docs/bugs/bug-explanation-N.md
+  b. If exit_code 0 (flow passed), break
+  c. git add --all
+     git commit -m "fix: <title from bug-explanation-N.md>"
+  d. Append docs/bugs/bug-explanation-N.md to accumulated_bug_files list
+  e. Optionally run deploy.sh
+
+After loop exits with all-green:
+  f. Spawn pr-agent(accumulated_bug_files=[path1, path2, ...])
+  g. Receive { pr_url, status: "ready" }
+  h. Return { all_green: true, pr_url }   ← single url, not an array
+```
+
+**Rule changes:**
+- Remove: "Never touch GitHub yourself. Always delegate to pr-agent." inside the loop
+- Add: commit the fix to the current branch after each debugger-agent iteration (exit_code 1)
+- Add: collect all bug file paths in a list across iterations
+- Add: spawn pr-agent exactly once after the loop, passing the full bug files list
+- Change return value from `{ all_green: true, pr_urls: [...] }` to `{ all_green: true, pr_url: "..." }`
+
+---
+
+### Flow: `pr-agent-multi-file`
+
+**File:** `agents/pr/agents/pr-agent.md`
+
+**Test files:** N/A (agent instruction file)
+
+**Changes to Input section:**
+- Accept either:
+  - A **single file path** — existing behavior for callers outside fix-flow
+  - A **list of file paths** — new behavior when called from ralph-fix-and-push
+
+**Changes to task steps:**
+
+Step 1 (Build PR body) — multi-file case:
+- Description section: render a markdown list with a link to each bug file
+  ```markdown
+  ## Bug Fixes
+  - [2026-04-28-bug-one](docs/bugs/2026-04-28-bug-one.md)
+  - [2026-04-28-bug-two](docs/bugs/2026-04-28-bug-two.md)
+
+  ---
+  <full raw contents of bug-explanation-1.md>
+
+  ---
+  <full raw contents of bug-explanation-2.md>
+  ```
+- Test Plan: run the project test suite (unchanged)
+
+Step 2 (currently "Create branch") — **remove when called from ralph**:
+- When a list of files is passed (ralph mode), skip branch creation. The current branch already has all commits.
+- When a single file is passed (existing mode), keep current branch creation behavior.
+
+Step 3 (currently "Stage and commit") — **remove when called from ralph**:
+- When a list of files is passed (ralph mode), skip staging and committing. Already committed by ralph.
+- When a single file is passed (existing mode), keep current staging and commit behavior.
+
+Step 4 (push + `gh pr create`) — **add push step in ralph mode**:
+- In ralph mode: `git push -u origin HEAD` before `gh pr create`
+- In single-file mode: push happens as part of existing branch creation
+
+Steps 5–6 (CI loop, comment resolution loop): unchanged in both modes.
+
+Return value: `{ pr_url, status: "ready" }` — unchanged.
+
+**Brain Patch:** unchanged.
+
+---
+
+### Flow: `create-pr-no-branch`
+
+**File:** `agents/pr/skills/create-pr/SKILL.md`
+
+**Change:** Add a note at the top of the Steps section:
+
+```
+> Note: When the fix has already been committed to the current branch (ralph-fix-and-push mode),
+> skip Steps 1–2. Start from Step 3: push the branch and open the PR.
+```
+
+No other changes to this file.
+
+---
+
+### Flow: `orchestrator-single-pr`
+
+**File:** `agents/fix-flow/agents/fix-flow-orchestrator.md`
+
+**Change — Phase 3 result:** ralph-fix-and-push now returns `{ all_green: true, pr_url }` (single string, not `pr_urls` array).
+
+**Change — Completion section:**
+```
+When ralph-fix-and-push returns all-green:
+1. Report success to the developer with the single PR URL
+2. Note that docs/plans/system-diagram.md and any docs/bugs/ files are kept as persistent project documentation.
+```
+
+---
+
+### Flow: `update-fix-broken-flow-docs`
+
+**File:** `docs/docs/fix-broken-flow.md`
+
+**Changes:**
+- Update the `fixBrokenFlow` flow description: remove "opens a PR per bug fix", replace with "commits each fix to the current branch; opens one PR at the end"
+- Update the mermaid diagram to show: `ralph loop → commit → [loop back] → pr-agent (once) → single PR`
+- Update the `paths` table: remove `fix-per-bug.pr-per-iteration` path, add `fix-per-bug.single-pr-at-end` path
+- Note in the PR description section: "links to all docs/bugs/*.md files produced"
+
+---
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| fix-flow execution | `~/.claude/dark-factory/fix-flow-<date>-<slug>/execution.log` |
+| bug documentation | `docs/bugs/<date>-<slug>.md` |
+
+## Deployment
+
+- Mechanism: `no deployment required` (this is infrastructure for dark-factory)
+- Notes: Changes are shipped as part of the dark-factory main branch release.
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Handoff to Related Plan Reconciliation
+
+After all stages are approved, no plan reconciliation needed (this is internal to dark-factory).

--- a/skills/declare-tools-in-agent-frontmatter/SKILL.md
+++ b/skills/declare-tools-in-agent-frontmatter/SKILL.md
@@ -27,6 +27,10 @@ Use this whenever you create or modify an agent file (any `agents/**/*.md`) that
 - The same gate applies to skills: if a skill slug is invoked in the body but omitted from `skills:`, the agent cannot load it at runtime.
 - `PushNotification` is particularly easy to miss because it was added to agent bodies as a "notify before blocking on input" pattern after the initial `tools:` lists were written. Any future agent that adds this pattern must remember to add `PushNotification` to `tools:` as well.
 - `Skill` must be listed in `tools:` whenever an agent invokes any skill via the `Skill` tool. If an existing agent file gains its first skill invocation, `Skill` must be added to `tools:` at the same time — it is not implicitly available. This was a concrete omission discovered when adding the `open-in-vscode` skill call to `feature-agent`.
-- The `allowed-tools:` field (which restricts which sub-commands of `Bash` are permitted) is separate from `tools:` — both may need to be updated when adding new tool usage.
+- The `allowed-tools:` field (which restricts which sub-commands of `Bash` are permitted) is separate from `tools:` — both may need to be updated when adding new tool usage. For example, when an agent is updated to perform local git operations, add the required git subcommands explicitly:
+  ```yaml
+  allowed-tools: Bash(bash *), Bash(find *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *)
+  ```
+  Without these entries, the agent will be blocked from running those git commands at runtime.
 - A regression test (`tests/test_push_notification_declared.py`) exists in this repo that parses the YAML front-matter of all agent files and asserts `PushNotification` is present in `tools:` for every agent that references it in its body. Run this test after modifying agent files to catch omissions early.
 - When adding a new skill invocation to an existing agent (e.g., adding `skills/logging/SKILL.md` to `implementation-agent.md`), always update the `skills:` field in the same edit — do not treat it as optional cleanup.

--- a/skills/fix-loop-accumulate-commits-single-pr/SKILL.md
+++ b/skills/fix-loop-accumulate-commits-single-pr/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: fix-loop-accumulate-commits-single-pr
+description: "Use this skill when designing any iterative fix loop (e.g., ralph-fix-and-push) to accumulate all fixes as local git commits on the current feature branch and create a single PR only after the loop exits successfully."
+user-invocable: false
+---
+## When to use
+
+Any time you write or modify an agent that:
+- Iterates over repeated fix attempts (debug → fix → re-test → repeat)
+- Previously created a PR per iteration
+
+The correct pattern is to commit each fix locally and create ONE PR after all bugs are resolved.
+
+## Steps
+
+1. At the start of the agent, initialize a list to track bug doc file paths:
+   ```
+   bugDocPaths = []
+   ```
+
+2. After each fix attempt inside the loop, commit locally — do NOT spawn pr-agent yet:
+   ```
+   git add -A
+   git commit -m "fix: resolve bug from docs/bugs/$(basename $bugDocPath)"
+   ```
+   For partial fixes (flow still failing), use a descriptive message:
+   ```
+   git commit -m "fix: attempt fix from docs/bugs/$(basename $bugDocPath)"
+   ```
+
+3. Append the bug doc path to the tracking list on every iteration:
+   ```
+   bugDocPaths.append(bugDocPath)
+   ```
+
+4. After the loop exits (flow passes green), format all bug doc paths as markdown links and pass them to pr-agent in the PR body:
+   ```
+   bugFileLinks = format_pr_body(bugDocPaths)
+   prResult = spawn pr-agent(
+     taskDescription = "Fix integration flow: accumulated fixes from: " + bugFileLinks,
+     prBody = "## Fixes\n\nThis PR accumulates all bug fixes for the integration flow:\n" + bugFileLinks
+   )
+   ```
+
+5. Return a single `pr_url` (not an array) plus `bugFiles` from the agent:
+   ```
+   return { pr_url: prResult.pr_url, merged: prResult.merged, bugFiles: bugDocPaths, allGreen: true }
+   ```
+
+6. Update the agent's `allowed-tools` front-matter to include the git subcommands used:
+   ```yaml
+   allowed-tools: Bash(bash *), Bash(find *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *)
+   ```
+
+## Notes
+
+- The instinct to create a PR per iteration is wrong for iterative fix loops. It creates noisy PR history and blocks the flow until each PR is merged before the next iteration can push.
+- Only call pr-agent once, after the loop exits. The single PR will contain all accumulated commits from every iteration.
+- If the loop gets stuck (same root cause repeats with no progress), call PushNotification + AskUserQuestion before aborting — do not create a PR for a stuck loop.
+- The output contract changes from `pr_urls: string[]` to `pr_url: string` when migrating from per-iteration to single-PR. Any upstream orchestrator that previously reported a list of PR URLs must be updated to report the single URL.
+- This pattern was introduced in the 2026-04-28 fix-flow-single-branch change to `ralph-fix-and-push.md`.


### PR DESCRIPTION
## Description

# Change Fix Flow to Single Branch with Accumulated Commits

## System Intent

- What is being built: Modify the fix-flow loop to accumulate all bug fixes as commits on a single feature branch instead of creating a new PR for each fix. The final PR will contain all fixes and link to all `docs/bugs/*.md` files produced during the fix loop.
- Primary consumer(s): `ralph-fix-and-push` agent (the fix loop orchestrator), developers using `/dark-factory:manufacture` with broken integration flows
- Boundary (black-box scope only): The fix-flow input contract (flow name, script paths) and output contract (single PR URL containing all commits, list of bug doc files) remain the same from the user perspective. Internal implementation changes how PRs are created and merged.

## Stage Gate Tracker

- [ ] Stage 1 Mermaid approved
- [ ] Stage 2 Flows approved
- [ ] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

```mermaid
graph TD
  RFP["ralph-fix-and-push\n(fix loop agent)"]:::unchanged -->|Spawn| DA["debugger-agent\n(debug single issue)"]:::unchanged
  DA -->|Write| BUG1["docs/bugs/bug-1.md\ndocs/bugs/bug-2.md\netc."]:::unchanged
  
  RFP -->|OLD FLOW\nper iteration| OldPR["pr-agent\n(create new PR)"]:::removed
  OldPR -->|Create| ManyPRs["PR #1, PR #2, PR #3..."]:::removed
  
  RFP -->|NEW FLOW\nper iteration| LocalCommit["Git commit\n(on feature branch)"]:::created
  LocalCommit -->|Accumulate on| Branch["feature/fix-flow-single-branch\n(one branch)"]:::created
  
  RFP -->|After all bugs fixed| CollectBugs["Collect all bug doc\nfile paths"]:::created
  CollectBugs -->|Single PR with links| FinalPR["pr-agent\n(create 1 PR)"]:::created
  FinalPR -->|Returns| OneURL["{ pr_url: '...', \nmerged: true }"]:::created
  OneURL -->|Back to| Orch["fix-flow-orchestrator"]:::unchanged

  classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
  classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
  classDef removed fill:#ffb3b3,stroke:#666,stroke-width:1px;
```

## Flows

### Global Types

```txt
StandardError {
  message: string (human-readable description of what went wrong)
}

FixLoopIteration {
  bugDocPath: string (absolute path to docs/bugs/bug-N.md written by debugger-agent)
  fixed: boolean (true if the bug was resolved and flow now passes)
}
```

### Flow: fixLoopIteration

- Test files: N/A (ralph-fix-and-push is integration-tested via fix-flow-orchestrator end-to-end tests)
- Core files: agents/fix-flow/agents/ralph-fix-and-push.md, agents/pr/agents/pr-agent.md, agents/debugger/agents/debugger-agent.md

#### Types

```txt
FixLoopIterationInput {
  scriptPaths: {
    trigger: string (path to trigger.sh)
    waitForCompletion: string (path to wait-for-completion.sh)
    fetchLogs: string (path to fetch-logs.sh)
    deploy?: string (path to deploy.sh, optional)
  }
  previousBugDocs: string[] (list of all previous docs/bugs/*.md file paths)
  branchName: string (the feature branch to commit to)
}

FixLoopIterationOutput {
  bugDocPath: string (absolute path to the new docs/bugs/bug-N.md)
  fixed: boolean (true if flow passed after this iteration's fix)
  commitHash: string (git commit hash of the fix, only if fixed=true)
}
```

### Flow: prAgentIntegration

- Test files: N/A
- Core files: agents/pr/agents/pr-agent.md, agents/fix-flow/agents/ralph-fix-and-push.md

## Implementation Notes

### Key Changes to ralph-fix-and-push.md

1. **Remove per-iteration PR creation**: Currently calls pr-agent after each debugger-agent iteration. This must change to only create a PR after all bugs are fixed.

2. **Add local git commits**: After each debugger-agent writes a bug doc and fixes are applied, commit locally with a clear message. No push yet.

3. **Collect bug doc paths**: Track all docs/bugs/*.md files written during the loop.

4. **Create single PR with all commits**: After the loop exits (when flow passes), create ONE PR that contains all accumulated commits.

5. **Update output contract**: Return { pr_url: "...", merged: true, bugFiles: [...] } (single URL) instead of array of URLs.

### Impact Analysis

**Affected agents:**
- ralph-fix-and-push.md — core changes to fix loop logic
- pr-agent.md — may need minor updates to accept formatted PR body with bug links
- fix-flow-orchestrator.md — may need to report differently (single PR instead of multiple)

**Unchanged:**
- debugger-agent.md — continues to write docs/bugs/*.md files unchanged
- setup-wizard.md — continues to generate script templates
- investigation-agent.md — continues to document systems

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
