### PR TITLE
feat(plugin): bundle scripts with plugin using CLAUDE_PLUGIN_ROOT

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"
@@ -9,6 +9,7 @@
   "repository": "https://github.com/lewibs/dark-factory",
   "license": "MIT",
   "commands": "./commands/",
+  "hooks": "./hooks/hooks.json",
   "skills": [
     "./skills/",
     "./agents/debugger/skills/",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,39 +1,4 @@
 {
-  "hooks": {
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "if [ -n \"$DARK_FACTORY_WORK_DIR\" ] && [ -n \"$DARK_FACTORY_TASK_NAME\" ]; then bash agents/dark-factory/scripts/cleanup-worktree.sh \"$DARK_FACTORY_WORK_DIR\" \"$DARK_FACTORY_TASK_NAME\"; fi"
-          }
-        ]
-      }
-    ],
-    "PreToolUse": [
-      {
-        "matcher": "Agent",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash agents/dark-factory/scripts/pre-tool-use-hook.sh"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Agent",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash agents/dark-factory/scripts/post-tool-use-hook.sh"
-          }
-        ]
-      }
-    ]
-  },
   "permissions": {
     "allow": [
       "WebSearch",

--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -4,8 +4,8 @@ user-invocable: true
 description: Top-level dark-factory orchestrator. Preps an isolated work dir, routes to the right worker agent (feature/fix-flow/debugger/repair-implementation), runs code review and doc housekeeping, opens a PR, then removes the work dir.
 tools: Read, Bash, Agent, PushNotification, AskUserQuestion
 model: haiku
-scripts: agents/dark-factory/scripts/prep-feature-dir.sh, agents/dark-factory/scripts/cleanup-worktree.sh
-allowed-tools: Bash(bash agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(bash agents/dark-factory/scripts/cleanup-worktree.sh *), Bash(jq *), Bash(rm -f *), Bash(export *), Bash(python3 scripts/update-metrics.py *), Bash(echo * > /tmp/dark-factory-work-dir)
+scripts: ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh, ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh
+allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh *), Bash(jq *), Bash(rm -f *), Bash(export *), Bash(python3 ${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py *), Bash(echo * > /tmp/dark-factory-work-dir)
 ---
 
 You are the dark-factory-agent. Your job is to orchestrate an entire unit of work end-to-end: isolate it in a fresh working directory, delegate to the right worker, review the result, keep docs current, ship a PR, and clean up. You do not write code or modify files yourself — you delegate entirely.
@@ -24,7 +24,7 @@ All paths are relative to the project dir (or CWD when the agent is running insi
 
 | Resource | Path |
 |---|---|
-| `prep-feature-dir.sh` | `agents/dark-factory/scripts/prep-feature-dir.sh` |
+| `prep-feature-dir.sh` | `${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh` |
 | `feature-agent` | `agents/featurework/agents/feature-agent.md` |
 | `debugger-agent` | `agents/debugger/agents/debugger-agent.md` |
 | `fix-flow-orchestrator` | `agents/fix-flow/agents/fix-flow-orchestrator.md` |
@@ -44,7 +44,7 @@ dark-factory-agent(taskDescription, taskName):
 
   # Step 2 — prep isolated work dir (all routes)
   Run from the project root (git repo):
-    bash agents/dark-factory/scripts/prep-feature-dir.sh <taskName>
+    bash "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh" <taskName>
 
   Capture WORK_DIR from stdout line: WORK_DIR=<value>
   If script fails: report error and STOP (no cleanup needed — worktree was never created)
@@ -181,7 +181,7 @@ dark-factory-agent(taskDescription, taskName):
   # Step 7 — cleanup
   # metrics.flush — flush brain.json metrics to the permanent project-level CSV before deleting brain.json
   PROJECT_DIR = brain.json.projectDir  (the original git project root — not the worktree; stored at brain.create time)
-  python3 scripts/update-metrics.py --csv "$PROJECT_DIR/metrics.csv" --brain "$WORK_DIR/brain.json" || true
+  python3 "${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py" --csv "$PROJECT_DIR/metrics.csv" --brain "$WORK_DIR/brain.json" || true
 
   # brain.delete — remove brain.json and pointer file before cleaning the worktree
   rm -f $WORK_DIR/brain.json
@@ -195,7 +195,7 @@ dark-factory-agent(taskDescription, taskName):
 ## cleanup(WORK_DIR, taskName)
 
 ```
-bash agents/dark-factory/scripts/cleanup-worktree.sh WORK_DIR taskName
+bash "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh" WORK_DIR taskName
 ```
 
 ## Classification rules

--- a/agents/featurework/agents/feature-agent.md
+++ b/agents/featurework/agents/feature-agent.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: End-to-end feature orchestrator. Calls planning-agent for each phase (draft, mermaid, flows), gates on human approval between phases via return-question protocol, then calls execution-agent. The approval gate lives here — neither planning-agent nor execution-agent are modified.
 tools: Read, Write, Bash, Agent, PushNotification, Skill, AskUserQuestion
 model: haiku
-allowed-tools: Bash(find *), Bash(grep -r *)
+allowed-tools: Bash(find *), Bash(grep -r *), Bash(python3 ${CLAUDE_PLUGIN_ROOT}/scripts/render_section.py)
 ---
 
 You are the feature-agent. Your job is to orchestrate end-to-end feature work by driving the planning phase section-by-section with human approval at each step, then invoking execution-agent once the full plan is approved. You do not write code, modify plans, or open PRs yourself — you delegate.
@@ -66,7 +66,7 @@ feature-agent(taskDescription, answer, planPath):
     Read planPath and extract the ## System Intent section.
 
     Render the section by piping it through scripts/render_section.py:
-      rendered = bash(f'python3 scripts/render_section.py', stdin=section_content)
+      rendered = bash(f'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/render_section.py"', stdin=section_content)
       if rendered.exit_code == 0:
         formatted_content = rendered.stdout
       else:
@@ -100,7 +100,7 @@ feature-agent(taskDescription, answer, planPath):
     Read planPath and extract the ## Mermaid Diagram section.
 
     Render the section by piping it through scripts/render_section.py:
-      rendered = bash(f'python3 scripts/render_section.py', stdin=section_content)
+      rendered = bash(f'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/render_section.py"', stdin=section_content)
       if rendered.exit_code == 0:
         formatted_content = rendered.stdout
       else:
@@ -161,7 +161,7 @@ feature-agent(taskDescription, answer, planPath):
     Read planPath and extract the ### Flow: <nextFlow> section.
 
     Render the section by piping it through scripts/render_section.py:
-      rendered = bash(f'python3 scripts/render_section.py', stdin=section_content)
+      rendered = bash(f'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/render_section.py"', stdin=section_content)
       if rendered.exit_code == 0:
         formatted_content = rendered.stdout
       else:

--- a/agents/featurework/planning/agents/sub-planning-agent.md
+++ b/agents/featurework/planning/agents/sub-planning-agent.md
@@ -6,7 +6,7 @@ tools: Read, Write, Edit, Bash, Grep, Glob, Agent, Skill
 skills:
   - skills/create-mermaid-diagram/SKILL.md
 model: sonnet
-allowed-tools: "Bash(find *), Bash(grep -r *), Bash(ls *), Bash(python3 scripts/mermaid_to_image.py *)"
+allowed-tools: "Bash(find *), Bash(grep -r *), Bash(ls *), Bash(python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mermaid_to_image.py *)"
 ---
 
 You are the sub-planning-agent worker. You do all the heavy lifting for the planning system: researching the codebase, writing plan files, and running scripts. You are spawned by the planning-agent orchestrator for each phase.
@@ -50,7 +50,7 @@ When `phase == "mermaid"`:
 2. If `feedback` is not "none": apply the changes indicated by `feedback` to the Mermaid diagram section and write the updated plan file. When writing or updating the Mermaid diagram block, follow the `create-mermaid-diagram` skill at `skills/create-mermaid-diagram/SKILL.md` — this defines the required node color standards (gray/yellow/red/green by file status), edge label requirements, black-box external services, and syntax validation with mmdc.
 3. Run the mermaid image script with validation skipped so the URL is always generated:
    ```bash
-   MERMAID_SKIP_VALIDATE=1 python3 scripts/mermaid_to_image.py <planPath>
+   MERMAID_SKIP_VALIDATE=1 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/mermaid_to_image.py" <planPath>
    ```
    Capture stdout as `url`. If the script exits with a non-zero exit code, produces no output, or produces only whitespace, fall back to generating the URL inline:
    ```python

--- a/commands/build-factory.md
+++ b/commands/build-factory.md
@@ -7,5 +7,5 @@ Opens a new terminal in the current working directory and launches Claude in rem
 ## Execution
 
 ```bash
-bash scripts/build-factory.sh "${1:-dark factory}"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/build-factory.sh" "${1:-dark factory}"
 ```

--- a/commands/destroy-factories.md
+++ b/commands/destroy-factories.md
@@ -27,7 +27,7 @@ Linux only. Requires at least one of: `gnome-terminal`, `x-terminal-emulator`, `
 ## Implementation
 
 ```bash
-bash scripts/destroy-factories.sh "dark factory"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/destroy-factories.sh" "dark factory"
 ```
 
 ## Flows

--- a/commands/install.md
+++ b/commands/install.md
@@ -10,5 +10,5 @@ claude plugin marketplace add "$(pwd)"
 claude plugin marketplace update dark-factory
 claude plugin uninstall "dark-factory@dark-factory"
 claude plugin install "dark-factory@dark-factory"
-bash scripts/reopen-remote-control.sh "dark factory"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/reopen-remote-control.sh" "dark factory"
 ```

--- a/docs/bugs/2026-04-28-scripts-not-bundled-with-plugin-install.md
+++ b/docs/bugs/2026-04-28-scripts-not-bundled-with-plugin-install.md
@@ -1,0 +1,66 @@
+# Bug Audit Log: Scripts Not Bundled with Plugin Install
+
+**Date:** 2026-04-28
+**Severity:** Critical
+**Status:** Fixed
+
+---
+
+## Failure Signature
+
+When the dark-factory plugin is installed via `claude plugin install dark-factory`, the hook commands in `.claude/settings.json` and the script references in agent instruction files use relative paths (e.g., `bash agents/dark-factory/scripts/pre-tool-use-hook.sh`). These paths are resolved relative to the user's project CWD, not the plugin install directory, so the scripts cannot be found.
+
+---
+
+## Symptoms
+
+- `bash agents/dark-factory/scripts/pre-tool-use-hook.sh` fails with "No such file or directory" when Claude runs from a user project directory
+- `bash agents/dark-factory/scripts/post-tool-use-hook.sh` same failure
+- `bash agents/dark-factory/scripts/cleanup-worktree.sh` same failure
+- `bash agents/dark-factory/scripts/prep-feature-dir.sh` fails when dark-factory-agent runs
+- `python3 scripts/update-metrics.py` fails in dark-factory-agent cleanup
+- `python3 scripts/render_section.py` fails in feature-agent
+- `python3 scripts/mermaid_to_image.py` fails in sub-planning-agent
+- Brain state management (pre/post hooks) is completely broken for installed plugin users
+
+---
+
+## Root Cause
+
+The `.claude/settings.json` hooks and agent instruction files use relative paths to scripts. When the dark-factory plugin is installed globally (via `claude plugin install`), Claude Code runs from the **user's project directory**, not the plugin install directory. Relative paths like `bash agents/dark-factory/scripts/pre-tool-use-hook.sh` resolve against the user's CWD, where these scripts do not exist.
+
+The Claude Code plugin system provides the `${CLAUDE_PLUGIN_ROOT}` environment variable which resolves to the plugin's install directory. This variable must be used for all script references in:
+- Hook commands (in `hooks/hooks.json`)
+- Agent `allowed-tools` frontmatter
+- Agent instruction bodies
+
+Additionally, the hooks should be defined in `hooks/hooks.json` (the standard plugin hook format) rather than `.claude/settings.json`.
+
+---
+
+## Evidence
+
+- `installed_plugins.json` shows `installPath: /home/lewibs/.claude/plugins/cache/dark-factory/dark-factory/1.2.20`
+- `.claude/settings.json` hooks: `"command": "bash agents/dark-factory/scripts/pre-tool-use-hook.sh"` — no absolute path
+- The `hookify` and `ralph-loop` official plugins use `${CLAUDE_PLUGIN_ROOT}` correctly in `hooks/hooks.json`
+- `ralph-loop` command `.md` uses `allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)"]` showing the pattern for agent files too
+
+---
+
+## Fix Summary
+
+1. Created `hooks/hooks.json` with hook commands using `${CLAUDE_PLUGIN_ROOT}` absolute paths
+2. Added `"hooks": "./hooks/hooks.json"` to `.claude-plugin/plugin.json`
+3. Removed duplicate hook definitions from `.claude/settings.json`
+4. Updated `agents/dark-factory/agents/dark-factory-agent.md` allowed-tools and script invocations to use `${CLAUDE_PLUGIN_ROOT}`
+5. Updated `agents/featurework/agents/feature-agent.md` script invocations to use `${CLAUDE_PLUGIN_ROOT}`
+6. Updated `agents/featurework/planning/agents/sub-planning-agent.md` to use `${CLAUDE_PLUGIN_ROOT}`
+
+---
+
+## Verification
+
+- `hooks/hooks.json` created with correct `${CLAUDE_PLUGIN_ROOT}` paths
+- `.claude/settings.json` no longer contains hook definitions
+- `plugin.json` references `./hooks/hooks.json`
+- All agent files updated with `${CLAUDE_PLUGIN_ROOT}` script paths

--- a/docs/docs/agents.md
+++ b/docs/docs/agents.md
@@ -319,7 +319,7 @@ StandardError {
 
 ### Flow: `brain-hooks`
 
-- Core files: `agents/dark-factory/scripts/pre-tool-use-hook.sh`, `agents/dark-factory/scripts/post-tool-use-hook.sh`, `.claude/settings.json`
+- Core files: `agents/dark-factory/scripts/pre-tool-use-hook.sh`, `agents/dark-factory/scripts/post-tool-use-hook.sh`, `hooks/hooks.json`
 
 #### Types
 

--- a/docs/docs/brain-hooks.md
+++ b/docs/docs/brain-hooks.md
@@ -8,7 +8,7 @@
 
 - What this is: Hook-driven brain.json state management, metrics capture, and agent checklist injection for dark-factory. Claude Code PreToolUse and PostToolUse hooks on the Agent and Skill tools automatically inject brain state and a TodoWrite checklist into every sub-agent prompt, merge each sub-agent's output patch back into brain.json, and accumulate per-agent/skill runtime and token metrics into brain.json for later flush to metrics.csv. Phase transition flags (`*-running`, `*-complete`) are managed exclusively by the hooks — not by agent instruction text.
 - Primary consumer(s): dark-factory-agent (creates, exports, and deletes brain.json; flushes metrics.csv at cleanup); all sub-agents (write brain-patch.json with their specific outputs); pre-tool-use-hook.sh and post-tool-use-hook.sh (inject brain state, merge patches, and capture metrics); `scripts/generate_checklist.sh` (generates TodoWrite JSON for per-agent task checklists).
-- Boundary: `agents/dark-factory/scripts/pre-tool-use-hook.sh`, `agents/dark-factory/scripts/post-tool-use-hook.sh`, `scripts/generate_checklist.sh`, `.claude/settings.json` hooks configuration, `scripts/update-metrics.py`, and sub-agent .md files that produce output fields. Claude Code's internal hook execution engine is out of scope.
+- Boundary: `agents/dark-factory/scripts/pre-tool-use-hook.sh`, `agents/dark-factory/scripts/post-tool-use-hook.sh`, `scripts/generate_checklist.sh`, `hooks/hooks.json` (plugin-bundled hook registration), `scripts/update-metrics.py`, and sub-agent .md files that produce output fields. Claude Code's internal hook execution engine is out of scope.
 
 ## Mermaid Diagram
 
@@ -242,25 +242,25 @@ post-tool-use-hook.sh:
 
 ---
 
-### Flow: `settings-json-hooks`
+### Flow: `plugin-hooks`
 
-- Core files: `.claude/settings.json`
+- Core files: `hooks/hooks.json`, `plugin.json`
 - Test files: N/A
 
 #### Types
 
 ```txt
 HookConfig {
+  // hooks/hooks.json — registered in plugin.json as "hooks": "./hooks/hooks.json"
+  // All script paths use ${CLAUDE_PLUGIN_ROOT} so hooks work from any install location.
   hooks: {
     PreToolUse: [
-      { matcher: "Agent", hooks: [{ type: "command", command: string }] },
-      { matcher: "Skill", hooks: [{ type: "command", command: string }] }
+      { matcher: "Agent", hooks: [{ type: "command", command: "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pre-tool-use-hook.sh\"" }] }
     ]
     PostToolUse: [
-      { matcher: "Agent", hooks: [{ type: "command", command: string }] },
-      { matcher: "Skill", hooks: [{ type: "command", command: string }] }
+      { matcher: "Agent", hooks: [{ type: "command", command: "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/post-tool-use-hook.sh\"" }] }
     ]
-    Stop: [{ matcher: "", hooks: [{ type: "command", command: string }] }]  // pre-existing
+    Stop: [{ matcher: "", hooks: [{ type: "command", command: string }] }]
   }
 }
 ```
@@ -269,10 +269,9 @@ HookConfig {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `hooks.pre-agent` | Agent tool call | modified prompt with brain context + start_ms written to brain.json | happy path | PreToolUse hook matched to "Agent" tool |
-| `hooks.pre-skill` | Skill tool call | start_ms written to brain.json for skill key | happy path | PreToolUse hook matched to "Skill" tool |
-| `hooks.post-agent` | Agent tool result | brain.json updated (patch merge + phase flags + metrics accumulation) | happy path | PostToolUse hook matched to "Agent" tool |
-| `hooks.post-skill` | Skill tool result | brain.json metrics accumulated for skill key | happy path | PostToolUse hook matched to "Skill" tool |
+| `hooks.pre-agent` | Agent tool call | modified prompt with brain context + start_ms written to brain.json | happy path | PreToolUse hook matched to "Agent" tool; script path uses `${CLAUDE_PLUGIN_ROOT}` |
+| `hooks.post-agent` | Agent tool result | brain.json updated (patch merge + phase flags + metrics accumulation) | happy path | PostToolUse hook matched to "Agent" tool; script path uses `${CLAUDE_PLUGIN_ROOT}` |
+| `hooks.stop-cleanup` | Claude stop event | cleanup-worktree.sh called if DARK_FACTORY_WORK_DIR and DARK_FACTORY_TASK_NAME set | happy path | Stop hook fires on session end; script path uses `${CLAUDE_PLUGIN_ROOT}` |
 
 ---
 
@@ -426,13 +425,17 @@ Each test creates an isolated `tempfile.TemporaryDirectory`, writes a minimal `b
 - Mechanism: `local only`
 - Deploy command:
   ```bash
-  # No deploy needed — changes are to agent .md files, shell scripts, and settings.json.
+  # Hooks are bundled with the plugin and registered in plugin.json.
+  # No manual settings.json editing required — install or update the plugin:
+  claude plugin install dark-factory
+  # Or after pulling new changes:
+  claude plugin marketplace add "$(pwd)"
+  claude plugin update dark-factory
   # Hook scripts must be executable:
   chmod +x agents/dark-factory/scripts/pre-tool-use-hook.sh
   chmod +x agents/dark-factory/scripts/post-tool-use-hook.sh
   chmod +x scripts/generate_checklist.sh
   # Run tests to validate checklist script and hook injection:
   pytest tests/test_generate_checklist.py -v
-  # All changes take effect immediately after files are written.
   ```
-- Notes: Hook scripts must be executable (`chmod +x`). The `.claude/settings.json` hooks section must be valid JSON. `DARK_FACTORY_WORK_DIR` must be exported by dark-factory-agent before any Agent tool calls — if it is unset, both hooks are no-ops. `scripts/generate_checklist.sh` must be executable and accessible from the repo root — the pre-tool-use-hook resolves its path relative to the hook's own directory using `BASH_SOURCE[0]`. All transient files managed by these hooks (`brain.json`, `brain.json.lock`, `brain-patch.json`, `flows-state.json`) are listed in the root `.gitignore` and are never committed to git.
+- Notes: Hook scripts must be executable (`chmod +x`). Hooks are registered via `hooks/hooks.json` (referenced in `plugin.json`) and are activated automatically when the plugin is installed — no manual `.claude/settings.json` edits needed. All script paths in `hooks/hooks.json` use `${CLAUDE_PLUGIN_ROOT}` so hooks resolve correctly from any install location. `DARK_FACTORY_WORK_DIR` must be exported by dark-factory-agent before any Agent tool calls — if it is unset, both hooks are no-ops. `scripts/generate_checklist.sh` must be executable and accessible — the pre-tool-use-hook resolves its path relative to the hook's own directory using `BASH_SOURCE[0]`. All transient files managed by these hooks (`brain.json`, `brain.json.lock`, `brain-patch.json`, `flows-state.json`) are listed in the root `.gitignore` and are never committed to git.

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -25,7 +25,7 @@ flowchart TD
   CMD_M -->|delegates to| DFA[agents/dark-factory/agents/dark-factory-agent.md]
   CMD_S -->|launches| TERM[New gnome-terminal running claude /remote-control]
   CMD_I -->|runs directly| GIT[git pull + claude plugin marketplace add/update/uninstall/install]
-  CMD_D -->|bash scripts/destroy-factories.sh| DS[scripts/destroy-factories.sh kills Claude terminals, spawns fresh one]
+  CMD_D -->|"bash ${CLAUDE_PLUGIN_ROOT}/scripts/destroy-factories.sh"| DS[scripts/destroy-factories.sh kills Claude terminals, spawns fresh one]
 ```
 
 ## Flows
@@ -120,7 +120,7 @@ InstallOutput {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `install.success` | `InstallInput` | `InstallOutput` | `happy path` | Runs `git pull`, `claude plugin marketplace add "$(pwd)"`, `claude plugin marketplace update dark-factory`, `claude plugin uninstall "dark-factory@dark-factory"`, `claude plugin install "dark-factory@dark-factory"`, `bash scripts/reopen-remote-control.sh "dark factory"` |
+| `install.success` | `InstallInput` | `InstallOutput` | `happy path` | Runs `git pull`, `claude plugin marketplace add "$(pwd)"`, `claude plugin marketplace update dark-factory`, `claude plugin uninstall "dark-factory@dark-factory"`, `claude plugin install "dark-factory@dark-factory"`, `bash "${CLAUDE_PLUGIN_ROOT}/scripts/reopen-remote-control.sh" "dark factory"` |
 
 ---
 

--- a/docs/docs/destroy-factories.md
+++ b/docs/docs/destroy-factories.md
@@ -17,7 +17,7 @@
 
 ```mermaid
 graph TD
-  User["User: /dark-factory:destroy-factories"]:::unchanged -->|"bash scripts/destroy-factories.sh"| Script["destroy-factories.sh"]:::modified
+  User["User: /dark-factory:destroy-factories"]:::unchanged -->|"bash ${CLAUDE_PLUGIN_ROOT}/scripts/destroy-factories.sh"| Script["destroy-factories.sh"]:::modified
   Script --> FindScopes["find_claude_scope_terminals(): enumerate vte-spawn-*.scope units via systemd"]:::modified
   Script --> FindPID["find_claude_terminals(): PID scan for xterm/konsole (fallback)"]:::unchanged
   FindScopes -->|"scopes found"| StopScopes["systemctl --user stop <scope> for each"]:::modified
@@ -134,7 +134,7 @@ walk up process tree from $$:
 - Deploy command:
   ```bash
   # Called automatically by the /dark-factory:destroy-factories slash command.
-  # Can also be invoked directly:
-  bash scripts/destroy-factories.sh "dark factory"
+  # Can also be invoked directly (from a Claude Code session where CLAUDE_PLUGIN_ROOT is set):
+  bash "${CLAUDE_PLUGIN_ROOT}/scripts/destroy-factories.sh" "dark factory"
   ```
 - Notes: Linux only (same platform support as `reopen-remote-control.sh`). Requires at least one of: `gnome-terminal`, `x-terminal-emulator`, `xterm`, or `konsole`. On GNOME systems the script uses `systemd` vte-spawn cgroup scopes to identify individual gnome-terminal windows; on non-GNOME systems it falls back to PID-based detection. The script is safe by design — it only stops/kills terminals whose process tree contains a `claude` descendant. After spawning a fresh terminal, the script self-closes: it stops its own vte-spawn scope and kills its own `claude` ancestor process.

--- a/docs/docs/manufacture.md
+++ b/docs/docs/manufacture.md
@@ -38,7 +38,7 @@ flowchart TD
   CodeReview --> UpdateDocs["update-documentation-agent"]
   UpdateDocs --> SkillUpdate["skill-update-agent (non-fatal)"]
   SkillUpdate --> PR["pr-agent"]
-  PR --> MetricsFlush["scripts/update-metrics.py\n(flush metrics.csv — non-fatal)"]
+  PR --> MetricsFlush["${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py\n(flush metrics.csv — non-fatal)"]
   MetricsFlush --> BrainDelete["rm brain.json"]
   BrainDelete --> Cleanup["cleanup-worktree.sh"]
   Cleanup --> Done["Report: Done. PR: <url>"]
@@ -103,7 +103,7 @@ dark-factory-agent(taskDescription, taskName):
     - ambiguous → PushNotification("Clarification Required"), ask developer one question, then route
 
   # Step 2 — prep work dir (all routes)
-  bash agents/dark-factory/scripts/prep-feature-dir.sh <taskName>
+  bash "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh" <taskName>
   capture WORK_DIR from stdout
   if fail: report error, STOP
 
@@ -151,7 +151,7 @@ dark-factory-agent(taskDescription, taskName):
   # Step 7 — cleanup
   # metrics.flush — flush accumulated brain.json metrics to permanent CSV before deleting brain.json
   PROJECT_DIR = jq '.workDir' $WORK_DIR/brain.json
-  python3 scripts/update-metrics.py --csv "$PROJECT_DIR/metrics.csv" --brain "$WORK_DIR/brain.json" || true
+  python3 "${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py" --csv "$PROJECT_DIR/metrics.csv" --brain "$WORK_DIR/brain.json" || true
   # Non-fatal: metrics failure never blocks the PR or cleanup.
 
   # brain.delete — remove brain.json before cleaning the worktree

--- a/docs/docs/mermaid-to-image.md
+++ b/docs/docs/mermaid-to-image.md
@@ -238,7 +238,7 @@ PlanningAgentUrlStep {
 
 ```
 sub-planning-agent (mermaid phase — URL generation):
-  run: MERMAID_SKIP_VALIDATE=1 python3 scripts/mermaid_to_image.py <plan_file_path>
+  run: MERMAID_SKIP_VALIDATE=1 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/mermaid_to_image.py" <plan_file_path>
   capture stdout as url
   if exit_code != 0 or url is empty/whitespace:
     # inline Python fallback

--- a/docs/docs/reopen-remote-control.md
+++ b/docs/docs/reopen-remote-control.md
@@ -9,14 +9,14 @@
 ## System Intent
 
 - What this is: A shell script invoked at the end of the `/dark-factory:install` command. It opens a new terminal window running Claude in remote-control mode (`claude "/remote-control <name>"`), then closes the installer terminal by killing its parent process (`kill $PPID`). This ensures the developer ends up in a clean Claude remote-control session without the stale installer terminal lingering.
-- Primary consumer(s): The `commands/install.md` slash command; called as `bash scripts/reopen-remote-control.sh "dark factory"`.
+- Primary consumer(s): The `commands/install.md` slash command; called as `bash "${CLAUDE_PLUGIN_ROOT}/scripts/reopen-remote-control.sh" "dark factory"`.
 - Boundary: Responsible only for terminal lifecycle management — launching the new Claude terminal and cleaning up the installer terminal. All plugin installation logic runs before this script is called.
 
 ## Mermaid Diagram
 
 ```mermaid
 flowchart TD
-  Install["commands/install.md (slash command)"] -->|"bash scripts/reopen-remote-control.sh 'dark factory'"| Script["reopen-remote-control.sh"]
+  Install["commands/install.md (slash command)"] -->|"bash ${CLAUDE_PLUGIN_ROOT}/scripts/reopen-remote-control.sh 'dark factory'"| Script["reopen-remote-control.sh"]
   Script --> OpenTerminal["open_terminal(): try gnome-terminal, x-terminal-emulator, xterm, konsole"]
   OpenTerminal -->|success, exit 0| KillPPID["kill $PPID (close installer terminal)"]
   OpenTerminal -->|failure, exit != 0| Error["echo error to stderr, exit non-zero"]
@@ -88,7 +88,7 @@ else if TERMINAL_EXIT != 0:
 - Deploy command:
   ```bash
   # Called automatically by the /dark-factory:install slash command.
-  # Can also be invoked directly:
-  bash scripts/reopen-remote-control.sh "dark factory"
+  # Can also be invoked directly (from a Claude Code session where CLAUDE_PLUGIN_ROOT is set):
+  bash "${CLAUDE_PLUGIN_ROOT}/scripts/reopen-remote-control.sh" "dark factory"
   ```
 - Notes: Must be run from the repo root or any directory where `pwd` resolves to the desired working directory for the new Claude session. The script requires at least one of: gnome-terminal, x-terminal-emulator, xterm, or konsole.

--- a/docs/docs/sub-planning-agent.md
+++ b/docs/docs/sub-planning-agent.md
@@ -26,7 +26,7 @@ flowchart TD
   D3 -->|planPath + summary| PA
 
   SPA -->|phase=mermaid| M1["Apply feedback to Mermaid section"]
-  M1 --> M2["Run python3 scripts/mermaid_to_image.py planPath"]
+  M1 --> M2["Run python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mermaid_to_image.py planPath"]
   M2 -->|url or null| PA
 
   SPA -->|phase=flows| F1["Locate ### Flow: flowName section"]
@@ -131,7 +131,7 @@ sub-planning-agent (phase=mermaid):
       - do not encode internal branching logic in diagram nodes
       - validate syntax with mmdc; fix any parse errors before finishing
     write updated plan file
-  run: MERMAID_SKIP_VALIDATE=1 python3 scripts/mermaid_to_image.py <planPath>
+  run: MERMAID_SKIP_VALIDATE=1 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/mermaid_to_image.py" <planPath>
   capture stdout as url
   if exit_code != 0 or url is empty/whitespace:
     # inline Python fallback

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,38 @@
+{
+  "description": "dark-factory plugin hooks — brain state management for agent orchestration",
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ -n \"$DARK_FACTORY_WORK_DIR\" ] && [ -n \"$DARK_FACTORY_TASK_NAME\" ]; then bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh\" \"$DARK_FACTORY_WORK_DIR\" \"$DARK_FACTORY_TASK_NAME\"; fi"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pre-tool-use-hook.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/post-tool-use-hook.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/brain-hook-driven-state/SKILL.md
+++ b/skills/brain-hook-driven-state/SKILL.md
@@ -56,16 +56,20 @@ When adding a new sub-agent to the dark-factory pipeline, or when modifying how 
 - If `DARK_FACTORY_WORK_DIR` is not set or the sub-agent has no output to record, skip writing the patch entirely.
 - The patch file is deleted by the post-hook after it is merged; sub-agents must not re-read it.
 
-### Registering hooks in settings.json
+### Registering hooks via hooks/hooks.json
+
+Hooks are registered via the plugin's `hooks/hooks.json` file (referenced from `plugin.json` as `"hooks": "./hooks/hooks.json"`). The hook commands use `${CLAUDE_PLUGIN_ROOT}` so they resolve correctly regardless of where Claude Code is run:
 
 ```json
-"hooks": {
-  "PreToolUse": [
-    { "matcher": "Agent", "hooks": [{ "type": "command", "command": "bash agents/dark-factory/scripts/pre-tool-use-hook.sh" }] }
-  ],
-  "PostToolUse": [
-    { "matcher": "Agent", "hooks": [{ "type": "command", "command": "bash agents/dark-factory/scripts/post-tool-use-hook.sh" }] }
-  ]
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Agent", "hooks": [{ "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pre-tool-use-hook.sh\"" }] }
+    ],
+    "PostToolUse": [
+      { "matcher": "Agent", "hooks": [{ "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/post-tool-use-hook.sh\"" }] }
+    ]
+  }
 }
 ```
 

--- a/skills/capture-project-dir-before-worktree/SKILL.md
+++ b/skills/capture-project-dir-before-worktree/SKILL.md
@@ -26,9 +26,9 @@ Whenever a manufacture step needs to write a permanent file (metrics CSV, report
 3. In the cleanup step, read PROJECT_DIR from brain.json **before** deleting brain.json:
    ```bash
    PROJECT_DIR=$(jq -r '.projectDir' "$WORK_DIR/brain.json")
-   python3 scripts/update-metrics.py --csv "$PROJECT_DIR/metrics.csv" --brain "$WORK_DIR/brain.json" || true
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py" --csv "$PROJECT_DIR/metrics.csv" --brain "$WORK_DIR/brain.json" || true
    rm -f "$WORK_DIR/brain.json"
-   bash agents/dark-factory/scripts/cleanup-worktree.sh ...
+   bash "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh" ...
    ```
 
 4. Never use `brain.json.workDir` as the base path for permanent files. The worktree at `workDir` is deleted by `cleanup-worktree.sh`, so any write to `$workDir/foo` after cleanup is silently lost.

--- a/skills/generate-mermaid-ink-url/SKILL.md
+++ b/skills/generate-mermaid-ink-url/SKILL.md
@@ -26,7 +26,7 @@ When you need to share or display a Mermaid diagram as an image URL — for exam
 ## Notes
 
 - Use `urlsafe_b64encode` (replaces `+` → `-` and `/` → `_`). Standard `b64encode` will produce a broken URL because `+` and `/` are not URL-safe without percent-encoding.
-- The script at `scripts/mermaid_to_image.py` implements this pattern; import or call it rather than re-implementing inline.
+- The script at `${CLAUDE_PLUGIN_ROOT}/scripts/mermaid_to_image.py` implements this pattern; import or call it rather than re-implementing inline.
 - `mermaid.ink` is treated as an external black box — do not depend on its availability for correctness tests; unit tests should only assert the URL structure (`startswith("https://mermaid.ink/img/")`).
 - Padding characters (`=`) from base64 output are harmless in the URL for `mermaid.ink`, but if a future service requires padding-free encoding, strip them with `.rstrip("=")`.
 
@@ -35,7 +35,7 @@ When you need to share or display a Mermaid diagram as an image URL — for exam
 When invoking `scripts/mermaid_to_image.py` from an agent (e.g. sub-planning-agent), always set `MERMAID_SKIP_VALIDATE=1`:
 
 ```bash
-MERMAID_SKIP_VALIDATE=1 python3 scripts/mermaid_to_image.py <planPath>
+MERMAID_SKIP_VALIDATE=1 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/mermaid_to_image.py" <planPath>
 ```
 
 **Why:** By default the script calls `mmdc` (via `npx @mermaid-js/mermaid-cli`) to validate syntax before generating the URL. In agent/CI environments `npx` may be unavailable or slow, causing the script to exit non-zero even though the diagram content is valid and the URL could be generated. `MERMAID_SKIP_VALIDATE=1` bypasses this validation step and proceeds directly to URL generation.

--- a/skills/plugin-root-script-paths/SKILL.md
+++ b/skills/plugin-root-script-paths/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: plugin-root-script-paths
+description: "When an agent, command, or skill calls a script bundled inside the dark-factory plugin, always prefix the path with ${CLAUDE_PLUGIN_ROOT}/ instead of using a bare relative path."
+user-invocable: false
+---
+## When to use
+
+Any time you write or edit an agent (`.md` in `agents/`), a command (`.md` in `commands/`), or a skill (`SKILL.md` in `skills/`) that invokes a script (`bash`, `python3`, etc.) that ships inside the dark-factory plugin repository.
+
+This applies to:
+- `bash <script>.sh` calls
+- `python3 <script>.py` calls
+- `allowed-tools:` Bash() entries that include a script path
+- `scripts:` frontmatter declarations in agent files
+- Prose pseudocode inside agent instruction bodies
+
+## Steps
+
+1. Identify every script reference that uses a bare relative path such as:
+   - `bash agents/dark-factory/scripts/foo.sh`
+   - `python3 scripts/bar.py`
+2. Replace each bare relative path with the `${CLAUDE_PLUGIN_ROOT}/` prefix:
+   - `bash "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/foo.sh"`
+   - `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/bar.py"`
+3. Apply the same replacement in `allowed-tools:` Bash() entries:
+   - Before: `Bash(bash agents/dark-factory/scripts/foo.sh *)`
+   - After: `Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/foo.sh *)`
+4. Apply the same replacement in `scripts:` frontmatter lines.
+5. Double-quote the expanded path in shell contexts to handle spaces:
+   - `bash "${CLAUDE_PLUGIN_ROOT}/scripts/foo.sh"` (not `bash $CLAUDE_PLUGIN_ROOT/scripts/foo.sh`)
+
+## Notes
+
+- `${CLAUDE_PLUGIN_ROOT}` is injected by the Claude Code plugin runtime and resolves to the absolute directory where the plugin is installed. Bare relative paths break when the plugin is installed at a location different from the current working directory of the Claude process.
+- Relative paths like `bash scripts/foo.sh` look correct in development (when CWD is the repo root) but fail silently in production installs.
+- Skills that reference their own helper scripts (e.g. `mermaid_to_image.py`) must use `${CLAUDE_PLUGIN_ROOT}` too — they are bundled plugin assets, not project-local files.
+- The `${CLAUDE_PLUGIN_ROOT}` variable is available in hook commands, agent pseudocode, and allowed-tool patterns alike.

--- a/skills/register-plugin-hooks-in-hooks-json/SKILL.md
+++ b/skills/register-plugin-hooks-in-hooks-json/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: register-plugin-hooks-in-hooks-json
+description: "Plugin-level Claude Code hooks must be declared in hooks/hooks.json (referenced from plugin.json), not in .claude/settings.json, so they ship and resolve correctly with the installed plugin."
+user-invocable: false
+---
+## When to use
+
+Any time you add, remove, or modify a Claude Code PreToolUse, PostToolUse, or Stop hook that belongs to the dark-factory plugin — as opposed to a project-local hook that a user configures themselves.
+
+## Steps
+
+1. Open `hooks/hooks.json` in the plugin root (create it if it does not exist). It must follow this structure:
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [
+         { "matcher": "Agent", "hooks": [{ "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pre-tool-use-hook.sh\"" }] }
+       ],
+       "PostToolUse": [
+         { "matcher": "Agent", "hooks": [{ "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/post-tool-use-hook.sh\"" }] }
+       ]
+     }
+   }
+   ```
+2. Ensure `plugin.json` declares the hooks file:
+   ```json
+   {
+     "hooks": "./hooks/hooks.json"
+   }
+   ```
+3. Do NOT add plugin hooks to `.claude/settings.json`. That file is for project-level or user-level overrides. Plugin hooks in `settings.json` are not portable — they use relative paths that break when the plugin is installed outside the repo.
+4. Use `${CLAUDE_PLUGIN_ROOT}/` prefix for all script paths inside hook commands (see the `plugin-root-script-paths` skill at `skills/plugin-root-script-paths/SKILL.md`).
+
+## Notes
+
+- `.claude/settings.json` hooks use bare relative paths (e.g. `bash agents/dark-factory/scripts/foo.sh`) which only work when the CWD matches the plugin repo root. `hooks/hooks.json` hook commands using `${CLAUDE_PLUGIN_ROOT}` resolve correctly regardless of CWD.
+- If you need a hook for a one-project use case (not part of the plugin), use `.claude/settings.json` as normal — this rule applies only to hooks that are part of the plugin itself.
+- After modifying `hooks/hooks.json`, reinstall the plugin with `/dark-factory:install` to pick up the changes.


### PR DESCRIPTION
## Description

# Bug Audit Log: Scripts Not Bundled with Plugin Install

**Date:** 2026-04-28
**Severity:** Critical
**Status:** Fixed

---

## Failure Signature

When the dark-factory plugin is installed via `claude plugin install dark-factory`, the hook commands in `.claude/settings.json` and the script references in agent instruction files use relative paths (e.g., `bash agents/dark-factory/scripts/pre-tool-use-hook.sh`). These paths are resolved relative to the user's project CWD, not the plugin install directory, so the scripts cannot be found.

---

## Symptoms

- `bash agents/dark-factory/scripts/pre-tool-use-hook.sh` fails with "No such file or directory" when Claude runs from a user project directory
- `bash agents/dark-factory/scripts/post-tool-use-hook.sh` same failure
- `bash agents/dark-factory/scripts/cleanup-worktree.sh` same failure
- `bash agents/dark-factory/scripts/prep-feature-dir.sh` fails when dark-factory-agent runs
- `python3 scripts/update-metrics.py` fails in dark-factory-agent cleanup
- `python3 scripts/render_section.py` fails in feature-agent
- `python3 scripts/mermaid_to_image.py` fails in sub-planning-agent
- Brain state management (pre/post hooks) is completely broken for installed plugin users

---

## Root Cause

The `.claude/settings.json` hooks and agent instruction files use relative paths to scripts. When the dark-factory plugin is installed globally (via `claude plugin install`), Claude Code runs from the **user's project directory**, not the plugin install directory. Relative paths like `bash agents/dark-factory/scripts/pre-tool-use-hook.sh` resolve against the user's CWD, where these scripts do not exist.

The Claude Code plugin system provides the `${CLAUDE_PLUGIN_ROOT}` environment variable which resolves to the plugin's install directory. This variable must be used for all script references in:
- Hook commands (in `hooks/hooks.json`)
- Agent `allowed-tools` frontmatter
- Agent instruction bodies

Additionally, the hooks should be defined in `hooks/hooks.json` (the standard plugin hook format) rather than `.claude/settings.json`.

---

## Evidence

- `installed_plugins.json` shows `installPath: /home/lewibs/.claude/plugins/cache/dark-factory/dark-factory/1.2.20`
- `.claude/settings.json` hooks: `"command": "bash agents/dark-factory/scripts/pre-tool-use-hook.sh"` — no absolute path
- The `hookify` and `ralph-loop` official plugins use `${CLAUDE_PLUGIN_ROOT}` correctly in `hooks/hooks.json`
- `ralph-loop` command `.md` uses `allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)"]` showing the pattern for agent files too

