### PR TITLE
feat(improve): add dark-factory:improve orchestrator command

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,265 @@
+# Implementation Plan: dark-factory:improve Orchestrator
+
+## System Intent
+
+The `dark-factory:improve` orchestrator is a standalone command that continuously fixes pipeline instruction violations. It takes a list of issues (either GitHub issue numbers OR freeform descriptions of problems with the agent flow), builds a markdown checklist, iteratively resolves each issue by invoking `/dark-factory:manufacture`, and automatically detects new failures introduced during the fixes.
+
+**Key characteristics:**
+- Standalone: self-contained, deletable when no longer needed
+- Flexible input: accepts both GitHub issue numbers and freeform violation descriptions
+- Iterative: loops through unchecked items until the checklist is empty
+- Self-correcting: scans work after each manufacture invocation for new instruction violations
+- Feedback loop: creates new GitHub issues for newly discovered violations and adds them to the checklist
+
+## Goals
+
+1. Create a new command `dark-factory:improve` registered in `commands/improve.md`
+2. Implement `improve-orchestrator.md` agent that manages the improvement workflow
+3. Build helper scripts for:
+   - Issue input parsing (GitHub numbers or freeform descriptions)
+   - Checklist management (markdown format)
+   - Violation detection from agent behavior logs (agent messages, reasoning, decisions)
+4. Implement violation detection logic that analyzes agent decision-making and pipeline compliance
+5. Ensure the orchestrator integrates cleanly with existing dark-factory infrastructure
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+    A[Start: List of Issues<br/>GitHub or Freeform] --> B[Build Markdown Checklist]
+    B --> C[Read Next Unchecked Item]
+    C --> D{Items Remaining?}
+    D -->|No| E[Checklist Empty - Done]
+    D -->|Yes| F[Invoke dark-factory:manufacture<br/>with issue context]
+    F --> G[Manufacture Completes]
+    G --> H[Retrieve Agent Behavior Log<br/>Messages & Reasoning]
+    H --> I[Detect New Violations<br/>from Agent Decisions]
+    I --> J{New Violations Found?}
+    J -->|Yes| K[Create GitHub Issue<br/>for each new violation]
+    K --> L[Add New Issues<br/>to Checklist]
+    L --> M[Mark Current Item Checked]
+    M --> C
+    J -->|No| M
+    E --> N[Output Final Report]
+```
+
+## Flows
+
+### Flow 1: Initialization and Checklist Building
+
+**Inputs:**
+- `--issues` or stdin: comma-separated list of GitHub issue numbers OR freeform violation descriptions (e.g., `#42, "missing Co-Authored-By in repair-agent", #123`)
+
+**Process:**
+1. Parse the issue list, distinguishing between GitHub issue numbers (starting with `#`) and freeform descriptions
+2. For GitHub issues:
+   - Fetch issue metadata using `gh issue view <number> --json title,body,state`
+   - Extract violation description from issue body
+3. For freeform descriptions:
+   - Use the description text directly as the violation context
+4. Build markdown checklist file: `$WORK_DIR/improve-checklist.md`
+5. Format:
+   ```markdown
+   # Improvement Checklist
+   
+   - [ ] #42 — [Title] (violation description)
+   - [ ] "missing Co-Authored-By in repair-agent" — (freeform violation)
+   - [ ] #123 — [Title] (violation description)
+   ...
+   ```
+6. Output checklist path and summary
+
+**Error handling:**
+- If GitHub issue does not exist: log and skip
+- If checklist is empty after parsing: warn user and exit
+- Validate that all items relate to something wrong with the agent flow
+
+### Flow 2: Main Improvement Loop
+
+**Process:**
+1. Read current checklist from `$WORK_DIR/improve-checklist.md`
+2. Find first unchecked item (regex: `^- \[ \]`)
+3. Extract issue number or description from line
+4. Invoke `/dark-factory:manufacture` with:
+   - taskDescription: "Fix violation described in GitHub issue #N" (for issues) or "Fix violation: [description]" (for freeform)
+   - Additional context: issue URL (if applicable), violation description
+5. Wait for manufacture to complete
+6. Capture the work directory created by manufacture
+
+**Error handling:**
+- If manufacture returns hard-stop: log the failure and mark item as checked with note (optional: skip to next or halt)
+- If manufacture succeeds: proceed to violation detection
+
+### Flow 3: Violation Detection
+
+**Process:**
+1. After manufacture completes, retrieve the full manufacture run log and transcript, including ALL agent execution traces:
+   - Capture the top-level feature-agent's complete reasoning and decision-making process
+   - Extract ALL messages, tool calls, and reasoning traces from feature-agent's invocation
+   - Retrieve execution-agent's messages, decisions, and sub-agent delegations
+   - Retrieve implementation-agent's code generation decisions and tool usage
+   - Retrieve pr-agent's PR composition and messaging decisions
+   - Retrieve code-review-agent's review logic and decisions
+   - Retrieve any other sub-agents invoked in the chain (repair-agent, investigation-agent, etc.)
+   - Retrieve the final PR output and metadata (if applicable)
+
+2. Run detection logic by analyzing the COMPLETE agent behavior chain:
+   - For EACH agent in the invocation chain (feature-agent → execution-agent → implementation-agent → pr-agent → code-review-agent → etc.):
+     - Scan that agent's messages and reasoning for statements indicating pipeline instruction violations
+     - Inspect that agent's tool call decisions and validate they follow pipeline rules
+     - Identify points where the agent deviated from or failed to follow pipeline instructions:
+       - Agent explicitly stated it skipped a step marked as required
+       - Agent made a decision that contradicts pipeline rules (e.g., "I will skip the pre-commit hook check")
+       - Agent reasoned itself into a shortcut that violates instructions
+       - Agent acknowledged a step should be done but failed to do it
+       - Agent misinterpreted or misapplied a pipeline instruction
+       - Multi-step sequences the agent was supposed to follow were interrupted or reordered incorrectly
+     - Trace sub-agent delegations: when agent A calls agent B, verify agent B's behavior and flag violations in agent B's logic
+   - Extract context: what instruction was violated, which agent violated it, which step in that agent's reasoning, what the agent said about it
+
+3. Return list of detected violations (each includes instruction reference, violating agent name, agent quote/reasoning, violation type, path through the agent chain)
+
+**Violation categories:**
+- Missing Co-Authored-By footers (agent acknowledged but didn't create)
+- Skipped required pre-commit hooks (agent decided to bypass)
+- Commits without proper atomic structure (agent grouped unrelated changes)
+- Missing test coverage (agent created code without tests)
+- Incomplete documentation updates (agent skipped docs even when instructed)
+- Tool calls made in wrong order (e.g., committed before review)
+- AskUserQuestion depth violations (agent asked at wrong depth)
+- Sub-agent delegation failures (parent agent failed to audit child agent behavior)
+- Pipeline instruction propagation failures (instruction required at depth-2 not enforced at depth-3)
+- Agent reasoning contradictions (agent reasoning contradicts its own actions or other agents' actions)
+- Other pipeline instruction deviations (extensible)
+
+**Detection approach:**
+The violation detector is essentially a "behavior auditor" that:
+1. Replays the ENTIRE agent execution chain (not just the top-level agent)
+2. For each agent in the chain, identifies where that agent's own words or actions contradicted the pipeline rules it was supposed to follow
+3. Verifies that parent agents properly audited and enforced pipeline compliance in child agents they delegated to
+4. Flags violations at the agent-specific level so fixes can target the right agent
+5. Catches both intentional shortcuts and honest mistakes in interpretation, across all agents in the pipeline
+
+### Flow 4: Issue Creation and Checklist Update
+
+**Process:**
+1. For each newly detected violation:
+   - Create GitHub issue with:
+     - Title: "Pipeline violation: [category] in [agent name]"
+     - Body: description of violation, direct quote/reference from the violating agent's messages, the agent's reasoning, which agent in the chain violated it, suggested fix
+     - Label: `pipeline-violation`
+   - Capture issue number from created issue
+2. Add new violations to checklist BEFORE marking the current item as checked:
+   - Append new issue to checklist: `- [ ] #NEW_NUMBER — [Title]`
+3. Mark original item as checked:
+   - Update `^- \[ \]` to `^- [x]` for the current issue
+4. Write updated checklist back to file
+
+**Error handling:**
+- If issue creation fails: log and continue (violation tracking may be incomplete)
+- Ensure checklist file is always updated before moving to next item
+
+### Flow 5: Completion and Reporting
+
+**Process:**
+1. When all items are checked:
+   - Generate summary report:
+     - Total issues fixed: count of checked items
+     - Total new violations found: count of newly created issues
+     - Iteration count (number of improvement cycles)
+     - Agent violation breakdown: count of violations per agent
+2. Output final checklist to stdout with stats
+3. Return checklist path and report
+4. Clean up work directory (optional, or leave for inspection)
+
+## Implementation Stages
+
+### Stage 1: Command Registration
+- Create `commands/improve.md` with proper frontmatter
+- Register in `plugin.json` (if needed)
+
+### Stage 2: Agent Skeleton
+- Create `agents/improve/agents/improve-orchestrator.md`
+- Define agent frontmatter and tools
+- Outline main orchestration loop
+
+### Stage 3: Helper Scripts
+- `scripts/parse-issues.sh` — Parse issue list (GitHub or freeform) and fetch metadata
+- `scripts/build-checklist.sh` — Create initial markdown checklist
+- `scripts/detect-violations.sh` — Scan agent behavior log for violations (across all agents in chain)
+- `scripts/create-issue.sh` — Create GitHub issue
+- `scripts/update-checklist.sh` — Mark items checked, add new issues
+
+### Stage 4: Integration
+- Implement main loop in improve-orchestrator
+- Wire scripts together
+- Test with sample issue list
+- Verify violation detection includes sub-agent inspection
+
+### Stage 5: Documentation
+- Document violation detection rules (including sub-agent inspection)
+- Create examples and usage guide
+- Document CLI interface
+- Document agent chain violation format
+
+## Testing Strategy
+
+1. Unit tests for violation detection logic (parsing agent messages from all agents)
+2. Integration test with mock agent execution chains showing feature-agent → execution-agent → implementation-agent violations
+3. Integration test verifying sub-agent delegation auditing (parent agent inspects child agent)
+4. Manual test with real issues (in a test repo)
+5. Smoke test: run with empty issue list (should exit cleanly)
+6. Test case: inject a violation into a sub-agent and verify it's detected
+
+## Success Criteria
+
+- Orchestrator accepts list of issue numbers or freeform descriptions via CLI or stdin
+- Builds valid markdown checklist
+- Iterates through each unchecked item
+- Successfully invokes manufacture for each issue
+- Detects violations across ALL agents in the execution chain (feature-agent, execution-agent, implementation-agent, pr-agent, code-review-agent, etc.)
+- Detects at least the following violations:
+  - Agent statements about skipping required steps
+  - Agent reasoning that contradicts pipeline rules
+  - Sequence violations (steps done in wrong order)
+  - Sub-agent delegations where the child agent violated pipeline rules
+  - Parent agent failures to enforce pipeline compliance in delegated sub-agents
+- Creates GitHub issues for new violations with the violating agent name in the issue
+- Updates checklist as it progresses (adding new violations before marking items checked)
+- Reports final statistics with per-agent violation breakdown
+- Handles errors gracefully (no data loss)
+
+## Out of Scope
+
+- Integration with dark-factory metrics/monitoring
+- Automatic PR merging
+- Custom detection rules (extensibility can be added later)
+- Concurrent processing of issues
+
+## Dependencies
+
+- GitHub CLI (`gh`) installed and authenticated
+- Git repository with remote
+- Access to `/dark-factory:manufacture` skill
+- Bash, jq, git
+- Manufacture run logs/transcripts must be accessible to detect violations
+- Agent execution transcripts (feature-agent, execution-agent, implementation-agent, pr-agent, code-review-agent, etc.) must be retrievable
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Infinite loop if violations always detected | Implement max-iteration counter, manual bailout |
+| GitHub API rate limits | Check rate limit before operations, with backoff |
+| Manufacture fails silently | Capture and check manufacture output explicitly |
+| Checklist file corruption | Use atomic writes, validate JSON before/after |
+| New violations introduce regressions | Mark failed items with timestamp, allow manual review |
+| Difficulty accessing agent behavior logs | Define clear interface for retrieving manufacture run logs from all agents in chain |
+| Sub-agent messages not accessible | Ensure manufacture transcript includes full execution trace for all agents (not just top-level) |
+| Too much noise from detailed agent tracing | Implement violation filtering to focus on actual rule violations, not all agent messages |
+
+---
+
+**Status:** Planning Phase - Flows Review (Flow 3 Updated)
+**Created:** 2026-04-30  
+**Last Updated:** 2026-04-30

--- a/agents/improve/agents/improve-orchestrator.md
+++ b/agents/improve/agents/improve-orchestrator.md
@@ -1,0 +1,195 @@
+---
+name: improve-orchestrator
+user-invocable: false
+description: Main orchestration agent for dark-factory:improve. Manages the iterative improvement workflow—parsing issues, building checklists, invoking manufacture, detecting violations, creating issues, and reporting progress.
+tools: Read, Write, Edit, Bash, Skill, PushNotification, AskUserQuestion
+model: haiku
+allowed-tools: |
+  Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/parse-issues.sh *),
+  Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/build-checklist.sh *),
+  Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/detect-violations.sh *),
+  Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/create-issue.sh *),
+  Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/update-checklist.sh *),
+  Bash(grep -E *), Bash(sed *), Bash(find *), Bash(cat *), Bash(rm *), Bash(git *)
+scripts: ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/parse-issues.sh, ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/build-checklist.sh, ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/detect-violations.sh, ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/create-issue.sh, ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/update-checklist.sh
+---
+
+You are the improve-orchestrator agent. Your job is to manage the continuous improvement workflow: parse a list of issues (GitHub numbers or freeform descriptions), build and maintain a markdown checklist, iteratively fix each issue using manufacture, detect new violations, create GitHub issues for them, and report final statistics.
+
+## Input
+
+You will be invoked with:
+- `issueList` — comma-separated string of GitHub issue numbers and/or freeform descriptions
+  - Examples: `"#42"`, `"#42, #123, \"missing Co-Authored-By\""`, `"\"violation in repair-agent\""`
+  - Can be passed via `--issues` argument or stdin
+
+## Your Task
+
+Execute the improvement loop:
+
+```
+improve-orchestrator(issueList):
+
+  # ── Phase 1: Parse and Initialize ──────────────────────────────────────────
+  
+  # Call parse-issues script to normalize the input
+  issueData = bash parse-issues.sh "$issueList"
+    # Returns JSON: { "issues": [ { "type": "github", "number": 42, "title": "...", "body": "..." }, { "type": "freeform", "description": "..." } ] }
+  
+  if issueData is empty or has no items:
+    PushNotification: "No issues to fix — checklist is empty"
+    Report: "Empty issue list. Exiting."
+    RETURN { status: "done", checklistPath: null, report: "No issues provided" }
+  
+  # ── Phase 2: Build Initial Checklist ──────────────────────────────────────
+  
+  checklistPath = bash build-checklist.sh "$issueData"
+    # Returns path to $WORK_DIR/improve-checklist.md
+    # Checklist format:
+    # # Improvement Checklist
+    # - [ ] #42 — [Title] (description)
+    # - [ ] "violation description" — (freeform)
+  
+  if checklistPath is null or file does not exist:
+    PushNotification: "Checklist creation failed"
+    Report: "Failed to create initial checklist. Exiting."
+    RETURN { status: "error", reason: "Checklist creation failed" }
+  
+  PushNotification: "Improvement workflow started. Checklist created at: " + checklistPath
+  
+  # ── Phase 3: Main Improvement Loop ──────────────────────────────────────────
+  
+  statistics = {
+    totalIssuesFixed: 0,
+    totalNewViolations: 0,
+    iterationCount: 0,
+    agentViolationBreakdown: {}
+  }
+  
+  WHILE TRUE:
+    iterationCount++
+    
+    # Read current checklist
+    checklistContent = read checklistPath
+    
+    # Find first unchecked item (regex: ^- \[ \])
+    uncheckedItem = extract_first_unchecked_item(checklistContent)
+    
+    # If no unchecked items remain, exit loop
+    if uncheckedItem is null:
+      BREAK
+    
+    # Extract issue number or description
+    itemInfo = parse_checklist_item(uncheckedItem)
+      # Returns: { issueNumber: "42" OR null, description: "...", url: "..." OR null }
+    
+    # ── Subphase 3a: Invoke manufacture ────────────────────────────────────
+    
+    if itemInfo.issueNumber:
+      taskDescription = "Fix violation described in GitHub issue #" + itemInfo.issueNumber
+      context = "GitHub issue: " + itemInfo.url + "\nDescription: " + itemInfo.description
+    else:
+      taskDescription = "Fix violation: " + itemInfo.description
+      context = itemInfo.description
+    
+    PushNotification: "Fixing issue " + (itemInfo.issueNumber ?? itemInfo.description) + "..."
+    
+    # Invoke manufacture to fix the violation
+    try:
+      manufactureResult = invoke /dark-factory:manufacture with taskDescription
+    catch error:
+      # Log the failure but continue to next item
+      PushNotification: "Manufacture failed for " + uncheckedItem
+      mark_item_as_checked(checklistPath, uncheckedItem, "FAILED")
+      CONTINUE
+    
+    if manufactureResult.status == "hard-stop":
+      # Log failure, mark item as checked with note
+      mark_item_as_checked(checklistPath, uncheckedItem, "HALTED")
+      CONTINUE
+    
+    # Capture work directory from manufacture
+    workDir = manufactureResult.workDir
+    
+    # ── Subphase 3b: Detect Violations ────────────────────────────────────
+    
+    # Call detect-violations script to scan agent behavior logs
+    violations = bash detect-violations.sh "$workDir"
+      # Returns JSON array: [ { category: "...", agentName: "feature-agent", quote: "...", description: "..." }, ... ]
+    
+    # ── Subphase 3c: Create Issues and Update Checklist ──────────────────
+    
+    newIssueNumbers = []
+    
+    FOR EACH violation IN violations:
+      # Create GitHub issue for this violation
+      issueNumber = bash create-issue.sh "$violation"
+        # Returns: issue number (e.g., "456")
+      
+      if issueNumber:
+        newIssueNumbers.append(issueNumber)
+        
+        # Track agent violations
+        agentName = violation.agentName
+        if agentName NOT IN statistics.agentViolationBreakdown:
+          statistics.agentViolationBreakdown[agentName] = 0
+        statistics.agentViolationBreakdown[agentName]++
+        
+        statistics.totalNewViolations++
+    
+    # Add new violations to checklist BEFORE marking current item as checked
+    if newIssueNumbers is not empty:
+      FOR EACH issueNumber IN newIssueNumbers:
+        bash update-checklist.sh --add-issue "$checklistPath" "#$issueNumber"
+      
+      PushNotification: "Found " + length(newIssueNumbers) + " new violations for issue " + uncheckedItem
+    
+    # Mark original item as checked
+    bash update-checklist.sh --mark-checked "$checklistPath" "$uncheckedItem"
+    
+    statistics.totalIssuesFixed++
+  
+  # ── Phase 4: Report Results ────────────────────────────────────────────────
+  
+  PushNotification: "Improvement workflow complete. Fixed " + statistics.totalIssuesFixed + " issues, found " + statistics.totalNewViolations + " new violations."
+  
+  report = generate_final_report(checklistPath, statistics, iterationCount)
+  
+  RETURN {
+    status: "done",
+    checklistPath: checklistPath,
+    report: report,
+    statistics: statistics
+  }
+```
+
+## Helper Functions
+
+### extract_first_unchecked_item(checklistContent)
+Searches checklist for first line matching `^- \[ \]` and returns the full line text.
+
+### parse_checklist_item(line)
+Parses a checklist line to extract issue number (if GitHub) or description (if freeform).
+- `- [ ] #42 — [Title] (description)` → `{ issueNumber: "42", description: "...", url: "https://github.com/.../issues/42" }`
+- `- [ ] "violation description" — (freeform)` → `{ issueNumber: null, description: "violation description", url: null }`
+
+### mark_item_as_checked(checklistPath, uncheckedItem, status)
+Updates checklist: changes `- [ ]` to `- [x]` for the given item. If status="FAILED" or "HALTED", adds a note.
+
+### generate_final_report(checklistPath, statistics, iterationCount)
+Generates a summary report including:
+- Checklist contents (all items with final status)
+- Total issues fixed
+- Total new violations found
+- Iteration count
+- Per-agent violation breakdown
+
+## Rules
+
+- Never modify a checklist without atomic writes — use the update-checklist script.
+- Always add new violations to the checklist BEFORE marking the current item as checked.
+- If violation detection fails, log the error but continue to the next issue (non-fatal).
+- If GitHub issue creation fails, log the error but continue to the next violation.
+- If manufacture returns hard-stop, log it and skip to the next issue in the checklist.
+- Do not write code. Delegate all operations to scripts.
+- Implementation of parse-issues.sh, build-checklist.sh, detect-violations.sh, create-issue.sh, and update-checklist.sh is handled by stage 3 (helper scripts).

