### PR TITLE
fix(feature-agent): prevent commits landing on main instead of feature branch

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -5,7 +5,7 @@ description: Top-level dark-factory orchestrator. Preps an isolated work dir, ro
 tools: Read, Bash, Agent, PushNotification, AskUserQuestion
 model: haiku
 scripts: ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh, ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh
-allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh *), Bash(jq *), Bash(rm -f *), Bash(export *), Bash(python3 ${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py *), Bash(echo * > /tmp/dark-factory-work-dir)
+allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh *), Bash(jq *), Bash(rm -f *), Bash(export *), Bash(python3 ${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py *), Bash(echo * > /tmp/dark-factory-work-dir), Bash(git -C * log *)
 ---
 
 You are the dark-factory-agent. Your job is to orchestrate an entire unit of work end-to-end: isolate it in a fresh working directory, delegate to the right worker, review the result, keep docs current, ship a PR, and clean up. You do not write code or modify files yourself — you delegate entirely.
@@ -132,6 +132,19 @@ dark-factory-agent(taskDescription, taskName):
       rm -f /tmp/dark-factory-work-dir
       run cleanup(WORK_DIR)
       report error and STOP
+
+  # branch-drift guard — verify worker committed to the feature branch, not main
+  # Run this check immediately after the worker returns and before proceeding to code review.
+  # If the feature branch has no commits ahead of main the worker either committed to the
+  # wrong branch or did not commit at all. Halt with a clear error rather than silently
+  # proceeding to code review with no changes.
+  featureBranch = "feature/" + taskName
+  driftCheck = bash("git -C \"$WORK_DIR\" log main.." + featureBranch + " --oneline")
+  if driftCheck output is empty:
+    rm -f /tmp/dark-factory-work-dir
+    run cleanup(WORK_DIR)
+    report error: "Branch-drift guard failed: feature/" + taskName + " has no commits ahead of main. The worker agent may have committed to the wrong branch or failed to commit at all. Halting before code review to prevent opening a PR with no changes."
+    STOP
 
   # brain.read-results — read brain.json to get planFilePath (hooks merged it from sub-agent patches)
   Read $WORK_DIR/brain.json

--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Manages the PR lifecycle for a code fix. Opens a PR, waits for CI, addresses review comments, and stops once CI is green and all threads are resolved. Does not merge. Accepts a file path or description string as input for the PR body; falls back to looking at the changes.
 tools: Read, Bash, Write, Edit
 skills: create-pr
-allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr comment *), Bash(gh pr review *), Bash(gh api graphql *), Bash(git push *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *), Bash(gh pr create *), Bash(cat > /tmp/pr-body.md *), Bash(git status *), Bash(git log *)
+allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr comment *), Bash(gh pr review *), Bash(gh api graphql *), Bash(git push *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *), Bash(gh pr create *), Bash(cat > /tmp/pr-body.md *), Bash(git status *), Bash(git log *), Bash(git -C * push *), Bash(git -C * add *), Bash(git -C * commit *), Bash(git -C * branch *), Bash(git -C * status *), Bash(git -C * log *)
 model: sonnet
 ---
 
@@ -102,8 +102,10 @@ If neither is provided, look at the git diff and any relevant `docs/bugs/` or `d
 
 ## Rules
 
-- The fix is already applied to the working tree when you are spawned. Do not re-apply it.
-- Always stage with `git add --all` before committing — never stage individual files, so nothing is missed.
+- The fix is already applied to the working tree (WORK_DIR) when you are spawned. Do not re-apply it.
+- Always use `git -C "$WORK_DIR"` for all git operations (add, commit, push, branch, checkout, status, log). Never run bare `git` commands from the default CWD — the default CWD is the main worktree and running git there causes commits to land on `main` instead of the feature branch.
+- WORK_DIR is available in the brain context injected by the pre-hook (`brain.workDir`). Read it before issuing any git commands.
+- Always stage with `git -C "$WORK_DIR" add --all` before committing — never stage individual files, so nothing is missed.
 - Always use `agents/pr/templates/pr-template.md` as the PR body structure. Never free-form the body.
 - Always write the PR body to `/tmp/pr-body.md` and open the PR with `gh pr create --body-file /tmp/pr-body.md`. Never use `--body` with inline content — large bodies cause a "Parser aborted" interactive prompt.
 - Do not merge — stop once CI is green and all review threads are resolved.

--- a/agents/pr/skills/create-pr/SKILL.md
+++ b/agents/pr/skills/create-pr/SKILL.md
@@ -10,26 +10,33 @@ Open a pull request on GitHub and manage it through to merge.
 
 ## Steps
 
-1. Create a new branch for the fix:
+The worktree is already on the correct feature branch (`feature/<taskName>`). Do NOT create a
+new branch — committing from the main worktree CWD on a new `fix/` branch would cause commits
+to land on `main` instead of `feature/<taskName>`. All git commands must use `-C "$WORK_DIR"`
+to operate on the feature worktree.
+
+1. Confirm the current branch in the worktree:
    ```bash
-   git checkout -b fix/<slug-from-bug-title>
+   git -C "$WORK_DIR" branch --show-current
+   # Expected output: feature/<taskName>
+   # If not on the correct feature branch, stop and report the error.
    ```
 
-2. Stage and commit all changes:
+2. Stage and commit all changes from the worktree:
    ```bash
