### PR TITLE
fix(feature-agent): prevent skipping per-flow approval gates

### DIFF
--- a/agents/featurework/agents/feature-agent.md
+++ b/agents/featurework/agents/feature-agent.md
@@ -29,6 +29,7 @@ You will be invoked with:
 - Write, edit, or scaffold code files yourself (other than flows-state.json and brain-patch.json).
 - Call AskUserQuestion directly — return `{ status: "question", ... }` instead; dark-factory-agent asks the question at depth-2.
 - Skip the approval gate and proceed directly to execution.
+- Skip the per-flow gate: each flow MUST be presented via AskUserQuestion and explicitly approved before advancing to the next flow or to execution.
 - Re-invoke `execution-agent` after a hard-stop.
 - Invoke `pr-agent`. The caller (dark-factory-agent) handles the PR.
 

--- a/agents/featurework/execution/agents/execution-agent.md
+++ b/agents/featurework/execution/agents/execution-agent.md
@@ -17,17 +17,23 @@ You will be invoked with a `planPath` — a path to a `docs/plans/*.md` file.
 
 1. Read the plan file at `planPath`.
    - If the file does not exist: stop and report the error. Do not spawn any sub-agents.
-2. Spawn `skeleton-agent` with `planPath`. Wait for it to return.
+
+2. Assert that all flows in the plan have been approved before proceeding.
+   - Read `$DARK_FACTORY_WORK_DIR/flows-state.json` to check the approval state.
+   - Parse the plan file to get the total number of flows: `allFlows = count of "### Flow:" sections`.
+   - Assert: `flows-state.approved.length == allFlows`. If not, stop with error: "Not all flows have been approved. User must approve each flow via feature-agent before execution can proceed."
+
+4. Spawn `skeleton-agent` with `planPath`. Wait for it to return.
    - Assert `tmp/files-checklist.md` is fully checked off.
    - Assert every file listed in the checklist exists on disk.
-4. Spawn `testing-agent` with `planPath`. Wait for it to return.
+5. Spawn `testing-agent` with `planPath`. Wait for it to return.
    - Assert `tmp/flows-checklist.md` exists.
    - Assert the test run output confirms all new tests are failing.
-5. Spawn `implementation-agent` with `planPath` and the path to `tmp/flows-checklist.md`. Wait for it to return.
+6. Spawn `implementation-agent` with `planPath` and the path to `tmp/flows-checklist.md`. Wait for it to return.
    - If it returns `hardStop: true`: enter planning mode (see Planning Mode below).
    - If it returns `allFlowsGreen: true`:
-6. Delete `tmp/files-checklist.md` and `tmp/flows-checklist.md`.
-7. Report success to the developer.
+7. Delete `tmp/files-checklist.md` and `tmp/flows-checklist.md`.
+8. Report success to the developer.
 
 ## Planning Mode
 


### PR DESCRIPTION
Fixes issue #139: Flows not shown after diagram approval

## Changes

After diagram approval, the feature-agent must present each flow with AskUserQuestion and gate on approval before proceeding. Previously, the orchestrator would skip straight to plan generation.

### Changes Made:

1. **feature-agent.md**: Added explicit prohibition in 'What you must never do' section forbidding skipping of per-flow gates. Each flow MUST be presented and explicitly approved before advancing.

2. **execution-agent.md**: Added assertion at the start of execution to verify all flows have been approved:
   - Reads flows-state.json to check approval status
   - Counts total flows in the plan
   - Asserts flows-state.approved.length == allFlows
   - Stops execution if not all flows are approved

## Testing

- All 146 existing tests pass
- Changes are minimal, focused on agent prompt compliance
- No code generation or refactoring

## Fixes

Closes #139