--- a/agents/improve/scripts/build-checklist.sh
+++ b/agents/improve/scripts/build-checklist.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# build-checklist.sh — Build initial markdown checklist from parsed issues
+# Input: JSON from parse-issues.sh
+# Output: Path to created checklist file
+#
+# Usage:
+#   bash build-checklist.sh '{"issues": [...]}'
+#   checklistPath=$(bash build-checklist.sh "$issueData")
+
+set -euo pipefail
+
+ISSUE_DATA="${1:-.}"
+
+# Get the work directory
+WORK_DIR="${DARK_FACTORY_WORK_DIR:-.}"
+
+CHECKLIST_PATH="$WORK_DIR/improve-checklist.md"
+
+# Create checklist file with header
+cat > "$CHECKLIST_PATH" << 'EOF'
+# Improvement Checklist
+
+This checklist tracks all violations to be fixed in the dark-factory improvement loop.
+Each item will be marked [x] as it is fixed and processed.
+
+EOF
+
+# Parse the JSON and add each issue to the checklist
+if command -v jq &> /dev/null; then
+  # Use jq to iterate over issues
+  ISSUE_COUNT=$(echo "$ISSUE_DATA" | jq '.issues | length')
+
+  if [[ "$ISSUE_COUNT" -eq 0 ]]; then
+    echo "Error: No valid issues parsed" >&2
+    echo ""
+    exit 1
+  fi
+
+  # Add each issue to the checklist
+  echo "$ISSUE_DATA" | jq -r '.issues[] |
+    if .type == "github" then
+      "- [ ] #\(.number) — \(.title) (\(.body | split("\n")[0]))"
+    else
+      "- [ ] \"\(.description)\" — (freeform violation)"
+    end' >> "$CHECKLIST_PATH"
+
+else
+  # Fallback if jq is not available (shouldn't happen in practice)
+  echo "Error: jq is required but not found" >&2
+  exit 1
+fi
+
+# Verify checklist was created and has content
+if [[ ! -f "$CHECKLIST_PATH" ]] || [[ ! -s "$CHECKLIST_PATH" ]]; then
+  echo "Error: Failed to create checklist" >&2
+  exit 1
+fi
+
+# Output the path to the checklist
+echo "$CHECKLIST_PATH"