-   git add --all
-   git commit -m "<short title from bug explanation>"
+   git -C "$WORK_DIR" add --all
+   git -C "$WORK_DIR" commit -m "<short title from bug explanation>"
    ```
 
-3. Push the branch and open the PR:
+3. Push the feature branch and open the PR:
    ```bash
-   git push -u origin HEAD
+   git -C "$WORK_DIR" push -u origin HEAD
    # Always write the body to a temp file — never pass it inline with --body.
    # Inline bodies fail with "Parser aborted" when the content is large.
    cat > /tmp/pr-body.md << 'EOF'
    <body content here>
    EOF
-   gh pr create --title "<type>(<scope>): <description>" --body-file /tmp/pr-body.md
+   gh pr create --title "<type>(<scope>): <description>" --body-file /tmp/pr-body.md --head feature/<taskName>
    ```
 
 ## PR Title Format

--- a/docs/bugs/2026-04-29-feature-agent-commits-to-main.md
+++ b/docs/bugs/2026-04-29-feature-agent-commits-to-main.md
@@ -1,0 +1,128 @@
+# feature-agent commits to main branch instead of feature worktree branch
+
+## Metadata
+
+- Date: `2026-04-29`
+- Status: `fixed`
+- Severity: `critical`
+- Related issue/ticket: `#132`
+- Owner: `lewibs`
+
+## About
+
+**Overview**:
+- During a manufacture run, dark-factory-agent preps a git worktree at `dark_factory-<taskName>/` on branch `feature/<taskName>`. Worker agents (feature-agent → execution-agent → implementation-agent) write code into WORK_DIR but when git commits happen they land on `main` instead of `feature/<taskName>`.
+- This is critical because it directly contaminates the main branch with unreviewed, in-progress work, bypassing the PR / code-review gate entirely.
+
+**Technical Questions**:
+- Are we making assumptions about this bug? Yes — the hypothesis from issue #132 is that git operations run from a CWD that resolves to the main worktree rather than the feature worktree.
+- How old is this bug? Appears to have been present since the worktree isolation pattern was introduced.
+- Is there anything obvious we might have missed? The "cd into WORK_DIR" in `dark-factory-agent.md` Step 3 is pseudo-code / LLM intent — it does NOT persist as a CWD for subsequent Agent tool sub-calls. Each sub-agent inherits whatever CWD the Claude Code process started with (the project root / main worktree).
+- Are there specific system states required to reproduce it? Yes — requires a full manufacture run with the feature route, where dark-factory-agent invokes feature-agent which in turn invokes execution-agent and the implementation sub-agents.
+
+**Root cause (confirmed from code review)**:
+
+There are two distinct issues:
+
+1. **pr-agent / create-pr runs git from main worktree CWD**: `dark-factory-agent.md` Step 6 invokes `pr-agent` without passing WORK_DIR. The `create-pr` skill's Step 1 does `git checkout -b fix/<slug>` followed by `git add --all && git commit && git push`. These Bash commands run in the Claude Code process CWD (project root = main worktree), not WORK_DIR. The commit therefore lands on `main` (or `fix/<slug>` branched off main), not `feature/<taskName>`.
+
+2. **No branch-drift guard after worker returns**: After feature-agent/execution-agent/implementation-agent return in Step 3, `dark-factory-agent.md` does not verify that `feature/<taskName>` has commits ahead of `main`. If the worker committed to the wrong branch (or not at all), the orchestrator silently proceeds to code review with no changes.
+
+**Resources**:
+- `agents/dark-factory/agents/dark-factory-agent.md` — orchestrator, Steps 2–6
+- `agents/pr/agents/pr-agent.md` — PR agent (no WORK_DIR awareness)
+- `agents/pr/skills/create-pr/SKILL.md` — performs `git checkout -b fix/<slug>`, `git add --all`, `git commit`, `git push`
+- `agents/dark-factory/scripts/prep-feature-dir.sh` — creates worktree + `feature/<taskName>` branch
+- `agents/featurework/execution/agents/implementation-agent.md` — writes and runs code but no git operations here
+- GitHub issue #132
+
+## Steps to cause failure
+
+```mermaid
+flowchart LR
+    User -->|manufacture task| dark-factory-agent
+    dark-factory-agent -->|prep-feature-dir.sh| worktree["WORK_DIR on feature/taskName"]
+    dark-factory-agent -->|cd WORK_DIR pseudo-code only| feature-agent
+    feature-agent --> execution-agent
+    execution-agent --> implementation-agent
+    implementation-agent -->|writes files in WORK_DIR| done
+    dark-factory-agent -->|invoke pr-agent NO WORK_DIR| pr-agent
+    pr-agent -->|create-pr: git checkout -b fix/slug| main_worktree["main worktree CWD"]
+    main_worktree -->|git add --all, git commit, git push| main["commit lands on main"]
+```
+
+## System
+
+```mermaid
+flowchart TD
+    A[dark-factory-agent] -->|Step 2| B[prep-feature-dir.sh\ncreates WORK_DIR worktree\nbranch feature/taskName]
+    A -->|Step 3 cd WORK_DIR intent-only| C[feature-agent]
+    C --> D[execution-agent]
+    D --> E[skeleton-agent]
+    D --> F[testing-agent]
+    D --> G[implementation-agent\nwrites files in WORK_DIR]
+    A -->|Step 4| H[code-review-orchestrator-agent]
+    A -->|Step 5| I[update-documentation-agent]
+    A -->|Step 6 no WORK_DIR param| J[pr-agent]
+    J --> K[create-pr skill\ngit checkout -b fix/slug\ngit add --all\ngit commit\ngit push]
+    K -->|CWD = project root main worktree| L[commit on main WRONG]
+```
+
+Notes: The critical gap is that Agent tool sub-calls do not inherit a `cd` pseudo-statement from LLM pseudo-code. Each Bash call in the sub-agent starts in the Claude Code process CWD, which is the project root (main worktree).
+
+## Reproduction Details
+
+1. Start a manufacture run: `/dark-factory:manufacture taskDescription="add a test feature" taskName="test-feature"`
+2. dark-factory-agent runs `prep-feature-dir.sh test-feature` — creates `dark_factory-test-feature/` worktree on branch `feature/test-feature`.
+3. feature-agent → execution-agent → implementation-agent write code into WORK_DIR.
+4. dark-factory-agent invokes pr-agent (no WORK_DIR passed).
+5. pr-agent invokes `create-pr` skill which runs `git checkout -b fix/test-feature` from CWD = project root.
+6. `git add --all && git commit` — staged changes are from the main worktree (empty or wrong).
+7. `git push -u origin HEAD` — push lands on `fix/test-feature` branched from `main`, NOT `feature/test-feature`.
+8. Alternatively: if no `git checkout -b` step runs, commit goes directly to whatever is checked out in the main worktree = `main`.
+
+Reproduction test (unit preferred):
+`tests/test_dark_factory_agent_branch_drift_guard.py`
+
+## Notes for PR
+
+Two fixes are required:
+
+**Fix 1 — Branch-drift guard in `dark-factory-agent.md`**: After the worker agent (Step 3) returns and before proceeding to Step 4 (code review), add a guard that verifies `feature/<taskName>` is ahead of `main` by at least one commit. Use:
+```bash
+git -C "$WORK_DIR" log main..feature/<taskName> --oneline
+```
+If the output is empty, halt with a clear error: "Worker agent did not commit to feature/<taskName>. Commits may have gone to main or nowhere. Halting before code review."
+
+**Fix 2 — Pass WORK_DIR to pr-agent and use it as CWD for all git operations**: The `dark-factory-agent.md` Step 6 invocation of `pr-agent` must include WORK_DIR so that all git Bash commands run with `-C "$WORK_DIR"` or equivalent. Alternatively, the `pr-agent` and `create-pr` skill must be updated to read WORK_DIR from brain context (injected by pre-hook) and prefix all git commands with `git -C "$WORK_DIR"`.
+
+**Fix 3 — Remove `git checkout -b fix/<slug>` from `create-pr`**: The worktree is already on `feature/<taskName>`. The `create-pr` skill must NOT create a new branch — it should commit on the existing `feature/<taskName>` branch. Step 1 of `create-pr` should be removed or replaced with a check that the current branch is the expected feature branch.
+
+## Audit Log
+
+| ID | Action | Note | Context |
+| --- | --- | --- | --- |
+| 1 | Create audit log | Initialize bug investigation | Issue #132 — feature-agent commits to main |
+| 2 | Read agent chain | Traced dark-factory-agent → feature-agent → execution-agent → implementation-agent → pr-agent → create-pr | All files read |
+| 3 | Identify root cause 1 | pr-agent / create-pr runs git from main worktree CWD — no WORK_DIR passed | agents/pr/skills/create-pr/SKILL.md Step 1 |
+| 4 | Identify root cause 2 | No branch-drift guard after worker returns in dark-factory-agent | dark-factory-agent.md Step 3/4 gap |
+| 5 | Identify root cause 3 | create-pr Step 1 creates a new fix/ branch off main instead of using the existing feature/ branch | create-pr/SKILL.md line 14 |
+| 6 | Write reproduction test | tests/test_dark_factory_agent_branch_drift_guard.py | Verifies branch-drift guard logic and create-pr branch behavior |
+| 7 | Apply fix 1 | Add branch-drift guard to dark-factory-agent.md after Step 3 | Verifies feature/<taskName> is ahead of main |
+| 8 | Apply fix 2 | Remove git checkout -b from create-pr/SKILL.md; all git ops use -C "$WORK_DIR" | Commit stays on feature branch |
+| 9 | Apply fix 3 | pr-agent reads WORK_DIR from brain context and passes it to create-pr | Agent uses correct CWD |
+| 10 | Add git -C allowed-tools | Added `Bash(git -C * log *)` to dark-factory-agent and `Bash(git -C * ...)` variants to pr-agent | allowed-tools now permits the -C form |
+| 11 | Run full test suite | All 146 tests pass | No regressions |
+| 12 | Causality verification | Stashed fixes → 5/6 tests fail; restored → 6/6 pass | Causality confirmed |
+| 13 | Code review gate | Reviewed diff: DRY, root-cause fixes at source, no workarounds, allowed-tools updated | Fix validated |
+
+## Verification
+
+- [x] Reproduced failure before fix
+- [x] Reproduction test fails before fix (5 of 6 tests failed)
+- [x] Root cause identified with evidence
+- [x] Fix applied at source (no workaround-only patch)
+- [x] Reproduction test passes after fix (6/6 pass)
+- [x] Reproduction path now passes
+- [x] Regression test added/updated — `tests/test_dark_factory_agent_branch_drift_guard.py` (6 tests)
+- [x] Verified no duplicate solved-bug log exists for same root cause