---

## Fix Summary

1. Created `hooks/hooks.json` with hook commands using `${CLAUDE_PLUGIN_ROOT}` absolute paths
2. Added `"hooks": "./hooks/hooks.json"` to `.claude-plugin/plugin.json`
3. Removed duplicate hook definitions from `.claude/settings.json`
4. Updated `agents/dark-factory/agents/dark-factory-agent.md` allowed-tools and script invocations to use `${CLAUDE_PLUGIN_ROOT}`
5. Updated `agents/featurework/agents/feature-agent.md` script invocations to use `${CLAUDE_PLUGIN_ROOT}`
6. Updated `agents/featurework/planning/agents/sub-planning-agent.md` to use `${CLAUDE_PLUGIN_ROOT}`

---

## Verification

- `hooks/hooks.json` created with correct `${CLAUDE_PLUGIN_ROOT}` paths
- `.claude/settings.json` no longer contains hook definitions
- `plugin.json` references `./hooks/hooks.json`
- All agent files updated with `${CLAUDE_PLUGIN_ROOT}` script paths

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
rootdir: /home/lewibs/github/dark_factory/dark_factory-bundle-scripts-with-plugin
collected 140 items

tests/test_build_factory_no_destroy.py ............                      [  8%]
tests/test_destroy_factories.py .........                                [ 15%]
tests/test_destroy_factories_kills_other_windows.py ........             [ 20%]
tests/test_docs_template_compliance.py ............                      [ 29%]
tests/test_feature_agent_render.py ....                                  [ 32%]
tests/test_generate_checklist.py ......                                  [ 37%]
tests/test_hooks.py ....................                                  [ 51%]
tests/test_mermaid_to_image.py ..................                        [ 64%]
tests/test_metrics_env_isolation.py .....                                [ 67%]
tests/test_planning_approval_gate.py .....                               [ 71%]
tests/test_pre_tool_use_hook.py ..                                       [ 72%]
tests/test_push_notification_declared.py .......                         [ 77%]
tests/test_render_section.py ....                                        [ 80%]
tests/test_reopen_remote_control.py ................                     [ 92%]
tests/test_update_metrics.py ...........                                 [100%]

============================= 140 passed in 1.39s ==============================
```

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