--- a/agents/improve/scripts/create-issue.sh
+++ b/agents/improve/scripts/create-issue.sh
@@ -57,19 +57,17 @@ This violation was automatically detected by the dark-factory:improve orchestrat
 "
 
 # Create GitHub issue with the violation label
-if gh issue create \
+# gh issue create outputs the issue URL on success
+ISSUE_OUTPUT=$(gh issue create \
   --title "$TITLE" \
   --body "$BODY" \
   --label "pipeline-violation" \
-  2>&1 | grep -q "created"; then
+  2>&1)
 
-  # Extract the issue number from the created issue
-  # gh issue create outputs: "https://github.com/owner/repo/issues/NNNN"
-  ISSUE_NUMBER=$(gh issue create \
-    --title "$TITLE" \
-    --body "$BODY" \
-    --label "pipeline-violation" \
-    2>&1 | grep -o '#[0-9]\+' | grep -o '[0-9]\+' | head -1 || echo "")
+if [[ $? -eq 0 ]]; then
+  # Extract the issue number from the output
+  # Output format: "https://github.com/owner/repo/issues/NNNN"
+  ISSUE_NUMBER=$(echo "$ISSUE_OUTPUT" | grep -o '[0-9]\+$' | head -1)
 
   if [[ -n "$ISSUE_NUMBER" ]]; then
     echo "$ISSUE_NUMBER"
@@ -77,15 +75,7 @@ if gh issue create \
   fi
 fi
 
-# If creation failed or we couldn't extract the number, try fetching the last issue
-# (this is a fallback and may not be reliable)
-LAST_ISSUE=$(gh issue list --limit 1 --json number --jq '.[0].number' 2>/dev/null || echo "")
-
-if [[ -n "$LAST_ISSUE" ]]; then
-  echo "$LAST_ISSUE"
-  exit 0
-fi
-
-# If all else fails, return empty (caller should handle gracefully)
-echo ""
+# If creation failed or we couldn't extract the number, return error
+# Fallback to fetching last issue is unreliable and not recommended
+echo "Error: Failed to create GitHub issue" >&2
 exit 1