--- a/docs/docs/build-feature.md
+++ b/docs/docs/build-feature.md
@@ -171,8 +171,9 @@ FeatureAgentResult =
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
 | `loop.question` | `FeatureAgentResult{status:"question"}` | AskUserQuestion → re-invoke feature-agent | happy path | dark-factory-agent asks question at depth-2 (where AskUserQuestion works), re-invokes feature-agent with answer + planPath |
-| `loop.done` | `FeatureAgentResult{status:"done"}` | continue to Step 4 (code review) | happy path | planning + execution complete; planFilePath captured from result |
+| `loop.done` | `FeatureAgentResult{status:"done"}` | branch-drift guard → Step 4 (code review) | happy path | planning + execution complete; planFilePath captured from result; branch-drift guard verifies feature branch is ahead of main before proceeding |
 | `loop.hardStop` | `FeatureAgentResult{status:"hard-stop"}` | cleanup + report + STOP | error | surface reason to developer; dark-factory-agent runs cleanup before stopping |
+| `loop.branchDrift` | branch-drift guard: feature branch has no commits ahead of main | cleanup + report + STOP | error | worker committed to wrong branch or not at all; guard fires after worker returns and before code review to prevent empty PR |
 
 #### Pseudocode
 
@@ -184,7 +185,7 @@ result = invoke feature-agent({ taskDescription, answer: null, planPath: null })
 LOOP:
   if result.status == "done":
     planFilePath = result.planPath
