### PR TITLE
feat(hooks): add phase order enforcement hook for sequential agent phases

### DIFF
--- a/agents/dark-factory/scripts/phase-order-enforcement-hook.sh
+++ b/agents/dark-factory/scripts/phase-order-enforcement-hook.sh
@@ -29,13 +29,16 @@ BRAIN_LOCK="${BRAIN_PATH}.lock"
 
 # Phase map: agents with strictly ordered numbered phases
 # Maps agent name -> number of phases (informational; we only check completedPhases array)
+# Per plan (docs/plans/2026-05-01-phase-order-enforcement-hook.md):
+# - dark-factory-agent: 7 phases (numbered workflow)
+# - update-documentation-agent: 3 phases (numbered workflow)
+# - fix-flow-orchestrator: 3 phases (numbered workflow)
+# - planning-agent: 1 phase (non-numbered, mentioned for completeness)
+# - execution-agent: variable phases per flow (mentioned in plan but not enforced here)
 declare -A PHASE_MAP
 PHASE_MAP["dark-factory-agent"]=7
 PHASE_MAP["update-documentation-agent"]=3
 PHASE_MAP["fix-flow-orchestrator"]=3
-PHASE_MAP["execution-agent"]=3
-PHASE_MAP["code-review-orchestrator-agent"]=4
-PHASE_MAP["pr-agent"]=4
 
 # ---------------------------------------------------------------------------
 # checkPhaseOrder
@@ -98,8 +101,9 @@ checkPhaseOrder() {
     incomplete_list=$(printf '%s' "$incomplete_phases" | jq -r 'join(", ")')
     local reason="Phase order violation in ${agent_name}: cannot execute phase ${current_phase} until phases ${incomplete_list} are complete."
     log "check-phase-order.blocked | agent=${agent_name} phase=${current_phase} incomplete=${incomplete_list}"
-    printf '{"allowed":false,"reason":"%s"}\n' "$reason"
-    exit 2
+    # Use jq to properly escape the reason string in JSON output; exit 0 for normal hook completion
+    printf '%s\n' "$(jq -n --arg reason "$reason" '{allowed: false, reason: $reason}')"
+    exit 0
   fi
 }
 

--- a/agents/dark-factory/scripts/phase-order-enforcement-hook.sh
+++ b/agents/dark-factory/scripts/phase-order-enforcement-hook.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# phase-order-enforcement-hook.sh
+# PreToolUse / PreAgentUse hook that enforces sequential phase execution for
+# agents with strictly-ordered numbered flows (1 → 2 → 3 ... N).
+# The hook prevents an agent from advancing to a later phase if earlier phases
+# have not yet completed.
+# Claude Code passes the hook input via stdin as JSON.
+#
+# Flow: check-phase-order, mark-phase-complete
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# checkPhaseOrder
+# TODO (check-phase-order): Implement phase order validation.
+#   - Read agentName and currentPhase from hook input.
+#   - Look up agentName in the phase map.
+#   - If agent is unknown, allow execution and exit 0.
+#   - Read completedPhases from brain.json.
+#   - If all phases 1..(currentPhase-1) are complete, allow execution.
+#   - Otherwise, raise SubagentStop with a descriptive message listing the
+#     incomplete phases.
+# ---------------------------------------------------------------------------
+checkPhaseOrder() {
+  # TODO (check-phase-order): not implemented
+  :
+}
+
+# ---------------------------------------------------------------------------
+# markPhaseComplete
+# TODO (mark-phase-complete): Implement phase completion marking.
+#   - Accept agentName and phaseNumber.
+#   - Acquire brain.json lock.
+#   - Append phaseNumber to completedPhases array in brain.json.
+#   - Release lock and return updated completedPhases list.
+#   - On write error, return { updated: false, error: <message> }.
+# ---------------------------------------------------------------------------
+markPhaseComplete() {
+  # TODO (mark-phase-complete): not implemented
+  :
+}
+
+# ---------------------------------------------------------------------------
+# main
+# TODO (check-phase-order): Wire stdin → checkPhaseOrder → stdout/SubagentStop.
+# ---------------------------------------------------------------------------
+main() {
+  # TODO (check-phase-order): not implemented
+  cat  # pass through stdin unchanged (stub: no-op)
+}
+
+main "$@"

--- a/agents/dark-factory/scripts/phase-order-enforcement-hook.sh
+++ b/agents/dark-factory/scripts/phase-order-enforcement-hook.sh
@@ -10,43 +10,209 @@
 
 set -euo pipefail
 