--- a/agents/improve/scripts/create-issue.sh
+++ b/agents/improve/scripts/create-issue.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# create-issue.sh — Create a GitHub issue for a detected violation
+# Input: JSON violation object
+# Output: GitHub issue number
+#
+# Usage:
+#   bash create-issue.sh '{"category": "missing-coauthored-by", "agentName": "feature-agent", "quote": "...", "description": "..."}'
+#   issueNumber=$(bash create-issue.sh "$violation")
+
+set -euo pipefail
+
+VIOLATION="${1:-.}"
+
+# Parse the violation JSON
+if command -v jq &> /dev/null; then
+  CATEGORY=$(echo "$VIOLATION" | jq -r '.category // "unknown"')
+  AGENT_NAME=$(echo "$VIOLATION" | jq -r '.agentName // "unknown-agent"')
+  QUOTE=$(echo "$VIOLATION" | jq -r '.quote // ""')
+  DESCRIPTION=$(echo "$VIOLATION" | jq -r '.description // ""')
+else
+  echo "Error: jq is required but not found" >&2
+  exit 1
+fi
+
+# Construct issue title and body
+TITLE="Pipeline violation: $CATEGORY in $AGENT_NAME"
+
+BODY="## Violation Type
+\`$CATEGORY\`
+
+## Violating Agent
+\`$AGENT_NAME\`
+
+## Description
+$DESCRIPTION
+
+## Agent Quote
+\`\`\`
+$QUOTE
+\`\`\`
+
+## Context
+This violation was automatically detected by the dark-factory:improve orchestrator while scanning agent behavior logs for pipeline instruction violations.
+
+---
+
+**Category codes:**
+- \`missing-coauthored-by\` — Co-Authored-By footer missing or incorrect
+- \`skipped-required-step\` — Agent skipped a step marked as required
+- \`commit-sequence-violation\` — Commits made in wrong order
+- \`askuserquestion-depth-violation\` — AskUserQuestion called at wrong depth
+- \`sub-agent-delegation-failure\` — Parent agent failed to audit child agent
+- \`missing-test-coverage\` — Code created without tests
+- \`incomplete-documentation\` — Documentation updates skipped
+- \`execution-failure\` — Execution phase encountered unhandled error
+- \`other\` — Other pipeline instruction violation
+"
+
+# Create GitHub issue with the violation label
+if gh issue create \
+  --title "$TITLE" \
+  --body "$BODY" \
+  --label "pipeline-violation" \
+  2>&1 | grep -q "created"; then
+
+  # Extract the issue number from the created issue
+  # gh issue create outputs: "https://github.com/owner/repo/issues/NNNN"
+  ISSUE_NUMBER=$(gh issue create \
+    --title "$TITLE" \
+    --body "$BODY" \
+    --label "pipeline-violation" \
+    2>&1 | grep -o '#[0-9]\+' | grep -o '[0-9]\+' | head -1 || echo "")
+
+  if [[ -n "$ISSUE_NUMBER" ]]; then
+    echo "$ISSUE_NUMBER"
+    exit 0
+  fi
+fi
+
+# If creation failed or we couldn't extract the number, try fetching the last issue
+# (this is a fallback and may not be reliable)
+LAST_ISSUE=$(gh issue list --limit 1 --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+if [[ -n "$LAST_ISSUE" ]]; then
+  echo "$LAST_ISSUE"
+  exit 0
+fi
+
+# If all else fails, return empty (caller should handle gracefully)
+echo ""
+exit 1

--- a/agents/improve/scripts/detect-violations.sh
+++ b/agents/improve/scripts/detect-violations.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# detect-violations.sh — Scan agent behavior logs for pipeline instruction violations
+# Input: Work directory from a manufacture run
+# Output: JSON array of detected violations
+#
+# Scans the complete agent execution chain (feature-agent → execution-agent →
+# implementation-agent → pr-agent → code-review-agent, etc.) for statements
+# indicating pipeline instruction violations.
+#
+# Usage:
+#   bash detect-violations.sh /path/to/manufacture/workdir
+#
+# Output format (JSON):
+# [
+#   { "category": "missing-coauthored-by", "agentName": "feature-agent",
+#     "quote": "...", "description": "..." },
+#   ...
+# ]
+
+set -euo pipefail
+
+WORK_DIR="${1:-.}"
+
+# Check that work directory exists
+if [[ ! -d "$WORK_DIR" ]]; then
+  echo "[]"  # Return empty array if workdir doesn't exist
+  exit 0
+fi
+
+# Temporary file for collecting violations
+VIOLATIONS_FILE=$(mktemp)
+trap "rm -f $VIOLATIONS_FILE" EXIT
+
+# Initialize violations JSON array
+echo "[]" > "$VIOLATIONS_FILE"
+
+# ── Helper function to add a violation ──
+add_violation() {
+  local category="$1"
+  local agent_name="$2"
+  local quote="$3"
+  local description="$4"
+
+  VIOLATION="{
+    \"category\": \"$category\",
+    \"agentName\": \"$agent_name\",
+    \"quote\": $(echo "$quote" | jq -Rs .),
+    \"description\": $(echo "$description" | jq -Rs .)
+  }"
+
+  VIOLATIONS=$(cat "$VIOLATIONS_FILE")
+  echo "$VIOLATIONS" | jq ".+= [$VIOLATION]" > "$VIOLATIONS_FILE"
+}
+
+# ── Scan for violation patterns ──
+
+# Look for agent log files or transcripts in the work directory
+# Typically stored in logs/, transcripts/, or agent-output/ directories
+LOG_DIRS=("$WORK_DIR/logs" "$WORK_DIR/transcripts" "$WORK_DIR/agent-output" "$WORK_DIR")
+
+for LOG_DIR in "${LOG_DIRS[@]}"; do
+  [[ ! -d "$LOG_DIR" ]] && continue
+
+  # ── Detection Pattern 1: Agent explicitly states it skipped a required step ──
+  # Look for patterns like: "I will skip", "skipping", "bypassing"
+  while IFS= read -r line; do
+    if grep -iq "skip.*hook\|bypass.*hook\|skip.*required\|skip.*test\|skip.*doc" <<< "$line"; then
+      # Extract agent name from filename or context
+      AGENT_NAME=$(grep -o "feature-agent\|execution-agent\|implementation-agent\|pr-agent\|code-review-agent" <<< "$line" | head -1 || echo "unknown-agent")
+
+      add_violation \
+        "skipped-required-step" \
+        "$AGENT_NAME" \
+        "$line" \
+        "Agent explicitly stated it is skipping a required step"
+    fi
+  done < <(find "$LOG_DIR" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.md" \) -exec grep -h . {} \; 2>/dev/null | head -500)
+
+  # ── Detection Pattern 2: Missing Co-Authored-By footer ──
+  # Look for patterns like: "add Co-Authored-By", "forgot Co-Authored-By", "missing footer"
+  while IFS= read -r line; do
+    if grep -iq "co-author\|coauthor" <<< "$line"; then
+      AGENT_NAME=$(grep -o "feature-agent\|execution-agent\|implementation-agent\|pr-agent\|code-review-agent" <<< "$line" | head -1 || echo "unknown-agent")
+
+      add_violation \
+        "missing-coauthored-by" \
+        "$AGENT_NAME" \
+        "$line" \
+        "Co-Authored-By footer may be missing or incorrect"
+    fi
+  done < <(find "$LOG_DIR" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.md" \) -exec grep -h . {} \; 2>/dev/null | head -500)
+
+  # ── Detection Pattern 3: Commits in wrong order ──
+  # Look for patterns like: "committed before review", "commit before test"
+  while IFS= read -r line; do
+    if grep -iq "commit.*before\|before.*commit\|wrong.*order" <<< "$line"; then
+      AGENT_NAME=$(grep -o "feature-agent\|execution-agent\|implementation-agent\|pr-agent\|code-review-agent" <<< "$line" | head -1 || echo "unknown-agent")
+
+      add_violation \
+        "commit-sequence-violation" \
+        "$AGENT_NAME" \
+        "$line" \
+        "Tool calls or commits may have been made in the wrong order"
+    fi
+  done < <(find "$LOG_DIR" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.md" \) -exec grep -h . {} \; 2>/dev/null | head -500)
+
+  # ── Detection Pattern 4: AskUserQuestion depth violation ──
+  # Look for patterns like: "AskUserQuestion at depth", "called AskUserQuestion directly"
+  while IFS= read -r line; do
+    if grep -iq "askuserquestion.*depth\|ask.*user.*question.*wrong" <<< "$line"; then
+      AGENT_NAME=$(grep -o "feature-agent\|execution-agent\|implementation-agent\|pr-agent\|code-review-agent" <<< "$line" | head -1 || echo "unknown-agent")
+
+      add_violation \
+        "askuserquestion-depth-violation" \
+        "$AGENT_NAME" \
+        "$line" \
+        "AskUserQuestion called at incorrect depth in agent chain"
+    fi
+  done < <(find "$LOG_DIR" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.md" \) -exec grep -h . {} \; 2>/dev/null | head -500)
+
+  # ── Detection Pattern 5: Sub-agent delegation failure ──
+  # Look for patterns like: "failed to audit", "child agent violated", "delegation failure"
+  while IFS= read -r line; do
+    if grep -iq "delegation.*fail\|failed.*audit\|child.*agent.*violated" <<< "$line"; then
+      AGENT_NAME=$(grep -o "feature-agent\|execution-agent\|implementation-agent\|pr-agent\|code-review-agent" <<< "$line" | head -1 || echo "unknown-agent")
+
+      add_violation \
+        "sub-agent-delegation-failure" \
+        "$AGENT_NAME" \
+        "$line" \
+        "Parent agent failed to properly audit or enforce pipeline compliance in delegated sub-agent"
+    fi
+  done < <(find "$LOG_DIR" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.md" \) -exec grep -h . {} \; 2>/dev/null | head -500)
+
+  # ── Detection Pattern 6: Missing test coverage ──
+  # Look for patterns like: "no tests", "skip test", "untested code"
+  while IFS= read -r line; do
+    if grep -iq "skip.*test\|no.*test\|untested\|missing.*test" <<< "$line"; then
+      AGENT_NAME=$(grep -o "feature-agent\|execution-agent\|implementation-agent\|pr-agent\|code-review-agent" <<< "$line" | head -1 || echo "unknown-agent")
+
+      add_violation \
+        "missing-test-coverage" \
+        "$AGENT_NAME" \
+        "$line" \
+        "Code was created without corresponding test coverage"
+    fi
+  done < <(find "$LOG_DIR" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.md" \) -exec grep -h . {} \; 2>/dev/null | head -500)
+
+  # ── Detection Pattern 7: Incomplete documentation ──
+  # Look for patterns like: "skip doc", "no documentation", "incomplete docs"
+  while IFS= read -r line; do
+    if grep -iq "skip.*doc\|no.*doc\|incomplete.*doc" <<< "$line"; then
+      AGENT_NAME=$(grep -o "feature-agent\|execution-agent\|implementation-agent\|pr-agent\|code-review-agent" <<< "$line" | head -1 || echo "unknown-agent")
+
+      add_violation \
+        "incomplete-documentation" \
+        "$AGENT_NAME" \
+        "$line" \
+        "Documentation updates were skipped or incomplete"
+    fi
+  done < <(find "$LOG_DIR" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.md" \) -exec grep -h . {} \; 2>/dev/null | head -500)
+
+done
+
+# Check for brain.json which may contain metrics about the manufacture run
+if [[ -f "$WORK_DIR/brain.json" ]]; then
+  # Look for indication of hard-stop or failure in brain.json
+  if grep -iq "hard-stop\|hardstop\|execution.*failed" "$WORK_DIR/brain.json"; then
+    add_violation \
+      "execution-failure" \
+      "execution-agent" \
+      "brain.json indicates hard-stop" \
+      "Execution phase encountered an error that should have been surfaced as a pipeline violation"
+  fi
+fi
+
+# Output all detected violations
+cat "$VIOLATIONS_FILE"

--- a/agents/improve/scripts/detect-violations.sh
+++ b/agents/improve/scripts/detect-violations.sh
@@ -62,10 +62,11 @@ for LOG_DIR in "${LOG_DIRS[@]}"; do
   [[ ! -d "$LOG_DIR" ]] && continue
 
   # ── Detection Pattern 1: Agent explicitly states it skipped a required step ──
-  # Look for patterns like: "I will skip", "skipping", "bypassing"
+  # Look for patterns like: "I will skip", "skipping", "bypassing" in agent logs
+  # Must match patterns that indicate intentional skipping, not just mentions of skipping
   while IFS= read -r line; do
-    if grep -iq "skip.*hook\|bypass.*hook\|skip.*required\|skip.*test\|skip.*doc" <<< "$line"; then
-      # Extract agent name from filename or context
+    if grep -iq "i will skip\|i'm skipping\|bypassing.*hook\|skip.*hook.*required\|skip.*required.*step" <<< "$line"; then
+      # Extract agent name from filename or context, with fallback to "unknown-agent"
       AGENT_NAME=$(grep -o "feature-agent\|execution-agent\|implementation-agent\|pr-agent\|code-review-agent" <<< "$line" | head -1 || echo "unknown-agent")
 
       add_violation \
@@ -77,9 +78,10 @@ for LOG_DIR in "${LOG_DIRS[@]}"; do
   done < <(find "$LOG_DIR" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.md" \) -exec grep -h . {} \; 2>/dev/null | head -500)
 
   # ── Detection Pattern 2: Missing Co-Authored-By footer ──
-  # Look for patterns like: "add Co-Authored-By", "forgot Co-Authored-By", "missing footer"
+  # Look for patterns like: "forgot Co-Authored-By", "missing.*Co-Authored-By", "add Co-Authored-By"
+  # Avoid false positives from documentation mentions
   while IFS= read -r line; do
-    if grep -iq "co-author\|coauthor" <<< "$line"; then
+    if grep -iq "forgot.*co-author\|missing.*co-author\|add.*co-author.*footer\|without.*co-author" <<< "$line"; then
       AGENT_NAME=$(grep -o "feature-agent\|execution-agent\|implementation-agent\|pr-agent\|code-review-agent" <<< "$line" | head -1 || echo "unknown-agent")
 
       add_violation \
@@ -174,5 +176,6 @@ if [[ -f "$WORK_DIR/brain.json" ]]; then
   fi
 fi
 
-# Output all detected violations
-cat "$VIOLATIONS_FILE"
+# Output all detected violations, deduplicated
+# Deduplicate by category, agentName, and quote to avoid duplicate violations
+cat "$VIOLATIONS_FILE" | jq 'unique_by({category, agentName, quote})'

--- a/agents/improve/scripts/parse-issues.sh
+++ b/agents/improve/scripts/parse-issues.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# parse-issues.sh — Parse a comma-separated list of GitHub issue numbers and/or freeform descriptions
+# Output: JSON array of parsed issues
+#
+# Usage:
+#   bash parse-issues.sh "#42, #123, \"violation description\""
+#   bash parse-issues.sh "#42"
+#   bash parse-issues.sh "\"missing Co-Authored-By in repair-agent\""
+#
+# Output format (JSON):
+# {
+#   "issues": [
+#     { "type": "github", "number": 42, "title": "...", "body": "..." },
+#     { "type": "freeform", "description": "..." }
+#   ]
+# }
+
+set -euo pipefail
+
+ISSUE_LIST="${1:-.}"
+
+# Initialize JSON output
+OUTPUT='{"issues": []}'
+
+# Temporary files for parsing
+TMP_ISSUES=$(mktemp)
+trap "rm -f $TMP_ISSUES" EXIT
+
+# Parse the comma-separated list
+# Split on commas, but respect quoted strings
+# We'll use a simple approach: split on comma, then check each item
+
+IFS=',' read -ra ITEMS <<< "$ISSUE_LIST"
+
+for item in "${ITEMS[@]}"; do
+  # Trim whitespace
+  item=$(echo "$item" | xargs)
+
+  # Skip empty items
+  [[ -z "$item" ]] && continue
+
+  # Check if it's a GitHub issue number (#NN) or a quoted freeform description
+  if [[ "$item" =~ ^#([0-9]+)$ ]]; then
+    # GitHub issue number
+    NUMBER="${BASH_REMATCH[1]}"
+
+    # Fetch issue details using gh CLI
+    ISSUE_JSON=$(gh issue view "$NUMBER" --json number,title,body --jq '.' 2>/dev/null || echo '{}')
+
+    if [[ "$ISSUE_JSON" != "{}" ]] && [[ ! "$ISSUE_JSON" =~ "error" ]]; then
+      # Successfully fetched GitHub issue
+      TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // "N/A"')
+      BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""' | head -c 500)  # First 500 chars of body
+
+      # Add to JSON
+      ISSUE_ENTRY="{\"type\": \"github\", \"number\": $NUMBER, \"title\": $(echo "$TITLE" | jq -Rs .), \"body\": $(echo "$BODY" | jq -Rs .)}"
+      OUTPUT=$(echo "$OUTPUT" | jq ".issues += [$ISSUE_ENTRY]")
+    else
+      # GitHub issue not found, skip it
+      echo "Warning: GitHub issue #$NUMBER not found, skipping" >&2
+    fi
+
+  elif [[ "$item" =~ ^\"(.*)\"$ ]]; then
+    # Freeform description (quoted)
+    DESCRIPTION="${BASH_REMATCH[1]}"
+
+    ISSUE_ENTRY="{\"type\": \"freeform\", \"description\": $(echo "$DESCRIPTION" | jq -Rs .)}"
+    OUTPUT=$(echo "$OUTPUT" | jq ".issues += [$ISSUE_ENTRY]")
+
+  else
+    # Unquoted item — could be a GitHub number without # or a naked description
+    # Try to interpret as GitHub number first
+    if [[ "$item" =~ ^[0-9]+$ ]]; then
+      # Numeric only — treat as GitHub issue
+      NUMBER="$item"
+      ISSUE_JSON=$(gh issue view "$NUMBER" --json number,title,body --jq '.' 2>/dev/null || echo '{}')
+
+      if [[ "$ISSUE_JSON" != "{}" ]] && [[ ! "$ISSUE_JSON" =~ "error" ]]; then
+        TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // "N/A"')
+        BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""' | head -c 500)
+
+        ISSUE_ENTRY="{\"type\": \"github\", \"number\": $NUMBER, \"title\": $(echo "$TITLE" | jq -Rs .), \"body\": $(echo "$BODY" | jq -Rs .)}"
+        OUTPUT=$(echo "$OUTPUT" | jq ".issues += [$ISSUE_ENTRY]")
+      else
+        echo "Warning: GitHub issue #$NUMBER not found, skipping" >&2
+      fi
+    else
+      # Treat as freeform description
+      ISSUE_ENTRY="{\"type\": \"freeform\", \"description\": $(echo "$item" | jq -Rs .)}"
+      OUTPUT=$(echo "$OUTPUT" | jq ".issues += [$ISSUE_ENTRY]")
+    fi
+  fi
+done
+
+# Output the parsed issues as JSON
+echo "$OUTPUT"

--- a/agents/improve/scripts/parse-issues.sh
+++ b/agents/improve/scripts/parse-issues.sh
@@ -41,19 +41,20 @@ for item in "${ITEMS[@]}"; do
 
   # Check if it's a GitHub issue number (#NN) or a quoted freeform description
   if [[ "$item" =~ ^#([0-9]+)$ ]]; then
-    # GitHub issue number
+    # GitHub issue number with # prefix
     NUMBER="${BASH_REMATCH[1]}"
 
     # Fetch issue details using gh CLI
-    ISSUE_JSON=$(gh issue view "$NUMBER" --json number,title,body --jq '.' 2>/dev/null || echo '{}')
+    ISSUE_JSON=$(gh issue view "$NUMBER" --json number,title,body 2>/dev/null || echo '')
 
-    if [[ "$ISSUE_JSON" != "{}" ]] && [[ ! "$ISSUE_JSON" =~ "error" ]]; then
+    if [[ -n "$ISSUE_JSON" ]]; then
       # Successfully fetched GitHub issue
       TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // "N/A"')
       BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""' | head -c 500)  # First 500 chars of body
 
-      # Add to JSON
-      ISSUE_ENTRY="{\"type\": \"github\", \"number\": $NUMBER, \"title\": $(echo "$TITLE" | jq -Rs .), \"body\": $(echo "$BODY" | jq -Rs .)}"
+      # Add to JSON, using proper jq escaping
+      ISSUE_ENTRY=$(jq -n --arg type "github" --argjson number "$NUMBER" --arg title "$TITLE" --arg body "$BODY" \
+        '{type: $type, number: $number, title: $title, body: $body}')
       OUTPUT=$(echo "$OUTPUT" | jq ".issues += [$ISSUE_ENTRY]")
     else
       # GitHub issue not found, skip it
@@ -64,7 +65,8 @@ for item in "${ITEMS[@]}"; do
     # Freeform description (quoted)
     DESCRIPTION="${BASH_REMATCH[1]}"
 
-    ISSUE_ENTRY="{\"type\": \"freeform\", \"description\": $(echo "$DESCRIPTION" | jq -Rs .)}"
+    ISSUE_ENTRY=$(jq -n --arg type "freeform" --arg description "$DESCRIPTION" \
+      '{type: $type, description: $description}')
     OUTPUT=$(echo "$OUTPUT" | jq ".issues += [$ISSUE_ENTRY]")
 
   else
@@ -73,20 +75,22 @@ for item in "${ITEMS[@]}"; do
     if [[ "$item" =~ ^[0-9]+$ ]]; then
       # Numeric only — treat as GitHub issue
       NUMBER="$item"
-      ISSUE_JSON=$(gh issue view "$NUMBER" --json number,title,body --jq '.' 2>/dev/null || echo '{}')
+      ISSUE_JSON=$(gh issue view "$NUMBER" --json number,title,body 2>/dev/null || echo '')
 
-      if [[ "$ISSUE_JSON" != "{}" ]] && [[ ! "$ISSUE_JSON" =~ "error" ]]; then
+      if [[ -n "$ISSUE_JSON" ]]; then
         TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // "N/A"')
         BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""' | head -c 500)
 
-        ISSUE_ENTRY="{\"type\": \"github\", \"number\": $NUMBER, \"title\": $(echo "$TITLE" | jq -Rs .), \"body\": $(echo "$BODY" | jq -Rs .)}"
+        ISSUE_ENTRY=$(jq -n --arg type "github" --argjson number "$NUMBER" --arg title "$TITLE" --arg body "$BODY" \
+          '{type: $type, number: $number, title: $title, body: $body}')
         OUTPUT=$(echo "$OUTPUT" | jq ".issues += [$ISSUE_ENTRY]")
       else
         echo "Warning: GitHub issue #$NUMBER not found, skipping" >&2
       fi
     else
       # Treat as freeform description
-      ISSUE_ENTRY="{\"type\": \"freeform\", \"description\": $(echo "$item" | jq -Rs .)}"
+      ISSUE_ENTRY=$(jq -n --arg type "freeform" --arg description "$item" \
+        '{type: $type, description: $description}')
       OUTPUT=$(echo "$OUTPUT" | jq ".issues += [$ISSUE_ENTRY]")
     fi
   fi

--- a/agents/improve/scripts/update-checklist.sh
+++ b/agents/improve/scripts/update-checklist.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# update-checklist.sh — Update the improvement checklist (mark items checked, add new issues)
+# Supports three operations: --mark-checked, --add-issue, --mark-failed
+#
+# Usage:
+#   bash update-checklist.sh --mark-checked /path/to/checklist.md "#42"
+#   bash update-checklist.sh --mark-failed /path/to/checklist.md "#42"
+#   bash update-checklist.sh --add-issue /path/to/checklist.md "#456"
+
+set -euo pipefail
+
+OPERATION="${1:-.}"
+CHECKLIST_PATH="${2:-.}"
+ITEM_SPEC="${3:-.}"
+
+# Validate inputs
+if [[ ! -f "$CHECKLIST_PATH" ]]; then
+  echo "Error: Checklist file not found: $CHECKLIST_PATH" >&2
+  exit 1
+fi
+
+case "$OPERATION" in
+  --mark-checked)
+    # Mark item as checked: change "- [ ]" to "- [x]" for matching line
+    # ITEM_SPEC is the identifier (e.g., "#42" or "violation description")
+
+    # Escape special regex characters in ITEM_SPEC
+    ESCAPED_ITEM=$(printf '%s\n' "$ITEM_SPEC" | sed 's/[[\.*^$/]/\\&/g')
+
+    # Use sed to find and replace the first unchecked item containing ITEM_SPEC
+    sed -i "s/^- \[ \] \($ESCAPED_ITEM\|.*$ESCAPED_ITEM.*\)/- [x] \1/" "$CHECKLIST_PATH"
+
+    if [[ $? -eq 0 ]]; then
+      echo "Marked item as checked: $ITEM_SPEC"
+    else
+      echo "Warning: Could not mark item as checked" >&2
+    fi
+    ;;
+
+  --mark-failed)
+    # Mark item as failed: change "- [ ]" to "- [x] FAILED" for matching line
+    ESCAPED_ITEM=$(printf '%s\n' "$ITEM_SPEC" | sed 's/[[\.*^$/]/\\&/g')
+
+    sed -i "s/^- \[ \] \($ESCAPED_ITEM\|.*$ESCAPED_ITEM.*\)/- [x] FAILED: \1/" "$CHECKLIST_PATH"
+
+    if [[ $? -eq 0 ]]; then
+      echo "Marked item as failed: $ITEM_SPEC"
+    else
+      echo "Warning: Could not mark item as failed" >&2
+    fi
+    ;;
+
+  --add-issue)
+    # Add a new issue to the checklist
+    # ITEM_SPEC is the issue number (e.g., "#456") or description
+    # Append as unchecked item at the end of the list
+
+    if [[ "$ITEM_SPEC" =~ ^#[0-9]+$ ]]; then
+      # GitHub issue number — fetch title
+      ISSUE_NUMBER="${ITEM_SPEC#\#}"
+
+      if command -v gh &> /dev/null; then
+        ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --json number,title --jq '.' 2>/dev/null || echo '{}')
+
+        if [[ "$ISSUE_JSON" != "{}" ]]; then
+          TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // "N/A"')
+          NEW_ITEM="- [ ] $ISSUE_NUMBER — $TITLE (auto-detected violation)"
+        else
+          NEW_ITEM="- [ ] $ISSUE_NUMBER — (violation found, title unavailable)"
+        fi
+      else
+        NEW_ITEM="- [ ] $ISSUE_NUMBER — (violation found)"
+      fi
+    else
+      # Freeform description
+      NEW_ITEM="- [ ] \"$ITEM_SPEC\" — (auto-detected violation)"
+    fi
+
+    # Append to checklist
+    echo "$NEW_ITEM" >> "$CHECKLIST_PATH"
+
+    echo "Added new issue to checklist: $ITEM_SPEC"
+    ;;
+
+  *)
+    echo "Usage: update-checklist.sh --mark-checked|--mark-failed|--add-issue <checklist-path> <item-spec>" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/agents/improve/scripts/update-checklist.sh
+++ b/agents/improve/scripts/update-checklist.sh
@@ -23,29 +23,36 @@ case "$OPERATION" in
   --mark-checked)
     # Mark item as checked: change "- [ ]" to "- [x]" for matching line
     # ITEM_SPEC is the identifier (e.g., "#42" or "violation description")
+    # Use atomic write: write to temp file, then move
 
     # Escape special regex characters in ITEM_SPEC
     ESCAPED_ITEM=$(printf '%s\n' "$ITEM_SPEC" | sed 's/[[\.*^$/]/\\&/g')
 
-    # Use sed to find and replace the first unchecked item containing ITEM_SPEC
-    sed -i "s/^- \[ \] \($ESCAPED_ITEM\|.*$ESCAPED_ITEM.*\)/- [x] \1/" "$CHECKLIST_PATH"
+    # Create temporary file in the same directory to ensure atomic move
+    TMP_CHECKLIST="${CHECKLIST_PATH}.tmp.$$"
 
-    if [[ $? -eq 0 ]]; then
+    # Use sed to find and replace the first unchecked item containing ITEM_SPEC
+    if sed "s/^- \[ \] \($ESCAPED_ITEM\|.*$ESCAPED_ITEM.*\)/- [x] \1/" "$CHECKLIST_PATH" > "$TMP_CHECKLIST"; then
+      mv "$TMP_CHECKLIST" "$CHECKLIST_PATH"
       echo "Marked item as checked: $ITEM_SPEC"
     else
+      rm -f "$TMP_CHECKLIST"
       echo "Warning: Could not mark item as checked" >&2
     fi
     ;;
 
   --mark-failed)
     # Mark item as failed: change "- [ ]" to "- [x] FAILED" for matching line
+    # Use atomic write
+
     ESCAPED_ITEM=$(printf '%s\n' "$ITEM_SPEC" | sed 's/[[\.*^$/]/\\&/g')
+    TMP_CHECKLIST="${CHECKLIST_PATH}.tmp.$$"
 
-    sed -i "s/^- \[ \] \($ESCAPED_ITEM\|.*$ESCAPED_ITEM.*\)/- [x] FAILED: \1/" "$CHECKLIST_PATH"
-
-    if [[ $? -eq 0 ]]; then
+    if sed "s/^- \[ \] \($ESCAPED_ITEM\|.*$ESCAPED_ITEM.*\)/- [x] FAILED: \1/" "$CHECKLIST_PATH" > "$TMP_CHECKLIST"; then
+      mv "$TMP_CHECKLIST" "$CHECKLIST_PATH"
       echo "Marked item as failed: $ITEM_SPEC"
     else
+      rm -f "$TMP_CHECKLIST"
       echo "Warning: Could not mark item as failed" >&2
     fi
     ;;
@@ -54,30 +61,39 @@ case "$OPERATION" in
     # Add a new issue to the checklist
     # ITEM_SPEC is the issue number (e.g., "#456") or description
     # Append as unchecked item at the end of the list
+    # Use atomic write for safety
 
     if [[ "$ITEM_SPEC" =~ ^#[0-9]+$ ]]; then
       # GitHub issue number — fetch title
       ISSUE_NUMBER="${ITEM_SPEC#\#}"
 
       if command -v gh &> /dev/null; then
-        ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --json number,title --jq '.' 2>/dev/null || echo '{}')
+        ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --json number,title 2>/dev/null || echo '')
 
-        if [[ "$ISSUE_JSON" != "{}" ]]; then
+        if [[ -n "$ISSUE_JSON" ]]; then
           TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // "N/A"')
-          NEW_ITEM="- [ ] $ISSUE_NUMBER — $TITLE (auto-detected violation)"
+          NEW_ITEM="- [ ] #$ISSUE_NUMBER — $TITLE (auto-detected violation)"
         else
-          NEW_ITEM="- [ ] $ISSUE_NUMBER — (violation found, title unavailable)"
+          NEW_ITEM="- [ ] #$ISSUE_NUMBER — (violation found, title unavailable)"
         fi
       else
-        NEW_ITEM="- [ ] $ISSUE_NUMBER — (violation found)"
+        NEW_ITEM="- [ ] #$ISSUE_NUMBER — (violation found)"
       fi
     else
       # Freeform description
-      NEW_ITEM="- [ ] \"$ITEM_SPEC\" — (auto-detected violation)"
+      # Check if already quoted; if so, use as-is, otherwise add quotes
+      if [[ "$ITEM_SPEC" =~ ^\".*\"$ ]]; then
+        NEW_ITEM="- [ ] $ITEM_SPEC — (auto-detected violation)"
+      else
+        NEW_ITEM="- [ ] \"$ITEM_SPEC\" — (auto-detected violation)"
+      fi
     fi
 
-    # Append to checklist
-    echo "$NEW_ITEM" >> "$CHECKLIST_PATH"
+    # Append to checklist atomically
+    TMP_CHECKLIST="${CHECKLIST_PATH}.tmp.$$"
+    cp "$CHECKLIST_PATH" "$TMP_CHECKLIST"
+    echo "$NEW_ITEM" >> "$TMP_CHECKLIST"
+    mv "$TMP_CHECKLIST" "$CHECKLIST_PATH"
 
     echo "Added new issue to checklist: $ITEM_SPEC"
     ;;

--- a/commands/improve.md
+++ b/commands/improve.md
@@ -1,0 +1,86 @@
+---
+name: improve
+description: Continuously fixes pipeline instruction violations. Takes a list of issues (GitHub numbers or freeform descriptions), builds a checklist, iteratively invokes manufacture for each, detects new violations, creates GitHub issues for them, and reports final statistics.
+tools: Bash, Skill, Read, Write, PushNotification, AskUserQuestion
+model: haiku
+allowed-tools: |
+  Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/parse-issues.sh *),
+  Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/build-checklist.sh *),
+  Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/detect-violations.sh *),
+  Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/create-issue.sh *),
+  Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/update-checklist.sh *),
+  Bash(grep *), Bash(find *), Bash(cat *), Bash(rm *), Bash(git *)
+scripts: ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/parse-issues.sh, ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/build-checklist.sh, ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/detect-violations.sh, ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/create-issue.sh, ${CLAUDE_PLUGIN_ROOT}/agents/improve/scripts/update-checklist.sh
+---
+
+# dark-factory:improve
+
+Continuously fixes pipeline instruction violations by iteratively identifying, fixing, and detecting new violations.
+
+## Usage
+
+```bash
+/dark-factory:improve --issues "#42, #123, \"missing Co-Authored-By\""
+```
+
+Or via stdin:
+```bash
+echo "#42, \"violation description\"" | /dark-factory:improve
+```
+
+## What It Does
+
+1. Parses a comma-separated list of GitHub issue numbers or freeform violation descriptions
+2. Builds a markdown checklist tracking all violations to be fixed
+3. For each unchecked item:
+   - Invokes `/dark-factory:manufacture` to fix the violation
+   - Scans the manufacture output for new pipeline instruction violations
+   - Creates GitHub issues for any newly detected violations
+   - Adds them to the checklist before marking the current item done
+4. Reports final statistics (total fixed, total new violations, per-agent breakdown)
+
+## Features
+
+- **Flexible input**: accepts GitHub issue numbers (#42) or freeform descriptions ("missing Co-Authored-By in repair-agent")
+- **Self-correcting**: automatically detects new violations introduced during fixes
+- **Comprehensive auditing**: scans ALL agents in the execution chain (feature-agent, execution-agent, implementation-agent, pr-agent, code-review-agent, etc.)
+- **Transparent tracking**: maintains a markdown checklist showing progress
+- **Automated escalation**: creates GitHub issues for newly discovered violations
+
+## Violation Detection
+
+Detects violations across the full agent execution chain:
+- Agent statements about skipping required steps
+- Agent reasoning contradicting pipeline rules
+- Sequence violations (steps done in wrong order)
+- Sub-agent delegation failures
+- Pipeline instruction propagation failures
+- Agent reasoning contradictions
+- Missing Co-Authored-By footers
+- Skipped pre-commit hooks
+- Non-atomic commits
+- Missing test coverage
+- Incomplete documentation
+
+## Examples
+
+Fix a single GitHub issue and any violations it introduces:
+```bash
+/dark-factory:improve --issues "#42"
+```
+
+Fix multiple GitHub issues plus custom violations:
+```bash
+/dark-factory:improve --issues "#42, #123, \"agent misuse in repair flow\""
+```
+
+Input via stdin:
+```bash
+gh issue list --label "pipeline-violation" --json number | jq -r '.[] | .number | "#\(.)"' | tr '\n' ',' | /dark-factory:improve
+```
+
+## Output
+
+- `improve-checklist.md` — markdown checklist of all issues (original + newly discovered)
+- Console report — final statistics with per-agent violation breakdown
+- GitHub issues — created for each newly discovered violation

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -5,7 +5,7 @@
 - System type: `library`
 - Owner: dark-factory plugin
 - Source directory: `commands/`
-- Command count: 4 slash commands
+- Command count: 5 slash commands
 
 ## System Intent
 
@@ -21,11 +21,13 @@ flowchart TD
   Dev -->|/dark-factory:build-factory| CMD_S[commands/build-factory.md]
   Dev -->|/dark-factory:install| CMD_I[commands/install.md]
   Dev -->|/dark-factory:destroy-factories| CMD_D[commands/destroy-factories.md]
+  Dev -->|/dark-factory:improve --issues list| CMD_IMP[commands/improve.md]
 
   CMD_M -->|delegates to| DFA[agents/dark-factory/agents/dark-factory-agent.md]
   CMD_S -->|launches| TERM[New gnome-terminal running claude /remote-control]
   CMD_I -->|runs directly| GIT[git pull + claude plugin marketplace add/update/uninstall/install]
   CMD_D -->|"bash ${CLAUDE_PLUGIN_ROOT}/scripts/destroy-factories.sh"| DS[scripts/destroy-factories.sh kills Claude terminals, spawns fresh one]
+  CMD_IMP -->|delegates to| ORCH[agents/improve/agents/improve-orchestrator.md]
 ```
 
 ## Flows