-    BREAK  # proceed to Step 4 (code review)
+    BREAK  # proceed to branch-drift guard then Step 4 (code review)
 
   if result.status == "hard-stop":
     rm -f /tmp/dark-factory-work-dir
@@ -197,6 +198,18 @@ LOOP:
     answer = developer response
     result = invoke feature-agent({ answer, planPath: result.planPath, taskDescription: null })
     CONTINUE LOOP
+
+# branch-drift guard — runs after the worker returns and before Step 4 (code review)
+featureBranch = "feature/" + taskName
+driftCheck = bash("git -C \"$WORK_DIR\" log main.." + featureBranch + " --oneline")
+if driftCheck output is empty:
+  rm -f /tmp/dark-factory-work-dir
+  run cleanup(WORK_DIR)
+  report error: "Branch-drift guard failed: feature/<taskName> has no commits ahead of main.
+    The worker agent may have committed to the wrong branch or failed to commit at all.
+    Halting before code review to prevent opening a PR with no changes."
+  STOP
+# Guard passed — proceed to Step 4 (code review)
 ```
 
 ### Flow: `planFeature`

--- a/docs/docs/open-pr.md
+++ b/docs/docs/open-pr.md
@@ -214,12 +214,16 @@ OpenPROutput {
 | `openPR.comments-resolved` | `OpenPRInput` | `OpenPROutput` | happy path | Review threads resolved, CI re-checked, returns ready |
 | `openPR.ci-unfixable` | `OpenPRInput` | `StandardError` | error | ciWatchLoop aborted with unfixable error |
 | `openPR.comment-unfixable` | `OpenPRInput` | `StandardError` | error | commentResolutionLoop aborted with unfixable thread |
+| `openPR.wrong-branch` | `OpenPRInput` | `StandardError` | error | create-pr confirms worktree is not on expected feature/<taskName>; stops before staging |
 
 #### Pseudocode
 
 ```
 openPR(planFilePathOrDescription):
   // Steps 1-2: build body, open PR via create-pr skill
+  // create-pr reads WORK_DIR from brain context.
+  // It confirms the worktree is on feature/<taskName> (does NOT create a new branch).
+  // All git commands run with git -C "$WORK_DIR" to operate on the feature worktree.
   prUrl = open PR via create-pr skill
 
   // Step 3: CI watch loop
