### PR TITLE
fix(hooks): add automatic cleanup of session files via Stop hook

### DIFF
--- a/agents/dark-factory/scripts/cleanup-session-files.sh
+++ b/agents/dark-factory/scripts/cleanup-session-files.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# cleanup-session-files.sh
+# Cleans up transient session files that were created during a dark-factory run.
+# This script is called by the Stop hook to ensure session files are never
+# accidentally committed to git, even if the manufacturing process is interrupted.
+#
+# Files cleaned up:
+#   - brain.json (agent state context)
+#   - brain.json.lock (flock file)
+#   - brain-patch.json (agent output patch)
+#   - flows-state.json (flow approval state)
+#   - /tmp/dark-factory-work-dir (pointer to work dir)
+#
+# This is deterministic and automatic — no manual intervention required.
+# Failures are logged as warnings but do not cause the hook to fail (exit 0).
+
+set -euo pipefail
+
+# Resolve the work directory: prefer env var, fall back to pointer file
+DARK_FACTORY_POINTER_FILE="/tmp/dark-factory-work-dir"
+WORK_DIR="${DARK_FACTORY_WORK_DIR:-}"
+
+if [ -z "$WORK_DIR" ] && [ -f "$DARK_FACTORY_POINTER_FILE" ]; then
+  WORK_DIR=$(cat "$DARK_FACTORY_POINTER_FILE")
+  echo "cleanup-session-files | pointer-file | DARK_FACTORY_WORK_DIR=${WORK_DIR}" >&2
+fi
+
+# If no work dir found, nothing to clean up
+if [ -z "$WORK_DIR" ]; then
+  echo "cleanup-session-files | no-work-dir | skipping session file cleanup" >&2
+  exit 0
+fi
+
+# Array of session files to clean up (relative to WORK_DIR or absolute paths)
+SESSION_FILES=(
+  "$WORK_DIR/brain.json"
+  "$WORK_DIR/brain.json.lock"
+  "$WORK_DIR/brain-patch.json"
+  "$WORK_DIR/flows-state.json"
+  "/tmp/dark-factory-work-dir"
+)
+
+# Clean up each file
+for file in "${SESSION_FILES[@]}"; do
+  if [ -f "$file" ]; then
+    rm -f "$file" 2>/dev/null && \
+      echo "cleanup-session-files | deleted | $file" >&2 || \
+      echo "WARNING: cleanup-session-files | failed to delete | $file" >&2
+  fi
+done
+
+exit 0

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,6 +7,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-session-files.sh\""
+          },
+          {
+            "type": "command",
             "command": "if [ -n \"$DARK_FACTORY_WORK_DIR\" ] && [ -n \"$DARK_FACTORY_TASK_NAME\" ]; then bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh\" \"$DARK_FACTORY_WORK_DIR\" \"$DARK_FACTORY_TASK_NAME\"; fi"
           }
         ]


### PR DESCRIPTION
## Description

Added automatic cleanup of session files via Stop hook. During manufacture runs, transient files like brain.json, brain-patch.json, brain.json.lock, and flows-state.json are created that should never be committed to git. A new cleanup-session-files.sh script was added along with a Stop hook in hooks.json to remove these files automatically at the end of each session. This is deterministic and automatic — no manual intervention required. Tests were added in tests/test_hooks.py and docs were updated in docs/docs/brain-hooks.md.

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/lewibs/github/dark_factory/dark_factory-hook-cleanup-session-files
collecting ... collected 24 items

tests/test_hooks.py::TestPreHookInjectsBrainState::test_inject_success PASSED [  4%]
tests/test_hooks.py::TestPreHookInjectsBrainState::test_inject_no_brain PASSED [  8%]
tests/test_hooks.py::TestPreHookSetsRunningPhase::test_set_running_success PASSED [ 12%]
tests/test_hooks.py::TestPreHookSetsRunningPhase::test_set_running_no_incomplete PASSED [ 16%]
tests/test_hooks.py::TestPreHookEmitsValidJson::test_valid_json_output PASSED [ 20%]
tests/test_hooks.py::TestPreHookCapturesStart::test_agent_tool_writes_start_ms PASSED [ 25%]
tests/test_hooks.py::TestPreHookCapturesStart::test_skill_tool_writes_start_ms PASSED [ 29%]
tests/test_hooks.py::TestPreHookCapturesStart::test_other_tool_is_noop PASSED [ 33%]
tests/test_hooks.py::TestPreHookCapturesStart::test_no_brain_is_noop PASSED [ 37%]
tests/test_hooks.py::TestPostHookMergesPatch::test_merge_success PASSED  [ 41%]
tests/test_hooks.py::TestPostHookMergesPatch::test_merge_no_patch PASSED [ 45%]
tests/test_hooks.py::TestPostHookSetsCompleteAndClearsRunning::test_phase_success PASSED [ 50%]
tests/test_hooks.py::TestPostHookSetsCompleteAndClearsRunning::test_phase_no_running PASSED [ 54%]
tests/test_hooks.py::TestPostHookNoBrain::test_no_brain_exits_zero PASSED [ 58%]
tests/test_hooks.py::TestPostHookAccumulatesMetrics::test_success_accumulates_elapsed_tokens_runs PASSED [ 62%]
tests/test_hooks.py::TestPostHookAccumulatesMetrics::test_missing_start_ms_uses_zero_elapsed PASSED [ 66%]
tests/test_hooks.py::TestPostHookAccumulatesMetrics::test_no_usage_field_defaults_tokens_to_zero PASSED [ 70%]
tests/test_hooks.py::TestPostHookAccumulatesMetrics::test_other_tool_is_noop PASSED [ 75%]
tests/test_hooks.py::TestPostHookAccumulatesMetrics::test_accumulation_across_multiple_calls PASSED [ 79%]
tests/test_hooks.py::TestCleanupSessionFilesRemovesFiles::test_cleanup_success PASSED [ 83%]
tests/test_hooks.py::TestCleanupSessionFilesRemovesFiles::test_cleanup_graceful_no_op_when_workdir_unset PASSED [ 87%]
tests/test_hooks.py::TestCleanupSessionFilesRemovesFiles::test_cleanup_pointer_file_fallback PASSED [ 91%]
tests/test_hooks.py::TestCleanupSessionFilesRemovesFiles::test_cleanup_partial_files_still_exits_zero PASSED [ 95%]
tests/test_hooks.py::TestCleanupSessionFilesRemovesFiles::test_cleanup_no_files_still_exits_zero PASSED [100%]

============================== 24 passed in 0.54s ==============================
```

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