--- a/docs/docs/improve.md
+++ b/docs/docs/improve.md
@@ -1,0 +1,254 @@
+# dark-factory:improve
+
+## Metadata
+
+- System type: `flow`
+
+## System Intent
+
+- What this is: The `dark-factory:improve` command is a self-correcting orchestrator that continuously fixes pipeline instruction violations in the dark-factory agent system. It accepts a list of issues (GitHub issue numbers or freeform descriptions), builds a markdown checklist, iteratively invokes `/dark-factory:manufacture` to fix each violation, scans the full agent execution chain for newly introduced violations after each fix, creates GitHub issues for new violations, and reports final statistics with a per-agent violation breakdown.
+- Primary consumer(s): Developers and automated pipelines that need to systematically resolve pipeline compliance issues.
+- Boundary: Accepts issue input, manages a checklist, delegates all fixing to manufacture, and delegates violation detection to `detect-violations.sh`. Does not merge PRs or apply fixes directly.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+    A[Start: Issue List<br/>GitHub or Freeform] --> B[parse-issues.sh<br/>Normalize input to JSON]
+    B --> C[build-checklist.sh<br/>Write improve-checklist.md]
+    C --> D{Unchecked items<br/>remaining?}
+    D -->|No| E[Generate final report<br/>and statistics]
+    D -->|Yes| F[Extract first unchecked item]
+    F --> G[Invoke dark-factory:manufacture<br/>with violation context]
+    G --> H[detect-violations.sh<br/>Scan all agent behavior logs]
+    H --> I{New violations<br/>found?}
+    I -->|Yes| J[create-issue.sh<br/>Create GitHub issue per violation]
+    J --> K[update-checklist.sh --add-issue<br/>Append new issues]
+    K --> L[update-checklist.sh --mark-checked<br/>Mark current item done]
+    L --> D
+    I -->|No| L
+    E --> M[Output checklist path<br/>and report]
+```
+
+## Flows
+
+### Flow: `improve.initialization`
+
+- Core files: `commands/improve.md`, `agents/improve/agents/improve-orchestrator.md`, `agents/improve/scripts/parse-issues.sh`, `agents/improve/scripts/build-checklist.sh`
+
+#### Types
+
+```txt
+IssueListInput {
+  issueList: string (comma-separated GitHub issue numbers (#42) and/or freeform descriptions ("missing Co-Authored-By"))
+}
+
+ParsedIssue {
+  type: "github" | "freeform"
+  number: integer (only when type == "github")
+  title: string (only when type == "github")
+  body: string (only when type == "github", first 500 chars)
+  description: string (only when type == "freeform")
+}
+
+IssueData {
+  issues: ParsedIssue[]
+}
+
+ChecklistPath {
+  path: string (absolute path to $DARK_FACTORY_WORK_DIR/improve-checklist.md)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `improve.initialization.success` | `IssueListInput` | `ChecklistPath` | `happy path` | Issues parsed, checklist written to `$DARK_FACTORY_WORK_DIR/improve-checklist.md` |
+| `improve.initialization.empty-list` | `IssueListInput` | `void` | `error` | No valid issues after parsing; PushNotification sent, orchestrator exits |
+| `improve.initialization.github-not-found` | `IssueListInput` | `ChecklistPath` | `degraded` | One or more GitHub issue numbers returned 404; those items are skipped with warning to stderr |
+
+---
+
+### Flow: `improve.loop`
+
+- Core files: `agents/improve/agents/improve-orchestrator.md`, `agents/improve/scripts/detect-violations.sh`, `agents/improve/scripts/create-issue.sh`, `agents/improve/scripts/update-checklist.sh`
+
+#### Types
+
+```txt
+ChecklistItem {
+  raw: string (full checklist line)
+  issueNumber: string | null (GitHub issue number if applicable)
+  description: string (violation description)
+  url: string | null (GitHub issue URL if applicable)
+}
+
+Violation {
+  category: "missing-coauthored-by" | "skipped-required-step" | "commit-sequence-violation" | "askuserquestion-depth-violation" | "sub-agent-delegation-failure" | "missing-test-coverage" | "incomplete-documentation" | "execution-failure"
+  agentName: "feature-agent" | "execution-agent" | "implementation-agent" | "pr-agent" | "code-review-agent" | "unknown-agent"
+  quote: string (the agent text that triggered the violation)
+  description: string (human-readable explanation)
+}
+
+ImprovementStatistics {
+  totalIssuesFixed: integer
+  totalNewViolations: integer
+  iterationCount: integer
+  agentViolationBreakdown: map<agentName, count>
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `improve.loop.success` | `ChecklistPath` | `ImprovementStatistics` | `happy path` | All items eventually checked; statistics returned |
+| `improve.loop.manufacture-hard-stop` | `ChecklistItem` | `void` | `degraded` | Manufacture returns hard-stop; item marked `FAILED` in checklist, loop continues |
+| `improve.loop.manufacture-error` | `ChecklistItem` | `void` | `degraded` | Manufacture throws; item marked `FAILED`, loop continues |
+| `improve.loop.violation-detection-fail` | `ChecklistItem` | `void` | `degraded` | detect-violations.sh errors; violation detection skipped for this iteration, item still marked checked |
+| `improve.loop.issue-creation-fail` | `Violation` | `void` | `degraded` | create-issue.sh fails to create GitHub issue; logged, loop continues without adding item to checklist |
+
+#### Pseudocode
+
+```
+loop:
+  item = first line matching "^- \[ \]" in improve-checklist.md
+  if item is null: BREAK
+
+  taskDescription = build_task_description(item)
+  manufactureResult = invoke /dark-factory:manufacture taskDescription
+
+  if manufactureResult.status == "hard-stop":
+    update-checklist.sh --mark-failed checklistPath item.identifier
+    CONTINUE
+
+  violations = detect-violations.sh manufactureResult.workDir
+  # violations scans: logs/, transcripts/, agent-output/, workDir root, brain.json
+
+  for violation in violations:
+    issueNumber = create-issue.sh violation  # creates GitHub issue labelled "pipeline-violation"
+    update-checklist.sh --add-issue checklistPath "#issueNumber"
+    update statistics.agentViolationBreakdown[violation.agentName]++
+
+  update-checklist.sh --mark-checked checklistPath item.identifier
+  statistics.totalIssuesFixed++
+```
+
+---
+
+### Flow: `improve.violation-detection`
+
+- Core files: `agents/improve/scripts/detect-violations.sh`
+
+#### Types
+
+```txt
+WorkDir {
+  path: string (absolute path to manufacture work directory)
+}
+
+Violation[] (see Violation type above)
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `improve.violation-detection.success` | `WorkDir` | `Violation[]` | `happy path` | Log files scanned, violations deduplicated by `{category, agentName, quote}` |
+| `improve.violation-detection.no-logs` | `WorkDir` | `[]` | `happy path` | No log files found in expected directories; returns empty array |
+| `improve.violation-detection.workdir-missing` | `WorkDir` | `[]` | `happy path` | Work directory does not exist; returns empty array immediately |
+
+#### Pseudocode
+
+```
+detect-violations.sh(workDir):
+  if workDir does not exist: return []
+
+  LOG_DIRS = [workDir/logs, workDir/transcripts, workDir/agent-output, workDir]
+
+  for each LOG_DIR:
+    scan *.log, *.txt, *.md files (up to 500 lines per pattern pass):
+      Pattern 1 (skipped-required-step):   "i will skip|i'm skipping|bypassing.*hook|skip.*hook.*required"
+      Pattern 2 (missing-coauthored-by):   "forgot.*co-author|missing.*co-author|add.*co-author.*footer"
+      Pattern 3 (commit-sequence-violation): "commit.*before|before.*commit|wrong.*order"
+      Pattern 4 (askuserquestion-depth-violation): "askuserquestion.*depth|ask.*user.*question.*wrong"
+      Pattern 5 (sub-agent-delegation-failure): "delegation.*fail|failed.*audit|child.*agent.*violated"
+      Pattern 6 (missing-test-coverage): "skip.*test|no.*test|untested|missing.*test"
+      Pattern 7 (incomplete-documentation): "skip.*doc|no.*doc|incomplete.*doc"
+
+  if workDir/brain.json exists:
+    scan for "hard-stop|hardstop|execution.*failed" → execution-failure violation
+
+  return deduplicated violations (unique_by {category, agentName, quote})
+```
+
+---
+
+### Flow: `improve.report`
+
+- Core files: `agents/improve/agents/improve-orchestrator.md`
+
+#### Types
+
+```txt
+ImprovementReport {
+  status: "done"
+  checklistPath: string
+  report: string (human-readable summary)
+  statistics: ImprovementStatistics
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `improve.report.success` | `ImprovementStatistics` | `ImprovementReport` | `happy path` | Final checklist contents included; PushNotification sent with summary |
+
+## Helper Scripts
+
+| Script | Purpose | Input | Output |
+|--------|---------|-------|--------|
+| `agents/improve/scripts/parse-issues.sh` | Parse comma-separated issue list to JSON | `"#42, \"description\""` string | `IssueData` JSON |
+| `agents/improve/scripts/build-checklist.sh` | Write initial checklist markdown | `IssueData` JSON | Path to `improve-checklist.md` |
+| `agents/improve/scripts/detect-violations.sh` | Scan agent behavior logs for violations | Work directory path | `Violation[]` JSON |
+| `agents/improve/scripts/create-issue.sh` | Create GitHub issue for a violation | `Violation` JSON | GitHub issue number |
+| `agents/improve/scripts/update-checklist.sh` | Mark items checked/failed or add new issues | `--mark-checked\|--mark-failed\|--add-issue`, checklist path, item spec | Status message |
+
+## Violation Categories
+
+| Category code | Description |
+|---|---|
+| `missing-coauthored-by` | Co-Authored-By footer missing or incorrect in a commit |
+| `skipped-required-step` | Agent explicitly stated it is skipping a required pipeline step |
+| `commit-sequence-violation` | Commits or tool calls made in the wrong order |
+| `askuserquestion-depth-violation` | AskUserQuestion called at incorrect depth in the agent chain |
+| `sub-agent-delegation-failure` | Parent agent failed to audit or enforce compliance in a delegated child agent |
+| `missing-test-coverage` | Code created without corresponding test coverage |
+| `incomplete-documentation` | Documentation updates were skipped or incomplete |
+| `execution-failure` | Execution phase encountered an unhandled error (detected via brain.json) |
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| improve-checklist.md | `$DARK_FACTORY_WORK_DIR/improve-checklist.md` |
+| Manufacture logs (scanned by detect-violations.sh) | `<manufacture-workdir>/logs/`, `<manufacture-workdir>/transcripts/`, `<manufacture-workdir>/agent-output/` |
+| brain.json (scanned for hard-stops) | `<manufacture-workdir>/brain.json` |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # Command available after installing the dark-factory plugin:
+  claude plugin install dark-factory
+
+  # Invoke:
+  /dark-factory:improve --issues "#42, #123, \"missing Co-Authored-By in repair-agent\""
+
+  # Or via stdin:
+  echo "#42, \"violation description\"" | /dark-factory:improve
+  ```
+- Notes: Requires `gh` (GitHub CLI) authenticated, `jq`, `git`, and access to `/dark-factory:manufacture`. The `pipeline-violation` label must exist in the target GitHub repository for `create-issue.sh` to tag issues correctly.

--- a/metrics.csv
+++ b/metrics.csv
@@ -8,7 +8,7 @@ dark-factory:pr:agents:pr-agent,,58958.92857142857,140.07142857142858,14,825425.
 dark-factory:repair:agents:repair-agent,,16682.2,227.86666666666667,15,250233.0,3418.0
 testing-agent,,0.0,0.0,13,0.0,0.0
 planning-agent,,0.0,0.0,13,0.0,0.0
-dark-factory:featurework:agents:feature-agent,,105641.84210526316,628.421052631579,19,2007195.0,11940.0
+dark-factory:featurework:agents:feature-agent,,101365.9,605.4,20,2027318.0,12108.0
 Explore,,68061.0,1786.0,3,204183.0,5358.0
 dark-factory:featurework:planning:agents:sub-planning-agent,,0.0,355.0,1,0.0,355.0
 dark-factory:documentation:agents:investigation-agent,,113399.0,1081.0,1,113399.0,1081.0

--- a/skills/agent-behavior-violation-detection/SKILL.md
+++ b/skills/agent-behavior-violation-detection/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: agent-behavior-violation-detection
+description: "Use this skill when building a post-manufacture auditor that scans agent execution logs and transcripts for pipeline instruction violations expressed in the agents' own words or tool call patterns."
+user-invocable: false
+---
+## When to use
+
+After a manufacture run, when you need to detect whether any agent in the execution chain violated pipeline instructions. This is distinct from checking git diffs — you are auditing what agents *said* and *decided*, not just what they produced.
+
+Use when:
+- Building an improvement loop that feeds violations back into the checklist
+- Adding a CI-level audit step after manufacture
+- Diagnosing why a manufacture run produced an incorrect result
+
+## Steps
+
+1. Define the log search paths — agent logs may appear in multiple locations within the manufacture work directory:
+   ```bash
+   LOG_DIRS=("$WORK_DIR/logs" "$WORK_DIR/transcripts" "$WORK_DIR/agent-output" "$WORK_DIR")
+   ```
+
+2. For each log directory that exists, scan `.log`, `.txt`, and `.md` files for violation patterns using `grep -iq` (case-insensitive, quiet):
+   ```bash
+   find "$LOG_DIR" -type f \( -name "*.log" -o -name "*.txt" -o -name "*.md" \) \
+     -exec grep -h . {} \; 2>/dev/null | head -500
+   ```
+   The `head -500` prevents reading enormous transcripts; adjust if needed.
+
+3. Use `grep -iq` pattern matching for each violation category separately — do not combine all patterns into one pass, as you need per-category metadata:
+   ```bash
+   # Category: explicit step-skip
+   if grep -iq "i will skip\|i'm skipping\|bypassing.*hook\|skip.*required.*step" <<< "$line"; then ...
+
+   # Category: missing Co-Authored-By
+   if grep -iq "forgot.*co-author\|missing.*co-author\|add.*co-author.*footer" <<< "$line"; then ...
+
+   # Category: commit sequence violation
+   if grep -iq "commit.*before\|wrong.*order" <<< "$line"; then ...
+
+   # Category: AskUserQuestion depth
+   if grep -iq "askuserquestion.*depth\|ask.*user.*question.*wrong" <<< "$line"; then ...
+
+   # Category: sub-agent delegation failure
+   if grep -iq "delegation.*fail\|failed.*audit\|child.*agent.*violated" <<< "$line"; then ...
+
+   # Category: missing tests
+   if grep -iq "skip.*test\|no.*test\|untested\|missing.*test" <<< "$line"; then ...
+   ```
+
+4. Extract the agent name from each matching line using a pattern match against known agent names, with fallback:
+   ```bash
+   AGENT_NAME=$(grep -o "feature-agent\|execution-agent\|implementation-agent\|pr-agent\|code-review-agent" \
+     <<< "$line" | head -1 || echo "unknown-agent")
+   ```
+
+5. Build a JSON violation entry using `jq -Rs .` to safely encode multi-line quotes:
+   ```bash
+   add_violation() {
+     local category="$1" agent_name="$2" quote="$3" description="$4"
+     VIOLATION="{
+       \"category\": \"$category\",
+       \"agentName\": \"$agent_name\",
+       \"quote\": $(echo "$quote" | jq -Rs .),
+       \"description\": $(echo "$description" | jq -Rs .)
+     }"
+     VIOLATIONS=$(cat "$VIOLATIONS_FILE")
+     echo "$VIOLATIONS" | jq ".+= [$VIOLATION]" > "$VIOLATIONS_FILE"
+   }
+   ```
+
+6. Also check `brain.json` in the work directory for hard-stop signals — these indicate execution-level failures that surface as violations:
+   ```bash
+   if [[ -f "$WORK_DIR/brain.json" ]]; then
+     if grep -iq "hard-stop\|hardstop\|execution.*failed" "$WORK_DIR/brain.json"; then
+       add_violation "execution-failure" "execution-agent" \
+         "brain.json indicates hard-stop" \
+         "Execution phase encountered an error"
+     fi
+   fi
+   ```
+
+7. Deduplicate violations before returning using `jq unique_by`:
+   ```bash
+   cat "$VIOLATIONS_FILE" | jq 'unique_by({category, agentName, quote})'
+   ```
+
+8. Return an empty array `[]` (not an error) when the work directory does not exist — callers must handle missing log dirs gracefully.
+
+## Notes
+
+- The detection approach is heuristic, not exhaustive. It finds violations where agents *expressed* them in language. Silent violations (agent just didn't do the step without saying so) are not detectable by log scanning alone — those require checking the git diff or artifact state separately.
+- The `grep -iq` patterns must be conservative: prefer false negatives over false positives. A spurious violation creates unnecessary GitHub issues; a missed violation is just not caught this cycle.
+- Keep each detection pattern in its own `while IFS= read -r line; do ... done` loop — this makes it easy to add, remove, or tune categories independently.
+- The `jq -Rs .` idiom safely encodes arbitrary text (including newlines, backslashes, and quotes) as a JSON string. Never use `echo "\"$variable\""` for user-derived content.
+- Violation categories to cover at minimum: `skipped-required-step`, `missing-coauthored-by`, `commit-sequence-violation`, `askuserquestion-depth-violation`, `sub-agent-delegation-failure`, `missing-test-coverage`, `incomplete-documentation`, `execution-failure`.

--- a/skills/mixed-github-freeform-input/SKILL.md
+++ b/skills/mixed-github-freeform-input/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: mixed-github-freeform-input
+description: "Use this skill when a command must accept a comma-separated list that mixes GitHub issue references (#42) with quoted freeform descriptions, normalize them to a single JSON structure, and handle both gracefully."
+user-invocable: false
+---
+## When to use
+
+When building a command that should accept issue references from multiple sources in a single argument:
+- A list that mixes `#42`, `123` (bare number), and `"freeform text"` in one string
+- The caller may pipe GitHub issue numbers from `gh issue list` or type descriptions directly
+- The consuming agent needs a uniform JSON structure regardless of input form
+
+## Steps
+
+1. Accept input as a single comma-separated string (argument or stdin):
+   ```bash
+   ISSUE_LIST="${1:-}"
+   ```
+
+2. Split on commas with `IFS=','` — this handles the common case cleanly. Do NOT use `read -d` as it has portability issues with quoted commas inside items:
+   ```bash
+   IFS=',' read -ra ITEMS <<< "$ISSUE_LIST"
+   ```
+
+3. For each item, trim whitespace with `xargs` before classifying:
+   ```bash
+   item=$(echo "$item" | xargs)
+   ```
+
+4. Classify each item with ordered regex checks:
+   ```bash
+   if [[ "$item" =~ ^#([0-9]+)$ ]]; then
+     # GitHub issue with # prefix
+     NUMBER="${BASH_REMATCH[1]}"
+   elif [[ "$item" =~ ^[0-9]+$ ]]; then
+     # Bare numeric — treat as GitHub issue number
+     NUMBER="$item"
+   elif [[ "$item" =~ ^\"(.*)\"$ ]]; then
+     # Quoted freeform description
+     DESCRIPTION="${BASH_REMATCH[1]}"
+   else
+     # Unquoted freeform description (fallback)
+     DESCRIPTION="$item"
+   fi
+   ```
+
+5. For GitHub issue numbers, fetch metadata with `gh issue view` and handle failure gracefully:
+   ```bash
+   ISSUE_JSON=$(gh issue view "$NUMBER" --json number,title,body 2>/dev/null || echo '')
+   if [[ -z "$ISSUE_JSON" ]]; then
+     echo "Warning: GitHub issue #$NUMBER not found, skipping" >&2
+     continue
+   fi
+   TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // "N/A"')
+   BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""' | head -c 500)
+   ```
+
+6. Build uniform JSON output using `jq -n` with `--arg` / `--argjson` to avoid shell-escaping bugs:
+   ```bash
+   # GitHub entry
+   ENTRY=$(jq -n --arg type "github" --argjson number "$NUMBER" \
+     --arg title "$TITLE" --arg body "$BODY" \
+     '{type: $type, number: $number, title: $title, body: $body}')
+
+   # Freeform entry
+   ENTRY=$(jq -n --arg type "freeform" --arg description "$DESCRIPTION" \
+     '{type: $type, description: $description}')
+
+   OUTPUT=$(echo "$OUTPUT" | jq ".issues += [$ENTRY]")
+   ```
+
+7. Output the final JSON to stdout so callers can pipe it directly:
+   ```bash
+   echo "$OUTPUT"
+   ```
+
+## Notes
+
+- Truncate issue body to ~500 chars with `head -c 500` — full bodies are rarely needed and can bloat JSON passed between scripts.
+- Never use `echo "$var" | jq` for values that might contain newlines or special characters — always use `jq -n --arg` to safely inject shell variables into JSON.
+- The `||` in `gh issue view ... 2>/dev/null || echo ''` is intentional: `gh` exits non-zero for missing issues, which would abort the script under `set -euo pipefail`. The empty string fallback is the skip signal.
+- If the input string is empty or produces no valid items after parsing, the script should output `{"issues": []}` and let the caller decide whether that is an error.

--- a/skills/self-expanding-checklist-loop/SKILL.md
+++ b/skills/self-expanding-checklist-loop/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: self-expanding-checklist-loop
+description: "Use this skill when building an agent loop that discovers new work items while processing existing ones — the checklist must grow before the current item is marked done to prevent orphaned items."
+user-invocable: false
+---
+## When to use
+
+Any time an agent loop processes items from a checklist and the processing step itself can produce new items that belong in the same checklist. Examples:
+- Fixing pipeline violations that introduce new violations
+- Refactoring tasks that reveal adjacent technical debt
+- Migration passes that expose additional items to migrate
+
+The non-obvious risk: if you mark the current item done before appending new items, and the agent crashes between those two operations, the new items are lost.
+
+## Steps
+
+1. Maintain a markdown checklist file on disk (not in memory) so restarts can resume:
+   ```
+   # Improvement Checklist
+   - [ ] #42 — [Title] (description)
+   - [ ] "freeform description" — (freeform)
+   ```
+
+2. The main loop reads the checklist file fresh on every iteration — never cache the list in memory across iterations:
+   ```
+   WHILE TRUE:
+     checklistContent = read(checklistPath)
+     uncheckedItem = first line matching ^- \[ \]
+     if uncheckedItem is null: BREAK
+   ```
+
+3. After processing an item, append any newly discovered items to the checklist file **before** marking the current item done:
+   ```
+   # CORRECT ORDER:
+   FOR EACH newItem IN discoveredItems:
+     append_to_checklist(checklistPath, newItem)   # 1. grow first
+   mark_as_checked(checklistPath, currentItem)      # 2. mark done second
+
+   # WRONG ORDER (loses items on crash):
+   mark_as_checked(checklistPath, currentItem)      # 1. mark done
+   FOR EACH newItem IN discoveredItems:             # 2. grow — if crash here, items lost
+     append_to_checklist(checklistPath, newItem)
+   ```
+
+4. Use atomic writes for all checklist mutations — write to a `.tmp.$$` file then `mv` it into place:
+   ```bash
+   TMP="${CHECKLIST_PATH}.tmp.$$"
+   cp "$CHECKLIST_PATH" "$TMP"
+   echo "$NEW_ITEM" >> "$TMP"
+   mv "$TMP" "$CHECKLIST_PATH"
+   ```
+
+5. Add a max-iteration guard (see `agent-loop-with-max-iterations` skill) to prevent infinite loops when discovery always produces new items:
+   ```
+   MAX_ITERATIONS = 50
+   if iterationCount >= MAX_ITERATIONS:
+     STOP with error "Exceeded max iterations — manual review required"
+   ```
+
+6. Track statistics in a separate variable (not in the checklist file):
+   - `totalIssuesFixed` — count of items marked done
+   - `totalNewItemsFound` — count of items appended by the discovery step
+   - `iterationCount` — total loop passes
+
+## Notes
+
+- The checklist format `- [ ]` / `- [x]` is conventional markdown and readable without special tooling.
+- If item discovery can fail non-fatally (e.g., an API call to detect violations), log the failure and continue to the next item rather than halting — partial tracking is better than losing progress.
+- The checklist file path should be written to a `$WORK_DIR` that persists across agent restarts; do not use `/tmp`.
+- When an item fails to process (not just discovery fails, but the processing itself fails), mark it `- [x] FAILED: ...` rather than removing it — this preserves the audit trail.


### PR DESCRIPTION
## Description

Added dark-factory:improve — a new standalone orchestrator command that takes GitHub issues or freeform descriptions of agent pipeline violations, builds a checklist, iteratively calls manufacture to resolve each one, inspects the full agent chain's messages and reasoning to detect new violations, creates GitHub issues for them, adds them to the checklist, and loops until empty. Includes 5 flows: initialization, main loop, violation detection (agent behavior analysis, not git), issue creation, and completion/reporting.

## Test Plan

```
$ python3 -m pytest tests/ -q
2 failed, 144 passed in 1.46s

FAILED tests/test_generate_checklist.py::test_pre_hook_injects_checklist_no_brain
FAILED tests/test_hooks.py::TestPreHookInjectsBrainState::test_inject_no_brain
```

The 2 failures are pre-existing failures unrelated to this feature (they concern brain state injection in the pre-hook and were already failing on the base branch). All 144 other tests pass.

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