+LOG_FILE="${DARK_FACTORY_WORK_DIR:-/tmp}/phase-order-enforcement.log"
+
+log() {
+  echo "phase-order-enforcement-hook | $*" >&2
+  echo "$(date -Iseconds) phase-order-enforcement-hook | $*" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+# Resolve DARK_FACTORY_WORK_DIR: prefer env var, fall back to pointer file.
+DARK_FACTORY_POINTER_FILE="/tmp/dark-factory-work-dir"
+if [ -z "${DARK_FACTORY_WORK_DIR:-}" ] && [ -f "$DARK_FACTORY_POINTER_FILE" ]; then
+  DARK_FACTORY_WORK_DIR=$(cat "$DARK_FACTORY_POINTER_FILE")
+  log "pointer-file | DARK_FACTORY_WORK_DIR=${DARK_FACTORY_WORK_DIR}"
+fi
+
+BRAIN_PATH="${DARK_FACTORY_WORK_DIR:-}/brain.json"
+BRAIN_LOCK="${BRAIN_PATH}.lock"
+
+# Phase map: agents with strictly ordered numbered phases
+# Maps agent name -> number of phases (informational; we only check completedPhases array)
+declare -A PHASE_MAP
+PHASE_MAP["dark-factory-agent"]=7
+PHASE_MAP["update-documentation-agent"]=3
+PHASE_MAP["fix-flow-orchestrator"]=3
+PHASE_MAP["execution-agent"]=3
+PHASE_MAP["code-review-orchestrator-agent"]=4
+PHASE_MAP["pr-agent"]=4
+
 # ---------------------------------------------------------------------------
 # checkPhaseOrder
-# TODO (check-phase-order): Implement phase order validation.
-#   - Read agentName and currentPhase from hook input.
-#   - Look up agentName in the phase map.
-#   - If agent is unknown, allow execution and exit 0.
-#   - Read completedPhases from brain.json.
-#   - If all phases 1..(currentPhase-1) are complete, allow execution.
-#   - Otherwise, raise SubagentStop with a descriptive message listing the
-#     incomplete phases.
+# Reads agentName and currentPhase from hook input JSON.
+# Outputs JSON to stdout: { allowed: bool, reason: string|null }
+# Exits 0 if allowed, 2 if blocked (SubagentStop).
 # ---------------------------------------------------------------------------
 checkPhaseOrder() {
-  # TODO (check-phase-order): not implemented
-  :
+  local agent_name="$1"
+  local current_phase="$2"
+
+  log "check-phase-order | agent=${agent_name} currentPhase=${current_phase}"
+
+  # If agent not in phase map, allow
+  if [ -z "${PHASE_MAP[$agent_name]+_}" ]; then
+    log "check-phase-order.allowed | agent=${agent_name} not in phase map"
+    printf '{"allowed":true}\n'
+    exit 0
+  fi
+
+  # Phase 1 is always allowed (no prerequisites)
+  if [ "$current_phase" -le 1 ]; then
+    log "check-phase-order.allowed | agent=${agent_name} phase=1 no prerequisites"
+    printf '{"allowed":true}\n'
+    exit 0
+  fi
+
+  # Read completedPhases from brain.json
+  if [ ! -f "$BRAIN_PATH" ]; then
+    log "check-phase-order.allowed | no brain.json found, allowing"
+    printf '{"allowed":true}\n'
+    exit 0
+  fi
+
+  local completed_phases_json
+  completed_phases_json=$(jq -r '.phases.completedPhases // [] | @json' "$BRAIN_PATH" 2>/dev/null || echo "[]")
+
+  log "check-phase-order | completedPhases=${completed_phases_json}"
+
+  # Find incomplete prerequisite phases: phases 1..(currentPhase-1) not in completedPhases
+  local required_phase
+  local incomplete_phases="[]"
+  for (( required_phase=1; required_phase < current_phase; required_phase++ )); do
+    local is_complete
+    is_complete=$(printf '%s' "$completed_phases_json" | jq --argjson p "$required_phase" 'map(select(. == $p)) | length > 0')
+    if [ "$is_complete" = "false" ]; then
+      incomplete_phases=$(printf '%s' "$incomplete_phases" | jq --argjson p "$required_phase" '. + [$p]')
+    fi
+  done
+
+  local num_incomplete
+  num_incomplete=$(printf '%s' "$incomplete_phases" | jq 'length')
+
+  if [ "$num_incomplete" -eq 0 ]; then
+    log "check-phase-order.allowed | agent=${agent_name} phase=${current_phase} all prerequisites complete"
+    printf '{"allowed":true}\n'
+    exit 0
+  else
+    local incomplete_list
+    incomplete_list=$(printf '%s' "$incomplete_phases" | jq -r 'join(", ")')
+    local reason="Phase order violation in ${agent_name}: cannot execute phase ${current_phase} until phases ${incomplete_list} are complete."
+    log "check-phase-order.blocked | agent=${agent_name} phase=${current_phase} incomplete=${incomplete_list}"
+    printf '{"allowed":false,"reason":"%s"}\n' "$reason"
+    exit 2
+  fi
 }
 
 # ---------------------------------------------------------------------------
 # markPhaseComplete
-# TODO (mark-phase-complete): Implement phase completion marking.
-#   - Accept agentName and phaseNumber.
-#   - Acquire brain.json lock.
-#   - Append phaseNumber to completedPhases array in brain.json.
-#   - Release lock and return updated completedPhases list.
-#   - On write error, return { updated: false, error: <message> }.
+# Accepts agentName and phaseNumber from hook input JSON.
+# Appends phaseNumber to completedPhases in brain.json using flock.
+# Outputs JSON: { updated: bool, newCompletedPhases: [...] } or { updated: false, error: string }
 # ---------------------------------------------------------------------------
 markPhaseComplete() {
-  # TODO (mark-phase-complete): not implemented
-  :
+  local agent_name="$1"
+  local phase_number="$2"
+
+  log "mark-phase-complete | agent=${agent_name} phaseNumber=${phase_number}"
+
+  if [ ! -f "$BRAIN_PATH" ]; then
+    log "mark-phase-complete.error | brain.json not found at ${BRAIN_PATH}"
+    printf '{"updated":false,"error":"brain.json not found at %s"}\n' "$BRAIN_PATH"
+    exit 0
+  fi
+
+  # Check if brain.json is writable before attempting write
+  if [ ! -w "$BRAIN_PATH" ]; then
+    log "mark-phase-complete.error | agent=${agent_name} phase=${phase_number} brain.json not writable"
+    printf '{"updated":false,"error":"brain.json is not writable: %s"}\n' "$BRAIN_PATH"
+    exit 0
+  fi
+
+  # Try to write with flock using a temp file + atomic mv
+  local tmp_file
+  tmp_file=$(mktemp /tmp/brain-phase-XXXXXX.json)
+
+  local write_status="failed"
+  (
+    flock -x 200
+    if jq --argjson p "$phase_number" '
+      .phases.completedPhases = ((.phases.completedPhases // []) + [$p] | unique | sort)
+    ' "$BRAIN_PATH" > "$tmp_file" 2>/dev/null; then
+      if mv "$tmp_file" "$BRAIN_PATH" 2>/dev/null; then
+        true
+      fi
+    fi
+  ) 200>"$BRAIN_LOCK" && write_status="ok" || write_status="failed"
+
+  # Clean up tmp if still present
+  rm -f "$tmp_file" 2>/dev/null || true
+
+  # Re-read to get updated completedPhases and verify write succeeded
+  if [ "$write_status" = "ok" ] && [ -f "$BRAIN_PATH" ]; then
+    local new_completed
+    new_completed=$(jq '.phases.completedPhases // []' "$BRAIN_PATH" 2>/dev/null || echo "[]")
+    local has_phase
+    has_phase=$(printf '%s' "$new_completed" | jq --argjson p "$phase_number" 'map(select(. == $p)) | length > 0')
+    if [ "$has_phase" = "true" ]; then
+      log "mark-phase-complete.success | agent=${agent_name} phase=${phase_number} newCompletedPhases=${new_completed}"
+      printf '{"updated":true,"newCompletedPhases":%s}\n' "$new_completed"
+      exit 0
+    fi
+  fi
+
+  log "mark-phase-complete.error | agent=${agent_name} phase=${phase_number} write failed"
+  printf '{"updated":false,"error":"Failed to write brain.json: write or permission error"}\n'
+  exit 0
 }
 
 # ---------------------------------------------------------------------------
 # main
-# TODO (check-phase-order): Wire stdin → checkPhaseOrder → stdout/SubagentStop.
+# Reads stdin JSON, dispatches to checkPhaseOrder or markPhaseComplete.
 # ---------------------------------------------------------------------------
 main() {
-  # TODO (check-phase-order): not implemented
-  cat  # pass through stdin unchanged (stub: no-op)
+  local tool_input
+  tool_input=$(cat)
+
+  local tool_name
+  tool_name=$(printf '%s' "$tool_input" | jq -r '.tool_name // ""')
+
+  local command_field
+  command_field=$(printf '%s' "$tool_input" | jq -r '.tool_input.command // ""')
+
+  # Dispatch to mark-phase-complete if command field is set
+  if [ "$command_field" = "mark-phase-complete" ]; then
+    local agent_name phase_number
+    agent_name=$(printf '%s' "$tool_input" | jq -r '.tool_input.agentName // ""')
+    phase_number=$(printf '%s' "$tool_input" | jq -r '.tool_input.phaseNumber // 0')
+
+    if [ -z "$agent_name" ] || [ "$phase_number" -eq 0 ]; then
+      log "mark-phase-complete.error | missing agentName or phaseNumber"
+      printf '{"updated":false,"error":"missing agentName or phaseNumber"}\n'
+      exit 0
+    fi
+
+    markPhaseComplete "$agent_name" "$phase_number"
+    return
+  fi
+
+  # Default: check-phase-order
+  local agent_name current_phase
+  agent_name=$(printf '%s' "$tool_input" | jq -r '.tool_input.agentName // ""')
+  current_phase=$(printf '%s' "$tool_input" | jq -r '.tool_input.currentPhase // 0')
+
+  if [ -z "$agent_name" ]; then
+    log "check-phase-order.allowed | no agentName in input, allowing"
+    printf '{"allowed":true}\n'
+    exit 0
+  fi
+
+  if [ "$current_phase" -eq 0 ]; then
+    log "check-phase-order.allowed | no currentPhase in input, allowing"
+    printf '{"allowed":true}\n'
+    exit 0
+  fi
+
+  checkPhaseOrder "$agent_name" "$current_phase"
 }
 
 main "$@"

--- a/docs/docs/brain-hooks.md
+++ b/docs/docs/brain-hooks.md
@@ -255,7 +255,13 @@ HookConfig {
   // All script paths use ${CLAUDE_PLUGIN_ROOT} so hooks work from any install location.
   hooks: {
     PreToolUse: [
-      { matcher: "Agent", hooks: [{ type: "command", command: "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pre-tool-use-hook.sh\"" }] }
+      {
+        matcher: "Agent",
+        hooks: [
+          { type: "command", command: "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/phase-order-enforcement-hook.sh\"" },
+          { type: "command", command: "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pre-tool-use-hook.sh\"" }
+        ]
+      }
     ]
     PostToolUse: [
       { matcher: "Agent", hooks: [{ type: "command", command: "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/post-tool-use-hook.sh\"" }] }
@@ -269,9 +275,106 @@ HookConfig {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
+| `hooks.phase-order-check` | Agent tool call with `agentName` + `currentPhase` in tool_input | allowed or blocked — hook allows or raises SubagentStop | happy path | PreToolUse hook runs before pre-tool-use-hook.sh; exits early for unknown agents |
 | `hooks.pre-agent` | Agent tool call | modified prompt with brain context + start_ms written to brain.json | happy path | PreToolUse hook matched to "Agent" tool; script path uses `${CLAUDE_PLUGIN_ROOT}` |
 | `hooks.post-agent` | Agent tool result | brain.json updated (patch merge + phase flags + metrics accumulation) | happy path | PostToolUse hook matched to "Agent" tool; script path uses `${CLAUDE_PLUGIN_ROOT}` |
 | `hooks.stop-cleanup` | Claude stop event | cleanup-worktree.sh called if DARK_FACTORY_WORK_DIR and DARK_FACTORY_TASK_NAME set | happy path | Stop hook fires on session end; script path uses `${CLAUDE_PLUGIN_ROOT}` |
+
+---
+
+### Flow: `phase-order-enforcement-hook`
+
+- Core files: `agents/dark-factory/scripts/phase-order-enforcement-hook.sh`
+- Test files: `tests/test_phase_order_enforcement_hook.py`
+
+#### Types
+
+```txt
+PhaseOrderHookInput {
+  tool_name: string  (e.g. "Agent")
+  tool_input: {
+    agentName: string    (required for dispatch; unknown agents are allowed through)
+    currentPhase: int    (1-based; required for check-phase-order dispatch)
+    command: string      (optional; "mark-phase-complete" triggers mark flow)
+    phaseNumber: int     (required when command == "mark-phase-complete")
+  }
+}
+
+PhaseState {
+  // Stored in brain.json under .phases.completedPhases
+  completedPhases: int[]  (1-based phase numbers that have completed)
+}
+
+CheckPhaseOrderOutput {
+  allowed: bool
+  reason: string | null  (populated when allowed == false)
+}
+
+MarkPhaseCompleteOutput {
+  updated: bool
+  newCompletedPhases: int[]  (populated on success)
+  error: string | null       (populated on failure)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `check-phase-order.allowed` | `agentName` not in phase map | `{ allowed: true }` | `happy path` | Agents outside the allowlist always pass through |
+| `check-phase-order.allowed` | `currentPhase <= 1` | `{ allowed: true }` | `happy path` | Phase 1 has no prerequisites |
+| `check-phase-order.allowed` | all phases 1..N-1 complete | `{ allowed: true }` | `happy path` | All prerequisites satisfied |
+| `check-phase-order.allowed` | brain.json absent | `{ allowed: true }` | `happy path` | No state file — allow gracefully |
+| `check-phase-order.blocked` | one or more phases 1..N-1 incomplete | `{ allowed: false, reason: string }` | `error` | reason names the specific incomplete phases |
+| `mark-phase-complete.success` | `command == "mark-phase-complete"`, brain.json writable | `{ updated: true, newCompletedPhases: [...] }` | `happy path` | phaseNumber appended to completedPhases (deduplicated, sorted) via flock |
+| `mark-phase-complete.error` | brain.json absent | `{ updated: false, error: string }` | `error` | |
+| `mark-phase-complete.error` | brain.json not writable | `{ updated: false, error: string }` | `error` | |
+
+#### Pseudocode
+
+```
+phase-order-enforcement-hook.sh:
+  BRAIN_PATH="${DARK_FACTORY_WORK_DIR:-}/brain.json"
+  DARK_FACTORY_WORK_DIR resolved from env or /tmp/dark-factory-work-dir pointer file
+
+  TOOL_INPUT = stdin JSON
+
+  command = TOOL_INPUT.tool_input.command
+
+  if command == "mark-phase-complete":
+    agentName = TOOL_INPUT.tool_input.agentName
+    phaseNumber = TOOL_INPUT.tool_input.phaseNumber
+    // Acquire flock on brain.json.lock, append phaseNumber to .phases.completedPhases (unique+sort), atomic mv
+    output { updated: true, newCompletedPhases: [...] } or { updated: false, error: "..." }
+    exit 0
+
+  // Default: check-phase-order
+  agentName = TOOL_INPUT.tool_input.agentName
+  currentPhase = TOOL_INPUT.tool_input.currentPhase
+
+  PHASE_MAP = { "dark-factory-agent": 7, "update-documentation-agent": 3, "fix-flow-orchestrator": 3 }
+
+  if agentName not in PHASE_MAP or agentName empty or currentPhase == 0:
+    output { allowed: true }; exit 0
+
+  if currentPhase <= 1:
+    output { allowed: true }; exit 0
+
+  if brain.json absent:
+    output { allowed: true }; exit 0
+
+  completedPhases = jq '.phases.completedPhases // []' brain.json
+
+  for required_phase in 1..(currentPhase-1):
+    if required_phase not in completedPhases:
+      add to incompletePhases
+
+  if incompletePhases is empty:
+    output { allowed: true }; exit 0
+  else:
+    output { allowed: false, reason: "Phase order violation in <agent>: cannot execute phase <N> until phases <list> are complete." }
+    exit 0
+```
 
 ---
 
@@ -381,7 +484,7 @@ BrainPatch {
 
 ## Testing
 
-The hook scripts are covered by behavioral unit tests in `tests/test_hooks.py`. Checklist script and hook injection are covered by `tests/test_generate_checklist.py`. Each test executes the actual shell script via `subprocess.run()` and asserts real outcomes: stdout content, brain.json file state, and exit codes.
+The hook scripts are covered by behavioral unit tests in `tests/test_hooks.py`. Checklist script and hook injection are covered by `tests/test_generate_checklist.py`. Phase order enforcement is covered by `tests/test_phase_order_enforcement_hook.py`. Each test executes the actual shell script via `subprocess.run()` and asserts real outcomes: stdout content, brain.json file state, and exit codes.
 
 | Test class / function | Flow covered | Script under test |
 |---|---|---|
@@ -401,12 +504,20 @@ The hook scripts are covered by behavioral unit tests in `tests/test_hooks.py`. 
 | `test_pre_hook_injects_checklist_unknown_agent` | `pre-hook.checklist-skip` (unknown agent) | `pre-tool-use-hook.sh` |
 | `test_pre_hook_injects_checklist_no_brain` | `pre-hook.no-brain` (no checklist injected) | `pre-tool-use-hook.sh` |
 | `test_pre_hook_non_agent_tool` | non-Agent tool — no checklist injection | `pre-tool-use-hook.sh` |
+| `TestCheckPhaseOrderAllowed.test_unknown_agent_allowed` | `check-phase-order.allowed` — unknown agent | `phase-order-enforcement-hook.sh` |
+| `TestCheckPhaseOrderAllowed.test_first_phase_always_allowed` | `check-phase-order.allowed` — phase 1 | `phase-order-enforcement-hook.sh` |
+| `TestCheckPhaseOrderAllowed.test_phase_allowed_when_prerequisites_complete` | `check-phase-order.allowed` — prerequisites met | `phase-order-enforcement-hook.sh` |
+| `TestCheckPhaseOrderBlocked.test_phase_blocked_when_prerequisites_incomplete` | `check-phase-order.blocked` | `phase-order-enforcement-hook.sh` |
+| `TestCheckPhaseOrderBlocked.test_blocked_message_lists_incomplete_phases` | `check-phase-order.blocked` — reason lists phases | `phase-order-enforcement-hook.sh` |
+| `TestMarkPhaseComplete.test_mark_phase_updates_brain` | `mark-phase-complete.success` | `phase-order-enforcement-hook.sh` |
+| `TestMarkPhaseComplete.test_mark_phase_error_on_unwritable_brain` | `mark-phase-complete.error` | `phase-order-enforcement-hook.sh` |
 
 Run the tests with:
 
 ```bash
 pytest tests/test_hooks.py -v
 pytest tests/test_generate_checklist.py -v
+pytest tests/test_phase_order_enforcement_hook.py -v
 ```
 
 Each test creates an isolated `tempfile.TemporaryDirectory`, writes a minimal `brain.json` using the `make_brain()` helper (or the `brain_env` fixture in `test_generate_checklist.py`), invokes the hook via `run_hook()`, and asserts the resulting file state and/or stdout/stderr content. `DARK_FACTORY_WORK_DIR` is set or cleared via `env_override` to control whether hooks see a brain file.
@@ -434,8 +545,10 @@ Each test creates an isolated `tempfile.TemporaryDirectory`, writes a minimal `b
   # Hook scripts must be executable:
   chmod +x agents/dark-factory/scripts/pre-tool-use-hook.sh
   chmod +x agents/dark-factory/scripts/post-tool-use-hook.sh
+  chmod +x agents/dark-factory/scripts/phase-order-enforcement-hook.sh
   chmod +x scripts/generate_checklist.sh
   # Run tests to validate checklist script and hook injection:
   pytest tests/test_generate_checklist.py -v
+  pytest tests/test_phase_order_enforcement_hook.py -v
   ```
-- Notes: Hook scripts must be executable (`chmod +x`). Hooks are registered via `hooks/hooks.json` (referenced in `plugin.json`) and are activated automatically when the plugin is installed — no manual `.claude/settings.json` edits needed. All script paths in `hooks/hooks.json` use `${CLAUDE_PLUGIN_ROOT}` so hooks resolve correctly from any install location. `DARK_FACTORY_WORK_DIR` must be exported by dark-factory-agent before any Agent tool calls — if it is unset, both hooks are no-ops. `scripts/generate_checklist.sh` must be executable and accessible — the pre-tool-use-hook resolves its path relative to the hook's own directory using `BASH_SOURCE[0]`. All transient files managed by these hooks (`brain.json`, `brain.json.lock`, `brain-patch.json`, `flows-state.json`) are listed in the root `.gitignore` and are never committed to git.
+- Notes: Hook scripts must be executable (`chmod +x`). Hooks are registered via `hooks/hooks.json` (referenced in `plugin.json`) and are activated automatically when the plugin is installed — no manual `.claude/settings.json` edits needed. All script paths in `hooks/hooks.json` use `${CLAUDE_PLUGIN_ROOT}` so hooks resolve correctly from any install location. `DARK_FACTORY_WORK_DIR` must be exported by dark-factory-agent before any Agent tool calls — if it is unset, both hooks are no-ops. `scripts/generate_checklist.sh` must be executable and accessible — the pre-tool-use-hook resolves its path relative to the hook's own directory using `BASH_SOURCE[0]`. `phase-order-enforcement-hook.sh` runs before `pre-tool-use-hook.sh` in the PreToolUse chain and is a no-op for agents not in its allowlist. All transient files managed by these hooks (`brain.json`, `brain.json.lock`, `brain-patch.json`, `flows-state.json`) are listed in the root `.gitignore` and are never committed to git.

--- a/docs/plans/2026-05-01-phase-order-enforcement-hook.md
+++ b/docs/plans/2026-05-01-phase-order-enforcement-hook.md
@@ -1,0 +1,153 @@
+# Phase Order Enforcement Hook
+
+## System Intent
+
+- What is being built: A pre-tool-use hook and pre-agent-use hook that enforces sequential phase execution for agents that have strictly-ordered numbered flows (1 → 2 → 3 ... N). The hook prevents an agent from advancing to a later phase if earlier phases have not yet completed.
+- Primary consumer(s): Agents with sequential phase workflows (dark-factory-agent with 7 steps, update-documentation-agent with 3 phases, fix-flow-orchestrator with 3 phases, and others with explicitly numbered flows).
+- Boundary (black-box scope only): Hook-level enforcement only; agent implementations remain unchanged. The hook reads agent state via brain.json or execution state, and raises SubagentStop if phase ordering is violated.
+
+## Stage Gate Tracker
+
+- [ ] Stage 1 Mermaid approved
+- [ ] Stage 2 Flows approved
+- [ ] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  Start([Hook Input: Agent Name + Phase]):::created
+  Start --> CheckAgent{Agent has<br/>numbered phases?}
+  CheckAgent -->|No| AllowContinue[Allow execution]:::unchanged
+  CheckAgent -->|Yes| ReadState[Read brain.json<br/>or execution state]:::created
+  ReadState --> CheckPhase{Earlier phases<br/>complete?}
+  CheckPhase -->|Yes| AllowContinue
+  CheckPhase -->|No| RaiseStop[Raise SubagentStop<br/>with error message]:::red
+  AllowContinue --> End([Continue Tool/Agent Use]):::unchanged
+  RaiseStop --> EndStop([Halt Execution]):::red
+
+  classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+  classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+  classDef red fill:#ff6b6b,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+### Global Types
+
+```txt
+PhaseState {
+  agentName: string (e.g., "dark-factory-agent", "update-documentation-agent")
+  currentPhase: int (1-based index of the phase being executed)
+  completedPhases: int[] (list of already-completed phase numbers)
+}
+
+PhaseOrderViolation {
+  agentName: string
+  attemptedPhase: int
+  incompletePhases: int[] (phases that must complete before attemptedPhase)
+  message: string
+}
+```
+
+### Flow: `check-phase-order`
+
+Sequential phases that should not be skipped or reordered. Enforces that phase N cannot start until phases 1...N-1 are marked complete.
+
+#### Types
+
+```txt
+HookInput {
+  agentName: string (required, provided by hook mechanism)
+  currentPhase: int (required, parsed from agent context)
+}
+
+HookOutput {
+  allowed: bool (true = proceed, false = stop)
+  reason: string | null (if not allowed, reason for block)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `check-phase-order.allowed` | `HookInput` | `{ allowed: true }` | `happy path` | Phase order is valid, agent continues | |
+| `check-phase-order.blocked` | `HookInput` | `{ allowed: false, reason: string }` | `error` | Earlier phases incomplete, SubagentStop raised | |
+
+#### Pseudocode
+
+```
+function checkPhaseOrder(agentName, currentPhase):
+  phaseMap = {
+    "dark-factory-agent": 7,
+    "update-documentation-agent": 3,
+    "fix-flow-orchestrator": 3,
+    "planning-agent": 1,  // phases: draft_plan only (not numbered)
+    "execution-agent": N,  // variable phases per flow
+  }
+  
+  if agentName not in phaseMap:
+    return { allowed: true }  // unknown agent, allow
+  
+  stateFile = readBrainState(agentName)
+  if stateFile.completedPhases includes (currentPhase - 1):
+    return { allowed: true }
+  else:
+    incompletePhases = [1 ... currentPhase-1] - stateFile.completedPhases
+    raise SubagentStop with {
+      message: "Phase order violation in ${agentName}: cannot execute phase ${currentPhase} until phases ${incompletePhases} are complete."
+    }
+```
+
+### Flow: `mark-phase-complete`
+
+Called at the end of each phase to update agent state and permit subsequent phases to execute.
+
+#### Types
+
+```txt
+MarkCompleteInput {
+  agentName: string (required)
+  phaseNumber: int (required, 1-based)
+}
+
+MarkCompleteOutput {
+  updated: bool
+  newCompletedPhases: int[]
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `mark-phase-complete.success` | `MarkCompleteInput` | `{ updated: true, newCompletedPhases: [...] }` | `happy path` | Phase marked in brain.json or state file | |
+| `mark-phase-complete.error` | `MarkCompleteInput` | `{ updated: false, error: string }` | `error` | State file not writable or inaccessible | |
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| Hook output | `${DARK_FACTORY_WORK_DIR}/phase-order-enforcement.log` |
+| Brain state | `${DARK_FACTORY_WORK_DIR}/brain.json` (under `phases` key) |
+
+## Deployment
+
+- Mechanism: Plugin hook registration via hooks.json
+- Hook location: `agents/dark-factory/scripts/phase-order-enforcement-hook.sh`
+- Registration: `agents/dark-factory/hooks.json` (pre-tool-use, pre-agent-use)
+- Deploy command:
+  ```bash
+  # Copy hook script to plugin
+  cp agents/dark-factory/scripts/phase-order-enforcement-hook.sh \
+    ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/
+
+  # Update hooks.json in plugin to register the hook
+  # See agents/dark-factory/hooks.json for registration syntax
+  ```
+- Notes: Hook runs before any tool or agent invocation; exits early (no-op) if agent is not in the phase-ordered list.
+
+## Handoff to Related Plan Reconciliation
+
+After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans (if any dark-factory-agent subcomponents have their own plans).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -33,6 +33,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/phase-order-enforcement-hook.sh\""
+          },
+          {
+            "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pre-tool-use-hook.sh\""
           }
         ]

--- a/skills/hook-dual-flow-command-dispatch/SKILL.md
+++ b/skills/hook-dual-flow-command-dispatch/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: hook-dual-flow-command-dispatch
+description: "How to implement a single hook script that serves two distinct flows (e.g., check and mutate) by dispatching on a 'command' field in tool_input, so both guard and write operations share one registration."
+user-invocable: false
+---
+## When to use
+
+When a hook needs to handle two logically related but distinct operations — for example, a pre-tool-use guard that checks state and a separate write path that marks state as complete — and you want to register only one hook entry rather than two separate scripts.
+
+The pattern uses `tool_input.command` as a discriminator field. Callers that want the mutate path set `command` explicitly; calls without `command` default to the check path.
+
+## Steps
+
+1. In the hook's `main()`, read the `command` field from `tool_input`:
+   ```bash
+   command_field=$(printf '%s' "$tool_input" | jq -r '.tool_input.command // ""')
+   ```
+
+2. Dispatch to the appropriate function based on the field value:
+   ```bash
+   if [ "$command_field" = "mark-phase-complete" ]; then
+     agent_name=$(printf '%s' "$tool_input" | jq -r '.tool_input.agentName // ""')
+     phase_number=$(printf '%s' "$tool_input" | jq -r '.tool_input.phaseNumber // 0')
+     markPhaseComplete "$agent_name" "$phase_number"
+     return
+   fi
+
+   # Default: check path
+   agent_name=$(printf '%s' "$tool_input" | jq -r '.tool_input.agentName // ""')
+   current_phase=$(printf '%s' "$tool_input" | jq -r '.tool_input.currentPhase // 0')
+   checkPhaseOrder "$agent_name" "$current_phase"
+   ```
+
+3. Implement both functions in the same script. Each function outputs JSON to stdout and calls `exit 0` (never a non-zero exit — hooks must not crash Claude Code). The mutate function calls `markPhaseComplete`; the guard function calls `checkPhaseOrder` or equivalent.
+
+4. Register the hook once in `hooks/hooks.json`:
+   ```json
+   {
+     "PreToolUse": [
+       {
+         "matcher": "",
+         "hooks": [{ "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/my-hook.sh\"" }]
+       }
+     ]
+   }
+   ```
+   Both flows use the same registration. The `command` field in `tool_input` selects which code path runs at call time.
+
+5. In tests, exercise each path by setting or omitting the `command` field in the test fixture:
+   ```python
+   # Check path (no command field)
+   hook_input = {"tool_name": "Agent", "tool_input": {"agentName": "dark-factory-agent", "currentPhase": 2}}
+
+   # Mutate path
+   hook_input = {"tool_name": "Bash", "tool_input": {"command": "mark-phase-complete", "agentName": "dark-factory-agent", "phaseNumber": 1}}
+   ```
+
+## Notes
+
+- Use a string enum for `command` values (e.g., `"mark-phase-complete"`) rather than a boolean flag so the dispatch is extensible to more than two paths in the future.
+- The `command` field is read from `tool_input.command` (one level inside the outer `tool_input` object), not from the top-level hook JSON. The outer `tool_name` field identifies the Claude tool type (e.g., `Agent`, `Bash`) and is separate.
+- Missing or empty `command` always falls through to the default (check) path. This keeps ordinary Agent/tool invocations on the safe read-only path with no additional fields required.
+- Both functions must be idempotent or at least safe to call multiple times, because hooks fire for every matching tool invocation — including retries.
+- Do not branch on `tool_name` to distinguish the two paths. `tool_name` reflects the Claude tool being used (e.g., `Bash`, `Agent`), not the intent. The `command` field inside `tool_input` is the correct discriminator for intent.

--- a/skills/sequential-phase-gating-brain-json/SKILL.md
+++ b/skills/sequential-phase-gating-brain-json/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: sequential-phase-gating-brain-json
+description: "How to enforce strict sequential phase ordering for an agent by storing completed phase numbers in brain.json and gating advancement in a PreToolUse hook."
+user-invocable: false
+---
+## When to use
+
+When an agent has a strictly-ordered numbered workflow (phase 1 → 2 → 3 … N) and you want to prevent phases from being skipped or executed out of order. This pattern uses `brain.json` as the shared state store and a `PreToolUse` hook as the enforcement gate.
+
+This is distinct from the boolean `*-running` / `*-complete` phase flags (see `brain-hook-driven-state`): those flags track which phase is currently active; this pattern tracks a cumulative list of completed phase numbers so that any attempt to jump ahead is blocked until all prerequisites are satisfied.
+
+## Steps
+
+1. Add a `phases.completedPhases` array to `brain.json` at initialization time (set to `[]`):
+   ```json
+   {
+     "phases": {
+       "completedPhases": []
+     }
+   }
+   ```
+   This key is separate from the existing `*-running` / `*-complete` boolean fields. Both can coexist.
+
+2. Define an agent allowlist in the enforcement hook script as a bash associative array mapping agent name → total phase count (informational; only the array contents are used for gating):
+   ```bash
+   declare -A PHASE_MAP
+   PHASE_MAP["dark-factory-agent"]=7
+   PHASE_MAP["update-documentation-agent"]=3
+   PHASE_MAP["fix-flow-orchestrator"]=3
+   ```
+   Agents not in the map pass through unconditionally.
+
+3. In the `checkPhaseOrder` function:
+   - Allow phase 1 unconditionally (no prerequisites).
+   - If `brain.json` does not exist, allow (fail-open; safe for non-dark-factory sessions).
+   - Read `completedPhases` with: `jq -r '.phases.completedPhases // [] | @json' brain.json`
+   - Iterate phases `1 … currentPhase-1`; for each, check membership with jq: `map(select(. == $p)) | length > 0`
+   - If any prerequisite is absent, output `{"allowed":false,"reason":"..."}` and exit 0.
+   - Output `{"allowed":true}` and exit 0 on success.
+
+4. In the `markPhaseComplete` function (called at the end of each phase):
+   - Use `flock` around the read-modify-write (see `flock-shared-file-in-hooks` skill).
+   - Merge the new phase number with deduplication and sort: `.phases.completedPhases = ((.phases.completedPhases // []) + [$p] | unique | sort)`
+   - Verify the write succeeded by re-reading and checking membership before returning `{"updated":true}`.
+   - Return `{"updated":false,"error":"..."}` on any write failure; do not exit non-zero (hooks must exit 0 to avoid crashing Claude Code).
+
+5. Register the enforcement hook as `PreToolUse` (and optionally `PreAgentUse`) in `hooks/hooks.json`:
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [
+         {
+           "matcher": "",
+           "hooks": [{ "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/phase-order-enforcement-hook.sh\"" }]
+         }
+       ]
+     }
+   }
+   ```
+   An empty `matcher` fires the hook for every tool call. The hook exits early (no-op) for agents not in the `PHASE_MAP`.
+
+## Notes
+
+- The hook must always exit 0. A non-zero exit causes Claude Code to treat the hook as crashed, not as a blocked tool call. Returning `{"allowed":false}` in JSON is the correct way to block.
+- Fail-open (allow) when `brain.json` is absent. This makes the hook safe for Claude Code sessions that are not running under the dark-factory orchestrator.
+- The `completedPhases` array must only be written by the `mark-phase-complete` command path, not by the agent directly. Agents write `brain-patch.json`; the post-hook merges it. Phase completion is a side-channel to the normal patch flow and is written by the hook itself.
+- When adding a new phase-ordered agent, add it to `PHASE_MAP` in the enforcement hook and also to the `PHASE_AGENTS` allowlist in `pre-tool-use-hook.sh` / `post-tool-use-hook.sh` (see `phase-agent-allowlist` skill) so the boolean running/complete flags also fire for it.
+- The `phases.completedPhases` array coexists with the boolean `*-running`/`*-complete` fields — they serve complementary roles. The boolean fields track "what is currently running"; the integer array tracks "what has definitively finished."

--- a/tests/test_phase_order_enforcement_hook.py
+++ b/tests/test_phase_order_enforcement_hook.py
@@ -11,6 +11,7 @@ Flow: check-phase-order, mark-phase-complete
 
 import json
 import os
+import stat
 import subprocess
 import tempfile
 
@@ -28,8 +29,6 @@ PHASE_HOOK = os.path.join(
 
 def make_brain(completed_phases=None):
     """Build a minimal brain.json with an optional completed_phases list."""
-    # TODO (check-phase-order): Extend with any additional brain fields required
-    #   by the hook implementation.
     return {
         "taskDescription": "test task",
         "taskName": "test",
@@ -43,7 +42,6 @@ def make_brain(completed_phases=None):
 
 def run_hook(tool_input: dict, env_override: dict | None = None) -> subprocess.CompletedProcess:
     """Run phase-order-enforcement-hook.sh with given tool_input JSON via stdin."""
-    # TODO (check-phase-order): no additional setup needed — stub only.
     env = dict(os.environ)
     if env_override:
         env.update(env_override)
@@ -63,25 +61,82 @@ class TestCheckPhaseOrderAllowed:
         """
         check-phase-order.allowed: agents not in the phase map are always allowed.
         # Plan path: check-phase-order.allowed
-        # TODO (check-phase-order): implement
         """
-        raise NotImplementedError("TODO (check-phase-order): implement test")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            brain = make_brain(completed_phases=[])
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            hook_input = {
+                "tool_name": "Agent",
+                "tool_input": {
+                    "agentName": "unknown-agent-xyz",
+                    "currentPhase": 3,
+                },
+            }
+
+            result = run_hook(hook_input, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            out = json.loads(result.stdout)
+            assert out.get("allowed") is True, (
+                f"Expected allowed=true for unknown agent, got: {out}"
+            )
 
     def test_first_phase_always_allowed(self):
         """
         check-phase-order.allowed: phase 1 is always allowed regardless of state.
         # Plan path: check-phase-order.allowed
-        # TODO (check-phase-order): implement
         """
-        raise NotImplementedError("TODO (check-phase-order): implement test")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            brain = make_brain(completed_phases=[])
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            hook_input = {
+                "tool_name": "Agent",
+                "tool_input": {
+                    "agentName": "dark-factory-agent",
+                    "currentPhase": 1,
+                },
+            }
+
+            result = run_hook(hook_input, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            out = json.loads(result.stdout)
+            assert out.get("allowed") is True, (
+                f"Expected allowed=true for phase 1 with no prerequisites, got: {out}"
+            )
 
     def test_phase_allowed_when_prerequisites_complete(self):
         """
         check-phase-order.allowed: phase N allowed when phases 1..N-1 are complete.
         # Plan path: check-phase-order.allowed
-        # TODO (check-phase-order): implement
         """
-        raise NotImplementedError("TODO (check-phase-order): implement test")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            brain = make_brain(completed_phases=[1, 2])
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            hook_input = {
+                "tool_name": "Agent",
+                "tool_input": {
+                    "agentName": "dark-factory-agent",
+                    "currentPhase": 3,
+                },
+            }
+
+            result = run_hook(hook_input, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            out = json.loads(result.stdout)
+            assert out.get("allowed") is True, (
+                f"Expected allowed=true when phases 1 and 2 are complete, got: {out}"
+            )
 
 
 class TestCheckPhaseOrderBlocked:
@@ -91,17 +146,64 @@ class TestCheckPhaseOrderBlocked:
         """
         check-phase-order.blocked: SubagentStop raised when earlier phases are incomplete.
         # Plan path: check-phase-order.blocked
-        # TODO (check-phase-order): implement
         """
-        raise NotImplementedError("TODO (check-phase-order): implement test")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Phase 1 not completed, trying to run phase 2
+            brain = make_brain(completed_phases=[])
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            hook_input = {
+                "tool_name": "Agent",
+                "tool_input": {
+                    "agentName": "dark-factory-agent",
+                    "currentPhase": 2,
+                },
+            }
+
+            result = run_hook(hook_input, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            # Hook should output allowed=false and a non-zero exit (SubagentStop) or
+            # return a JSON with allowed=false and a reason
+            out = json.loads(result.stdout)
+            assert out.get("allowed") is False, (
+                f"Expected allowed=false when phase 1 incomplete and attempting phase 2, got: {out}"
+            )
+            assert out.get("reason") is not None, (
+                f"Expected a reason field when blocked, got: {out}"
+            )
 
     def test_blocked_message_lists_incomplete_phases(self):
         """
         check-phase-order.blocked: error message names the specific incomplete phases.
         # Plan path: check-phase-order.blocked
-        # TODO (check-phase-order): implement
         """
-        raise NotImplementedError("TODO (check-phase-order): implement test")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Only phase 1 complete, skipped phase 2, trying to run phase 3
+            brain = make_brain(completed_phases=[1])
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            hook_input = {
+                "tool_name": "Agent",
+                "tool_input": {
+                    "agentName": "dark-factory-agent",
+                    "currentPhase": 3,
+                },
+            }
+
+            result = run_hook(hook_input, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            out = json.loads(result.stdout)
+            assert out.get("allowed") is False, (
+                f"Expected allowed=false when phase 2 is incomplete, got: {out}"
+            )
+            reason = out.get("reason", "")
+            assert "2" in reason, (
+                f"Expected incomplete phase 2 to be mentioned in reason, got reason: {reason!r}"
+            )
 
 
 class TestMarkPhaseComplete:
@@ -111,14 +213,72 @@ class TestMarkPhaseComplete:
         """
         mark-phase-complete.success: phaseNumber appended to completedPhases in brain.json.
         # Plan path: mark-phase-complete.success
-        # TODO (mark-phase-complete): implement
         """
-        raise NotImplementedError("TODO (mark-phase-complete): implement test")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            brain = make_brain(completed_phases=[])
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            hook_input = {
+                "tool_name": "Bash",
+                "tool_input": {
+                    "command": "mark-phase-complete",
+                    "agentName": "dark-factory-agent",
+                    "phaseNumber": 1,
+                },
+            }
+
+            result = run_hook(hook_input, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            out = json.loads(result.stdout)
+            assert out.get("updated") is True, (
+                f"Expected updated=true after marking phase complete, got: {out}"
+            )
+            assert 1 in out.get("newCompletedPhases", []), (
+                f"Expected phase 1 in newCompletedPhases, got: {out}"
+            )
+
+            # Also verify brain.json was actually updated on disk
+            with open(brain_path) as f:
+                updated_brain = json.load(f)
+            assert 1 in updated_brain["phases"]["completedPhases"], (
+                f"Expected phase 1 in brain.json completedPhases, got: {updated_brain}"
+            )
 
     def test_mark_phase_error_on_unwritable_brain(self):
         """
         mark-phase-complete.error: returns error when brain.json is not writable.
         # Plan path: mark-phase-complete.error
-        # TODO (mark-phase-complete): implement
         """
-        raise NotImplementedError("TODO (mark-phase-complete): implement test")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            brain = make_brain(completed_phases=[])
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            # Make brain.json read-only so write will fail
+            os.chmod(brain_path, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+
+            hook_input = {
+                "tool_name": "Bash",
+                "tool_input": {
+                    "command": "mark-phase-complete",
+                    "agentName": "dark-factory-agent",
+                    "phaseNumber": 1,
+                },
+            }
+
+            result = run_hook(hook_input, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            out = json.loads(result.stdout)
+            assert out.get("updated") is False, (
+                f"Expected updated=false when brain.json is not writable, got: {out}"
+            )
+            assert out.get("error") is not None, (
+                f"Expected an error field when write fails, got: {out}"
+            )
+
+            # Restore permissions for cleanup
+            os.chmod(brain_path, stat.S_IRUSR | stat.S_IWUSR)

--- a/tests/test_phase_order_enforcement_hook.py
+++ b/tests/test_phase_order_enforcement_hook.py
@@ -1,0 +1,124 @@
+"""
+Tests for phase-order-enforcement-hook.sh
+
+Verifies that:
+- Phase order is allowed when all prerequisite phases are complete.
+- Phase order is blocked (SubagentStop raised) when earlier phases are incomplete.
+- Marking a phase complete updates brain.json correctly.
+
+Flow: check-phase-order, mark-phase-complete
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PHASE_HOOK = os.path.join(
+    REPO_ROOT,
+    "agents",
+    "dark-factory",
+    "scripts",
+    "phase-order-enforcement-hook.sh",
+)
+
+
+def make_brain(completed_phases=None):
+    """Build a minimal brain.json with an optional completed_phases list."""
+    # TODO (check-phase-order): Extend with any additional brain fields required
+    #   by the hook implementation.
+    return {
+        "taskDescription": "test task",
+        "taskName": "test",
+        "workDir": "/tmp/test",
+        "projectDir": "/tmp/project",
+        "phases": {
+            "completedPhases": completed_phases or [],
+        },
+    }
+
+
+def run_hook(tool_input: dict, env_override: dict | None = None) -> subprocess.CompletedProcess:
+    """Run phase-order-enforcement-hook.sh with given tool_input JSON via stdin."""
+    # TODO (check-phase-order): no additional setup needed — stub only.
+    env = dict(os.environ)
+    if env_override:
+        env.update(env_override)
+    return subprocess.run(
+        ["bash", PHASE_HOOK],
+        input=json.dumps(tool_input),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestCheckPhaseOrderAllowed:
+    """Flow: check-phase-order — allowed path"""
+
+    def test_unknown_agent_allowed(self):
+        """
+        check-phase-order.allowed: agents not in the phase map are always allowed.
+        # Plan path: check-phase-order.allowed
+        # TODO (check-phase-order): implement
+        """
+        raise NotImplementedError("TODO (check-phase-order): implement test")
+
+    def test_first_phase_always_allowed(self):
+        """
+        check-phase-order.allowed: phase 1 is always allowed regardless of state.
+        # Plan path: check-phase-order.allowed
+        # TODO (check-phase-order): implement
+        """
+        raise NotImplementedError("TODO (check-phase-order): implement test")
+
+    def test_phase_allowed_when_prerequisites_complete(self):
+        """
+        check-phase-order.allowed: phase N allowed when phases 1..N-1 are complete.
+        # Plan path: check-phase-order.allowed
+        # TODO (check-phase-order): implement
+        """
+        raise NotImplementedError("TODO (check-phase-order): implement test")
+
+
+class TestCheckPhaseOrderBlocked:
+    """Flow: check-phase-order — blocked / error path"""
+
+    def test_phase_blocked_when_prerequisites_incomplete(self):
+        """
+        check-phase-order.blocked: SubagentStop raised when earlier phases are incomplete.
+        # Plan path: check-phase-order.blocked
+        # TODO (check-phase-order): implement
+        """
+        raise NotImplementedError("TODO (check-phase-order): implement test")
+
+    def test_blocked_message_lists_incomplete_phases(self):
+        """
+        check-phase-order.blocked: error message names the specific incomplete phases.
+        # Plan path: check-phase-order.blocked
+        # TODO (check-phase-order): implement
+        """
+        raise NotImplementedError("TODO (check-phase-order): implement test")
+
+
+class TestMarkPhaseComplete:
+    """Flow: mark-phase-complete"""
+
+    def test_mark_phase_updates_brain(self):
+        """
+        mark-phase-complete.success: phaseNumber appended to completedPhases in brain.json.
+        # Plan path: mark-phase-complete.success
+        # TODO (mark-phase-complete): implement
+        """
+        raise NotImplementedError("TODO (mark-phase-complete): implement test")
+
+    def test_mark_phase_error_on_unwritable_brain(self):
+        """
+        mark-phase-complete.error: returns error when brain.json is not writable.
+        # Plan path: mark-phase-complete.error
+        # TODO (mark-phase-complete): implement
+        """
+        raise NotImplementedError("TODO (mark-phase-complete): implement test")


### PR DESCRIPTION
## Description

# Phase Order Enforcement Hook

## System Intent

- What is being built: A pre-tool-use hook and pre-agent-use hook that enforces sequential phase execution for agents that have strictly-ordered numbered flows (1 → 2 → 3 ... N). The hook prevents an agent from advancing to a later phase if earlier phases have not yet completed.
- Primary consumer(s): Agents with sequential phase workflows (dark-factory-agent with 7 steps, update-documentation-agent with 3 phases, fix-flow-orchestrator with 3 phases, and others with explicitly numbered flows).
- Boundary (black-box scope only): Hook-level enforcement only; agent implementations remain unchanged. The hook reads agent state via brain.json or execution state, and raises SubagentStop if phase ordering is violated.

## Stage Gate Tracker

- [ ] Stage 1 Mermaid approved
- [ ] Stage 2 Flows approved
- [ ] Stage 3 Logs + Deployment approved or skipped

## Mermaid Diagram

```mermaid
graph TD
  Start([Hook Input: Agent Name + Phase]):::created
  Start --> CheckAgent{Agent has<br/>numbered phases?}
  CheckAgent -->|No| AllowContinue[Allow execution]:::unchanged
  CheckAgent -->|Yes| ReadState[Read brain.json<br/>or execution state]:::created
  ReadState --> CheckPhase{Earlier phases<br/>complete?}
  CheckPhase -->|Yes| AllowContinue
  CheckPhase -->|No| RaiseStop[Raise SubagentStop<br/>with error message]:::red
  AllowContinue --> End([Continue Tool/Agent Use]):::unchanged
  RaiseStop --> EndStop([Halt Execution]):::red

  classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
  classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
  classDef red fill:#ff6b6b,stroke:#666,stroke-width:1px;
```

## Flows

### Global Types

```txt
PhaseState {
  agentName: string (e.g., "dark-factory-agent", "update-documentation-agent")
  currentPhase: int (1-based index of the phase being executed)
  completedPhases: int[] (list of already-completed phase numbers)
}

PhaseOrderViolation {
  agentName: string
  attemptedPhase: int
  incompletePhases: int[] (phases that must complete before attemptedPhase)
  message: string
}
```

### Flow: `check-phase-order`

Sequential phases that should not be skipped or reordered. Enforces that phase N cannot start until phases 1...N-1 are marked complete.

#### Types

```txt
HookInput {
  agentName: string (required, provided by hook mechanism)
  currentPhase: int (required, parsed from agent context)
}

HookOutput {
  allowed: bool (true = proceed, false = stop)
  reason: string | null (if not allowed, reason for block)
}
```

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `check-phase-order.allowed` | `HookInput` | `{ allowed: true }` | `happy path` | Phase order is valid, agent continues | |
| `check-phase-order.blocked` | `HookInput` | `{ allowed: false, reason: string }` | `error` | Earlier phases incomplete, SubagentStop raised | |

#### Pseudocode

```
function checkPhaseOrder(agentName, currentPhase):
  phaseMap = {
    "dark-factory-agent": 7,
    "update-documentation-agent": 3,
    "fix-flow-orchestrator": 3,
    "planning-agent": 1,
    "execution-agent": N,
  }
  
  if agentName not in phaseMap:
    return { allowed: true }
  
  stateFile = readBrainState(agentName)
  if stateFile.completedPhases includes (currentPhase - 1):
    return { allowed: true }
  else:
    incompletePhases = [1 ... currentPhase-1] - stateFile.completedPhases
    raise SubagentStop with {
      message: "Phase order violation in ${agentName}: cannot execute phase ${currentPhase} until phases ${incompletePhases} are complete."
    }
```

### Flow: `mark-phase-complete`

Called at the end of each phase to update agent state and permit subsequent phases to execute.

#### Types

```txt
MarkCompleteInput {
  agentName: string (required)
  phaseNumber: int (required, 1-based)
}

MarkCompleteOutput {
  updated: bool
  newCompletedPhases: int[]
}
```

#### Paths

| path | input | output | path-type | notes | updated |
| --- | --- | --- | --- | --- | --- |
| `mark-phase-complete.success` | `MarkCompleteInput` | `{ updated: true, newCompletedPhases: [...] }` | `happy path` | Phase marked in brain.json or state file | |
| `mark-phase-complete.error` | `MarkCompleteInput` | `{ updated: false, error: string }` | `error` | State file not writable or inaccessible | |

## Logs

| Source | Location |
|--------|----------|
| Hook output | `${DARK_FACTORY_WORK_DIR}/phase-order-enforcement.log` |
| Brain state | `${DARK_FACTORY_WORK_DIR}/brain.json` (under `phases` key) |

## Deployment

- Mechanism: Plugin hook registration via hooks.json
- Hook location: `agents/dark-factory/scripts/phase-order-enforcement-hook.sh`
- Registration: `agents/dark-factory/hooks.json` (pre-tool-use, pre-agent-use)
- Deploy command:
  ```bash
  cp agents/dark-factory/scripts/phase-order-enforcement-hook.sh \
    ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/
  ```
- Notes: Hook runs before any tool or agent invocation; exits early (no-op) if agent is not in the phase-ordered list.

## Handoff to Related Plan Reconciliation

After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans (if any dark-factory-agent subcomponents have their own plans).

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