@@ -290,4 +294,4 @@ ResolvePRIssueOutput {
 ## Deployment
 
 - Mechanism: `local only` — invoked as a sub-agent by dark-factory-agent
-- Notes: Always stages with `git add --all` before committing — never stages individual files. Always writes PR body to `/tmp/pr-body.md` and uses `--body-file` (never `--body` inline) to avoid "Parser aborted" interactive prompt on large bodies. Does not merge — caller is responsible for merge after receiving `status: "ready"`.
+- Notes: Always stages with `git -C "$WORK_DIR" add --all` before committing — never stages individual files. All git commands use `-C "$WORK_DIR"` to operate on the feature worktree; bare `git` commands from the default CWD are not used. `create-pr` does NOT create a new branch — it verifies the worktree is already on `feature/<taskName>` before proceeding. Always writes PR body to `/tmp/pr-body.md` and uses `--body-file` (never `--body` inline) to avoid "Parser aborted" interactive prompt on large bodies. Does not merge — caller is responsible for merge after receiving `status: "ready"`. WORK_DIR is read from the brain context injected by the pre-hook.

--- a/skills/branch-drift-guard/SKILL.md
+++ b/skills/branch-drift-guard/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: branch-drift-guard
+description: "After a worker agent returns in an orchestrator, verify the feature branch is ahead of main to detect cases where the worker committed to the wrong branch or failed to commit at all."
+user-invocable: false
+---
+## When to use
+
+Immediately after any worker agent (feature-agent, fix-flow-orchestrator, debugger-agent, repair-implementation-agent) returns control to the dark-factory orchestrator, and before proceeding to code review or PR steps.
+
+This guard catches the class of bug where a sub-agent runs `git commit` without an explicit `-C WORK_DIR` or `--work-tree` flag and the commit lands on the wrong branch (e.g., main) because the CWD defaults to the parent worktree.
+
+## Steps
+
+1. After the worker agent returns, compute the feature branch name:
+   ```
+   featureBranch = "feature/" + taskName
+   ```
+
+2. Run a scoped git log to check for commits ahead of main:
+   ```bash
+   git -C "$WORK_DIR" log main..feature/<taskName> --oneline
+   ```
+
+3. If the output is empty (no commits ahead), the worker either committed to the wrong branch or did not commit at all. Do not proceed:
+   ```
+   rm -f /tmp/dark-factory-work-dir
+   run cleanup(WORK_DIR)
+   report error: "Branch-drift guard failed: feature/<taskName> has no commits ahead of main.
+     The worker agent may have committed to the wrong branch or failed to commit at all.
+     Halting before code review to prevent opening a PR with no changes."
+   STOP
+   ```
+
+4. If the output is non-empty, the feature branch has the expected commits — continue to code review.
+
+## Notes
+
+- Always use `git -C "$WORK_DIR"` (not a bare `git`) so the command targets the isolated worktree, not whatever the orchestrator's CWD happens to be.
+- This guard should run even when the worker returns `status == "done"` — a successful return does not guarantee the commit landed on the correct branch.
+- The root cause of branch drift is sub-agents issuing git commands without `-C WORK_DIR`, causing git to resolve the repo from the ambient shell CWD, which may point to the main worktree. See skill `git-c-worktree-subagent` for the companion fix.
+- If the project uses a different default branch name (e.g., `master`), substitute it for `main` in the log range.

--- a/skills/git-c-worktree-subagent/SKILL.md
+++ b/skills/git-c-worktree-subagent/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: git-c-worktree-subagent
+description: "All git operations inside sub-agents that run in an isolated worktree must use git -C WORK_DIR to avoid silently defaulting to the main worktree CWD and committing to the wrong branch."
+user-invocable: false
+---
+## When to use
+
+Whenever writing or reviewing a sub-agent (feature-agent, debugger-agent, repair-implementation-agent, fix-flow-orchestrator, or any agent invoked by dark-factory-agent) that issues git commands — add, commit, push, checkout, log, status, etc.
+
+The Bash tool in a sub-agent does not inherit the orchestrator's working directory. If a sub-agent's CWD resolves to the original project root (main worktree) instead of WORK_DIR, any `git commit` will land on the branch that is currently checked out there — typically `main` — not the feature branch.
+
+## Steps
+
+1. In every sub-agent that receives `workDir` (or equivalent), require that all git commands be scoped with `-C`:
+   ```bash
+   git -C "$WORK_DIR" add -A
+   git -C "$WORK_DIR" commit -m "feat: ..."
+   git -C "$WORK_DIR" push origin feature/<taskName>
+   git -C "$WORK_DIR" status
+   git -C "$WORK_DIR" log --oneline -5
+   ```
+
+2. Never use bare `git <subcommand>` inside a sub-agent when the desired repo is a worktree at a specific path. Even if the agent appears to be "inside" the worktree, the Bash tool's CWD cannot be assumed.
+
+3. When reviewing a sub-agent for correctness, grep for bare `git ` lines (no `-C` flag) as an automated smell:
+   ```bash
+   grep -n '\bgit \b' agents/<agent-dir>/agents/<agent>.md | grep -v 'git -C'
+   ```
+
+4. In the orchestrator that spawns the sub-agent, pass `workDir` explicitly in the invocation payload, and document that the sub-agent must use `-C workDir` for all git calls.
+
+## Notes
+
+- `git -C <path>` is equivalent to `cd <path> && git` but does not mutate the process CWD, making it safe to use in a Bash tool call that might be followed by other shell operations.
+- The companion pattern for detecting when this rule was violated at runtime is the branch-drift guard — see skill `branch-drift-guard`.
+- This rule applies even when the sub-agent's instruction says "you are already inside WORK_DIR". The Bash tool's CWD is determined by the LLM runtime, not by prose instructions.
+- If a sub-agent truly cannot use `-C` (e.g., it must run a script that calls git internally), ensure the script itself is passed WORK_DIR and uses it as `--git-dir` / `--work-tree` or changes directory internally before any git calls.

--- a/tests/test_dark_factory_agent_branch_drift_guard.py
+++ b/tests/test_dark_factory_agent_branch_drift_guard.py
@@ -1,0 +1,211 @@
+"""
+Regression tests for: feature-agent commits to main branch instead of feature worktree branch.
+
+Two root causes are verified:
+
+1. Branch-drift guard: dark-factory-agent.md must contain a guard after the worker
+   returns (Step 3) that verifies feature/<taskName> has commits not on main. If the
+   worker committed to the wrong branch (or not at all), the orchestrator must halt
+   with a clear error rather than silently proceeding to code review with empty changes.
+
+2. create-pr must NOT create a new branch: The create-pr skill must not run
+   `git checkout -b fix/<slug>` because the worktree is already on the correct
+   feature/<taskName> branch. Creating a new branch off the main worktree CWD causes
+   commits to land on main (or on a fix/ branch branched from main, not feature/).
+
+3. pr-agent must use WORK_DIR for git operations: pr-agent's git commands must
+   reference WORK_DIR (via `git -C "$WORK_DIR"` or by running from WORK_DIR) so they
+   operate on the feature worktree, not the main worktree.
+
+See: docs/bugs/2026-04-29-feature-agent-commits-to-main.md
+"""
+
+import os
+import re
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+DARK_FACTORY_AGENT_PATH = os.path.join(
+    PROJECT_ROOT, "agents", "dark-factory", "agents", "dark-factory-agent.md"
+)
+CREATE_PR_SKILL_PATH = os.path.join(
+    PROJECT_ROOT, "agents", "pr", "skills", "create-pr", "SKILL.md"
+)
+PR_AGENT_PATH = os.path.join(
+    PROJECT_ROOT, "agents", "pr", "agents", "pr-agent.md"
+)
+
+
+def _body(path: str) -> str:
+    """Return the body of an agent/skill file (everything after the closing front-matter ---)."""
+    with open(path) as f:
+        content = f.read()
+    fm_end = content.find("\n---", 4)
+    return content[fm_end + 4:] if fm_end != -1 else content
+
+
+def _full(path: str) -> str:
+    """Return the full file content."""
+    with open(path) as f:
+        return f.read()
+
+
+class TestBranchDriftGuard:
+    """Flow: branchDriftGuard — dark-factory-agent must verify feature branch is ahead of main after worker."""
+
+    def test_dark_factory_agent_has_branch_drift_guard(self):
+        """
+        branchDriftGuard.guard-present: dark-factory-agent.md must contain a branch-drift
+        guard after the worker agent returns (Step 3) and before proceeding to Step 4.
+
+        The guard must check that feature/<taskName> has commits that main does not. If the
+        worker committed to the wrong branch, this guard halts with a clear error.
+
+        If this test fails: the branch-drift guard has been removed or never added, meaning
+        a worker that commits to main will silently proceed through code review with no changes.
+        # Plan path: branchDriftGuard.guard-present
+        """
+        body = _body(DARK_FACTORY_AGENT_PATH)
+        # Guard should reference checking that feature branch is ahead of main
+        assert re.search(
+            r"(?i)(branch.drift|drift.guard|ahead.of.main|log.*main\.\.|\.\.HEAD|feature.*commits|commits.*feature|worker.*commit|commit.*wrong|feature.*ahead)",
+            body,
+        ), (
+            "dark-factory-agent.md must contain a branch-drift guard after the worker returns "
+            "(Step 3) that verifies feature/<taskName> has commits not on main. "
+            "Without this guard, a worker that commits to the wrong branch proceeds silently "
+            "through code review with no changes."
+        )
+
+    def test_dark_factory_agent_branch_drift_guard_is_after_worker(self):
+        """
+        branchDriftGuard.guard-position: the branch-drift guard must appear after Step 3
+        (worker invocation) and before Step 4 (code review) in dark-factory-agent.md.
+
+        If this test fails: the guard exists but is in the wrong position — it may run before
+        the worker has committed, making it ineffective.
+        # Plan path: branchDriftGuard.guard-position
+        """
+        body = _body(DARK_FACTORY_AGENT_PATH)
+
+        # Find positions of Step 3 header, the guard, and Step 4 header.
+        # Use line-start anchors (via re.MULTILINE) to match the actual section headers,
+        # not inline references like "# proceed to Step 4 (code review)".
+        step3_match = re.search(r"(?im)^\s*#\s*Step\s+3\b", body)
+        step4_match = re.search(r"(?im)^\s*#\s*Step\s+4\b", body)
+
+        assert step3_match, "dark-factory-agent.md must contain a '# Step 3' section header"
+        assert step4_match, "dark-factory-agent.md must contain a '# Step 4' section header"
+
+        guard_match = re.search(
+            r"(?i)(branch.drift|drift.guard|log.*main\.\.|feature.*ahead|commits.*feature|worker.*commit.*wrong)",
+            body,
+        )
+        assert guard_match, (
+            "dark-factory-agent.md must contain a branch-drift guard expression"
+        )
+
+        step3_pos = step3_match.start()
+        step4_pos = step4_match.start()
+        guard_pos = guard_match.start()
+
+        assert step3_pos < guard_pos < step4_pos, (
+            f"Branch-drift guard (pos {guard_pos}) must appear after Step 3 (pos {step3_pos}) "
+            f"and before Step 4 (pos {step4_pos}) in dark-factory-agent.md. "
+            f"The guard must run after the worker commits and before code review begins."
+        )
+
+    def test_dark_factory_agent_branch_drift_halt_on_empty(self):
+        """
+        branchDriftGuard.halt-message: dark-factory-agent.md must halt with a clear error
+        message when the feature branch has no commits ahead of main.
+
+        If this test fails: the guard detects the drift condition but does not halt — meaning
+        dark-factory-agent silently proceeds to code review with no changes.
+        # Plan path: branchDriftGuard.halt-message
+        """
+        body = _body(DARK_FACTORY_AGENT_PATH)
+        # Must mention halting / error when no commits found
+        assert re.search(
+            r"(?i)(halt|stop|error|fail).{0,100}(no commit|wrong branch|main|commit.*missing|worker.*commit)",
+            body,
+        ) or re.search(
+            r"(?i)(no commit|wrong branch|commit.*missing).{0,100}(halt|stop|error|fail)",
+            body,
+        ), (
+            "dark-factory-agent.md must halt with an error when the branch-drift guard finds "
+            "no commits on feature/<taskName> ahead of main. The error message should indicate "
+            "the worker may have committed to the wrong branch."
+        )
+
+
+class TestCreatePrNoBranchSwitch:
+    """Flow: createPrNoBranchSwitch — create-pr skill must NOT create a new branch."""
+
+    def test_create_pr_does_not_checkout_new_branch(self):
+        """
+        createPrNoBranchSwitch.no-checkout-b: create-pr/SKILL.md must NOT contain
+        `git checkout -b` because the worktree is already on feature/<taskName>.
+
+        Running `git checkout -b fix/<slug>` from the main worktree CWD creates a new
+        branch off main, and the subsequent commit lands there instead of feature/<taskName>.
+
+        If this test fails: create-pr is still creating a new branch, which is the root
+        cause of commits landing on main.
+        # Plan path: createPrNoBranchSwitch.no-checkout-b
+        """
+        content = _full(CREATE_PR_SKILL_PATH)
+        assert "git checkout -b" not in content, (
+            "create-pr/SKILL.md must NOT contain `git checkout -b`. "
+            "The worktree is already on the correct feature/<taskName> branch. "
+            "Creating a new branch from the main worktree CWD causes commits to land on main. "
+            "Remove the `git checkout -b fix/<slug>` step entirely."
+        )
+
+    def test_create_pr_uses_existing_branch(self):
+        """
+        createPrNoBranchSwitch.use-existing-branch: create-pr/SKILL.md must document that
+        it commits to the existing feature branch (not create a new one).
+
+        The PR push should use `git push -u origin HEAD` from WORK_DIR so it pushes
+        feature/<taskName>, not a newly-created fix/ branch off main.
+
+        If this test fails: create-pr has no instruction about working on the existing
+        feature branch, leaving it ambiguous and prone to re-introducing the bug.
+        # Plan path: createPrNoBranchSwitch.use-existing-branch
+        """
+        content = _full(CREATE_PR_SKILL_PATH)
+        # Must mention working on the current branch / feature branch
+        assert re.search(
+            r"(?i)(current branch|feature.*branch|existing branch|WORK_DIR|worktree|feature/<)",
+            content,
+        ), (
+            "create-pr/SKILL.md must explicitly state that it commits to the existing "
+            "feature branch (the worktree branch), not create a new one. "
+            "This prevents future regressions of the checkout-b pattern."
+        )
+
+
+class TestPrAgentUsesWorkDir:
+    """Flow: prAgentUsesWorkDir — pr-agent must use WORK_DIR for git operations."""
+
+    def test_pr_agent_references_work_dir_for_git(self):
+        """
+        prAgentUsesWorkDir.work-dir-git: pr-agent.md must reference WORK_DIR for git
+        operations so that commits go to the feature worktree, not the main worktree.
+
+        If this test fails: pr-agent has no WORK_DIR awareness and will run git commands
+        from whatever CWD the Claude Code process started in (the main worktree).
+        # Plan path: prAgentUsesWorkDir.work-dir-git
+        """
+        body = _body(PR_AGENT_PATH)
+        assert re.search(
+            r"(?i)(WORK_DIR|work_dir|worktree|git -C|cd.*WORK)",
+            body,
+        ), (
+            "pr-agent.md must reference WORK_DIR (or instruct running git with -C $WORK_DIR) "
+            "for all git operations. Without this, git commands run from the main worktree CWD "
+            "and commits land on main instead of feature/<taskName>."
+        )


### PR DESCRIPTION
## Description

# feature-agent commits to main branch instead of feature worktree branch

## Metadata

- Date: `2026-04-29`
- Status: `fixed`
- Severity: `critical`
- Related issue/ticket: `#132`
- Owner: `lewibs`

## About

**Overview**:
- During a manufacture run, dark-factory-agent preps a git worktree at `dark_factory-<taskName>/` on branch `feature/<taskName>`. Worker agents (feature-agent → execution-agent → implementation-agent) write code into WORK_DIR but when git commits happen they land on `main` instead of `feature/<taskName>`.
- This is critical because it directly contaminates the main branch with unreviewed, in-progress work, bypassing the PR / code-review gate entirely.

**Root cause (confirmed from code review)**:

1. **pr-agent / create-pr runs git from main worktree CWD**: `dark-factory-agent.md` Step 6 invokes `pr-agent` without passing WORK_DIR. The `create-pr` skill's Step 1 does `git checkout -b fix/<slug>` followed by `git add --all && git commit && git push`. These Bash commands run in the Claude Code process CWD (project root = main worktree), not WORK_DIR. The commit therefore lands on `main` (or `fix/<slug>` branched off main), not `feature/<taskName>`.

2. **No branch-drift guard after worker returns**: After feature-agent/execution-agent/implementation-agent return in Step 3, `dark-factory-agent.md` does not verify that `feature/<taskName>` has commits ahead of `main`. If the worker committed to the wrong branch (or not at all), the orchestrator silently proceeds to code review with no changes.

**Fixes applied**:

- **Fix 1 — Branch-drift guard in `dark-factory-agent.md`**: After the worker agent (Step 3) returns, verify `feature/<taskName>` is ahead of `main` by at least one commit. Halt if empty.
- **Fix 2 — Pass WORK_DIR to pr-agent**: All git Bash commands in pr-agent and create-pr now use `git -C "$WORK_DIR"`.
- **Fix 3 — Remove `git checkout -b fix/<slug>` from `create-pr`**: The worktree is already on `feature/<taskName>`. The skill no longer creates a new branch.

**Audit Log**:

| ID | Action | Note | Context |
| --- | --- | --- | --- |
| 1 | Create audit log | Initialize bug investigation | Issue #132 — feature-agent commits to main |
| 2 | Read agent chain | Traced dark-factory-agent → feature-agent → execution-agent → implementation-agent → pr-agent → create-pr | All files read |
| 3 | Identify root cause 1 | pr-agent / create-pr runs git from main worktree CWD — no WORK_DIR passed | agents/pr/skills/create-pr/SKILL.md Step 1 |
| 4 | Identify root cause 2 | No branch-drift guard after worker returns in dark-factory-agent | dark-factory-agent.md Step 3/4 gap |
| 5 | Identify root cause 3 | create-pr Step 1 creates a new fix/ branch off main instead of using the existing feature/ branch | create-pr/SKILL.md line 14 |
| 6 | Write reproduction test | tests/test_dark_factory_agent_branch_drift_guard.py | Verifies branch-drift guard logic and create-pr branch behavior |
| 7 | Apply fix 1 | Add branch-drift guard to dark-factory-agent.md after Step 3 | Verifies feature/<taskName> is ahead of main |
| 8 | Apply fix 2 | Remove git checkout -b from create-pr/SKILL.md; all git ops use -C "$WORK_DIR" | Commit stays on feature branch |
| 9 | Apply fix 3 | pr-agent reads WORK_DIR from brain context and passes it to create-pr | Agent uses correct CWD |
| 10 | Add git -C allowed-tools | Added `Bash(git -C * log *)` to dark-factory-agent and `Bash(git -C * ...)` variants to pr-agent | allowed-tools now permits the -C form |
| 11 | Run full test suite | All 146 tests pass | No regressions |
| 12 | Causality verification | Stashed fixes → 5/6 tests fail; restored → 6/6 pass | Causality confirmed |
| 13 | Code review gate | Reviewed diff: DRY, root-cause fixes at source, no workarounds, allowed-tools updated | Fix validated |

**Verification**:

- [x] Reproduced failure before fix
- [x] Reproduction test fails before fix (5 of 6 tests failed)
- [x] Root cause identified with evidence
- [x] Fix applied at source (no workaround-only patch)
- [x] Reproduction test passes after fix (6/6 pass)
- [x] Reproduction path now passes
- [x] Regression test added/updated — `tests/test_dark_factory_agent_branch_drift_guard.py` (6 tests)
- [x] Verified no duplicate solved-bug log exists for same root cause

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/lewibs/github/dark_factory/dark_factory-fix-feature-agent-main-commit
collecting ... collected 6 items

tests/test_dark_factory_agent_branch_drift_guard.py::TestBranchDriftGuard::test_dark_factory_agent_has_branch_drift_guard PASSED [ 16%]
tests/test_dark_factory_agent_branch_drift_guard.py::TestBranchDriftGuard::test_dark_factory_agent_branch_drift_guard_is_after_worker PASSED [ 33%]
tests/test_dark_factory_agent_branch_drift_guard.py::TestBranchDriftGuard::test_dark_factory_agent_branch_drift_halt_on_empty PASSED [ 50%]
tests/test_dark_factory_agent_branch_drift_guard.py::TestCreatePrNoBranchSwitch::test_create_pr_does_not_checkout_new_branch PASSED [ 66%]
tests/test_dark_factory_agent_branch_drift_guard.py::TestCreatePrNoBranchSwitch::test_create_pr_uses_existing_branch PASSED [ 83%]
tests/test_dark_factory_agent_branch_drift_guard.py::TestPrAgentUsesWorkDir::test_pr_agent_references_work_dir_for_git PASSED [100%]

============================== 6 passed in 0.01s ===============================
```

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
