### PR TITLE
feat(gen-hooks): add YAML frontmatter hook declarations with additive settings.json merge

### DIFF
--- a/commands/gen-hooks.md
+++ b/commands/gen-hooks.md
@@ -17,4 +17,12 @@ Scans all `.md` files in the project directory for YAML frontmatter hook declara
 
 ## Implementation
 
-TODO: genHooksCommand flow implementation
+The command invokes the Python script at `scripts/gen_hooks.py` with the current project directory, which performs the following:
+
+1. **scanFrontmatter**: Recursively scans all `.md` files in the project for YAML frontmatter containing hook declarations (PreToolUse, PostToolUse, Stop, SubagentStop, PreCompact)
+2. **mergeIntoSettings**: Merges discovered hooks into `.claude/settings.json` additively, preserving existing entries and deduplicating by command string
+3. **genHooksCommand**: Orchestrates both flows and returns a summary message
+
+### Output
+
+Returns a message indicating the number of hooks added and duplicates skipped, along with the path to `.claude/settings.json`.

--- a/commands/gen-hooks.md
+++ b/commands/gen-hooks.md
@@ -1,0 +1,20 @@
+---
+name: gen-hooks
+description: Scans YAML frontmatter of skill/agent/command files for hook declarations and writes them to .claude/settings.json additively
+---
+
+# gen-hooks
+
+## Purpose
+
+Scans all `.md` files in the project directory for YAML frontmatter hook declarations (e.g., `PreToolUse: ./hooks/pre-use.sh`) and merges them into `.claude/settings.json` without disturbing existing entries.
+
+## Usage
+
+```
+/dark-factory:gen-hooks
+```
+
+## Implementation
+
+TODO: genHooksCommand flow implementation

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -5,7 +5,7 @@
 - System type: `library`
 - Owner: dark-factory plugin
 - Source directory: `commands/`
-- Command count: 5 slash commands
+- Command count: 6 slash commands
 
 ## System Intent
 
@@ -22,12 +22,14 @@ flowchart TD
   Dev -->|/dark-factory:install| CMD_I[commands/install.md]
   Dev -->|/dark-factory:destroy-factories| CMD_D[commands/destroy-factories.md]
   Dev -->|/dark-factory:improve --issues list| CMD_IMP[commands/improve.md]
+  Dev -->|/dark-factory:gen-hooks| CMD_GH[commands/gen-hooks.md]
 
   CMD_M -->|delegates to| DFA[agents/dark-factory/agents/dark-factory-agent.md]
   CMD_S -->|launches| TERM[New gnome-terminal running claude /remote-control]
   CMD_I -->|runs directly| GIT[git pull + claude plugin marketplace add/update/uninstall/install]
   CMD_D -->|"bash ${CLAUDE_PLUGIN_ROOT}/scripts/destroy-factories.sh"| DS[scripts/destroy-factories.sh kills Claude terminals, spawns fresh one]
   CMD_IMP -->|delegates to| ORCH[agents/improve/agents/improve-orchestrator.md]
+  CMD_GH -->|"python3 scripts/gen_hooks.py $projectDir"| GHS[scripts/gen_hooks.py scans .md frontmatter, writes .claude/settings.json]
 ```
 
 ## Flows
@@ -154,6 +156,39 @@ StandardError {
 | `destroy-factories.none-found` | `DestroyFactoriesInput` | `DestroyFactoriesOutput` | `happy path` | No other Claude terminals found; new factory terminal spawned (no kills needed) |
 | `destroy-factories.kill-failed` | `DestroyFactoriesInput` | `StandardError` | `degraded` | One or more terminals could not be killed (permission error); warns to stderr, continues to spawn |
 | `destroy-factories.spawn-failed` | `DestroyFactoriesInput` | `StandardError` | `error` | New terminal could not be opened (no emulator found or emulator returned non-zero); exits non-zero |
+
+---
+
+### Flow: `gen-hooks`
+
+- Core files: `commands/gen-hooks.md`, `scripts/gen_hooks.py`
+
+#### Types
+
+```txt
+GenHooksInput {
+  projectDir: string (CWD when the command is invoked)
+}
+
+GenHooksOutput {
+  addedCount: int
+  skippedCount: int
+  settingsPath: string
+  message: string (human-readable summary)
+}
+
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `gen-hooks.success` | `GenHooksInput` | `GenHooksOutput` | `happy path` | Scans all .md files recursively for YAML frontmatter hook declarations; merges into .claude/settings.json additively |
+| `gen-hooks.nothing-to-add` | `GenHooksInput` | `GenHooksOutput{addedCount:0}` | `happy path` | No YAML hook declarations found; settings.json created if missing |
+| `gen-hooks.error` | `GenHooksInput` | `StandardError` | `error` | Scan or settings.json write failed |
 
 ## Logs
 

--- a/docs/docs/gen-hooks.md
+++ b/docs/docs/gen-hooks.md
@@ -1,0 +1,260 @@
+# gen-hooks
+
+## Metadata
+
+- System type: `flow`
+
+## System Intent
+
+- What this is: The `gen-hooks` system consists of the `/dark-factory:gen-hooks` slash command (`commands/gen-hooks.md`) and its backing Python script (`scripts/gen_hooks.py`). It recursively scans all `.md` files in the project directory for hook declarations in YAML frontmatter (e.g., `PreToolUse: ./hooks/pre-use.sh`) and merges them into `.claude/settings.json` additively — never deleting existing entries, and deduplicating by exact command string.
+- Primary consumer(s): Plugin users who want to attach custom shell scripts to Claude Code hook events by declaring them in the YAML frontmatter of any `.md` file, then running `/dark-factory:gen-hooks` to activate them.
+- Boundary: `gen-hooks` reads `.md` frontmatter and writes `.claude/settings.json`. It does not modify `hooks/hooks.json`, does not delete existing hook entries from `settings.json`, and does not execute the declared scripts.
+
+### Supported hook event types
+
+- `PreToolUse`
+- `PostToolUse`
+- `Stop`
+- `SubagentStop`
+- `PreCompact`
+
+### YAML frontmatter syntax
+
+Declare hooks inside the `---` frontmatter block of any `.md` file in the project tree:
+
+```yaml
+---
+name: my-skill
+PreToolUse: ./hooks/pre-use.sh
+PostToolUse: ./hooks/post-use.sh
+---
+```
+
+Multiple declarations of the same hook key are allowed; each produces a separate hook entry in `settings.json`. The `matcher` field defaults to `""` (matches everything).
+
+### Output target structure
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "bash ./hooks/pre-use.sh" }] }
+    ]
+  }
+}
+```
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  User[User — invokes gen-hooks command]:::unchanged -->|CommandInput projectDir| GenHooksCmd[gen-hooks.md — commands/gen-hooks.md]:::created
+  GenHooksCmd -->|ScanInput rootDir| GenHooksScript[gen_hooks.py — scripts/gen_hooks.py]:::created
+  GenHooksScript -->|reads YAML frontmatter| SkillsMDs[all .md files — recursive project scan]:::unchanged
+  SkillsMDs -->|FrontmatterHook list| GenHooksScript
+  GenHooksScript -->|MergeInput settingsPath + newHooks| SettingsJSON[settings.json — .claude/settings.json]:::unchanged
+  SettingsJSON -->|existing HookEventMap| GenHooksScript
+  GenHooksScript -->|MergeOutput addedCount + skippedCount| GenHooksCmd
+  GenHooksCmd -->|CommandOutput message| User
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+
+FrontmatterHook {
+  eventType: string (e.g. "PreToolUse")
+  command: string (raw value from the YAML key)
+  matcher: string (defaults to "")
+  sourceFile: string (path to the .md file declaring the hook)
+}
+
+HookEntry {
+  type: "command"
+  command: string (the shell command string to execute, e.g. "bash ./hooks/pre-use.sh")
+}
+
+HookMatcher {
+  matcher: string (glob/regex matcher; defaults to "" for match-all)
+  hooks: HookEntry[]
+}
+
+HookEventMap {
+  PreToolUse?: HookMatcher[]
+  PostToolUse?: HookMatcher[]
+  Stop?: HookMatcher[]
+  SubagentStop?: HookMatcher[]
+  PreCompact?: HookMatcher[]
+}
+```
+
+---
+
+### Flow: `scanFrontmatter`
+
+- Test files: `tests/test_gen_hooks.py`
+- Core files: `scripts/gen_hooks.py`
+
+#### Types
+
+```txt
+ScanInput {
+  rootDir: string (absolute path to the project root being scanned)
+}
+
+ScanOutput {
+  hooks: FrontmatterHook[]
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `scanFrontmatter.success` | `ScanInput` | `ScanOutput` | `happy path` | Found 0 or more hook declarations |
+| `scanFrontmatter.no-md-files` | `ScanInput` | `ScanOutput{hooks:[]}` | `happy path` | No .md files with hook keys found |
+| `scanFrontmatter.invalid-yaml` | `ScanInput` | `StandardError` | `error` | A .md file has malformed YAML frontmatter |
+
+#### Pseudocode
+
+```
+scanFrontmatter(rootDir):
+  results = []
+  for each .md file found recursively under rootDir:
+    frontmatter = parse_yaml_frontmatter(file)
+    if frontmatter is None: continue
+    for each key in frontmatter:
+      if key in HOOK_TYPES:
+        values = ensure_list(frontmatter[key])
+        for value in values:
+          results.append(FrontmatterHook(eventType=key, command=value, matcher="", sourceFile=file))
+  return ScanOutput(hooks=results)
+```
+
+---
+
+### Flow: `mergeIntoSettings`
+
+- Test files: `tests/test_gen_hooks.py`
+- Core files: `scripts/gen_hooks.py`
+
+#### Types
+
+```txt
+MergeInput {
+  settingsPath: string (absolute path to .claude/settings.json)
+  newHooks: FrontmatterHook[]
+}
+
+MergeOutput {
+  addedCount: int
+  skippedCount: int (duplicates already present)
+  settingsPath: string
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `mergeIntoSettings.success` | `MergeInput` | `MergeOutput` | `happy path` | Hooks merged without deleting existing entries |
+| `mergeIntoSettings.settings-missing` | `MergeInput` | `MergeOutput` | `happy path` | settings.json does not exist — created with just the hooks key; parent dirs created via mkdir -p |
+| `mergeIntoSettings.all-duplicates` | `MergeInput` | `MergeOutput{addedCount:0}` | `happy path` | All declared hooks already present; file not modified |
+| `mergeIntoSettings.write-error` | `MergeInput` | `StandardError` | `error` | File system write fails (e.g. permission denied) |
+
+#### Pseudocode
+
+```
+mergeIntoSettings(settingsPath, newHooks):
+  settings = read_json(settingsPath) if exists else {}
+  existing = settings.get("hooks", {})
+  added = 0; skipped = 0
+  for hook in newHooks:
+    event_list = existing.setdefault(hook.eventType, [])
+    command_str = "bash " + hook.command
+    already_present = any(
+      entry["command"] == command_str
+      for matcher_obj in event_list
+      for entry in matcher_obj.get("hooks", [])
+    )
+    if already_present: skipped += 1; continue
+    event_list.append({"matcher": hook.matcher, "hooks": [{"type": "command", "command": command_str}]})
+    added += 1
+  settings["hooks"] = existing
+  mkdir_p(settingsPath.parent)
+  write_json(settingsPath, settings)
+  return MergeOutput(addedCount=added, skippedCount=skipped, settingsPath=settingsPath)
+```
+
+---
+
+### Flow: `genHooksCommand`
+
+- Test files: `tests/test_gen_hooks.py`
+- Core files: `commands/gen-hooks.md`, `scripts/gen_hooks.py`
+
+#### Types
+
+```txt
+CommandInput {
+  projectDir: string (CWD when the command is invoked — the user's project root)
+}
+
+CommandOutput {
+  addedCount: int
+  skippedCount: int
+  settingsPath: string
+  message: string (human-readable summary, e.g. "Added 2 hook(s), skipped 1 duplicate(s).")
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `genHooksCommand.success` | `CommandInput` | `CommandOutput` | `happy path` | Scanned + merged; prints summary to user |
+| `genHooksCommand.nothing-to-add` | `CommandInput` | `CommandOutput{addedCount:0}` | `happy path` | No YAML hook declarations found in any .md file |
+| `genHooksCommand.error` | `CommandInput` | `StandardError` | `error` | Scan or merge step failed |
+
+#### Pseudocode
+
+```
+genHooksCommand(projectDir):
+  scanResult = scanFrontmatter(projectDir)
+  if error: return StandardError
+
+  settingsPath = projectDir + "/.claude/settings.json"
+  mergeResult = mergeIntoSettings(settingsPath, scanResult.hooks)
+  if error: return StandardError
+
+  return CommandOutput(
+    addedCount=mergeResult.addedCount,
+    skippedCount=mergeResult.skippedCount,
+    settingsPath=mergeResult.settingsPath,
+    message="Added " + mergeResult.addedCount + " hook(s), skipped " + mergeResult.skippedCount + " duplicate(s)."
+  )
+```
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| gen-hooks script | stdout (printed to user terminal) |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment — ships as a plugin command + Python script.
+  # After implementing, run /dark-factory:install to pick up the new command.
+  ```
+- Notes: The command becomes available as `/dark-factory:gen-hooks` after the plugin is installed. The script can also be run directly: `python3 scripts/gen_hooks.py [project-dir]` (defaults to CWD if no argument given).

--- a/docs/plans/2026-05-03-yaml-hooks-in-gen-hooks.md
+++ b/docs/plans/2026-05-03-yaml-hooks-in-gen-hooks.md
@@ -1,0 +1,281 @@
+# YAML-Declared Hooks in gen-hooks Command
+
+## System Intent
+
+- What is being built: A new `/dark-factory:gen-hooks` slash command (and backing command file) that scans all skill, agent, and command `.md` files for hook declarations in their YAML frontmatter (e.g., `PreToolUse: ./commit.sh`) and writes those hooks into `.claude/settings.json` — additively, without disturbing any pre-existing hooks.
+- Primary consumer(s): Plugin users who want to attach custom shell scripts to Claude Code hook events (PreToolUse, PostToolUse, Stop, SubagentStop, PreCompact, etc.) by declaring them directly in the YAML frontmatter of a skill or agent file they own, then running `gen-hooks` to activate them.
+- Boundary (black-box scope only): `gen-hooks` reads `.md` frontmatter and writes `.claude/settings.json`. It does not modify plugin-level `hooks/hooks.json`, does not delete existing hooks entries from `settings.json`, and does not execute the declared scripts.
+
+### Supported hook types
+
+All hook events documented at https://code.claude.com/docs/en/hooks:
+- `PreToolUse`
+- `PostToolUse`
+- `Stop`
+- `SubagentStop`
+- `PreCompact`
+
+### YAML frontmatter syntax
+
+Users declare hooks inside the `---` frontmatter block of any `.md` file anywhere in the project directory (scanned recursively):
+
+```yaml
+---
+name: my-skill
+PreToolUse: ./hooks/pre-use.sh
+PostToolUse: ./hooks/post-use.sh
+PreToolUse: ./hooks/pre-use-2.sh   # second entry — both are registered
+---
+```
+
+Multiple declarations of the same hook key are allowed; each produces a separate hook entry in `settings.json`.
+
+The `matcher` field defaults to `""` (matches everything) unless the user also declares `matcher: <value>` directly below the hook line (exact syntax TBD in flows).
+
+### Output target
+
+Hooks are written to `.claude/settings.json` under the `hooks` key, following the same structure Claude Code uses natively:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "bash ./hooks/pre-use.sh" }] }
+    ]
+  }
+}
+```
+
+Existing entries are preserved; only new entries derived from the YAML scan are appended (deduplication by exact command string).
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 Flows approved
+- [x] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  User[User — invokes gen-hooks command]:::unchanged -->|CommandInput projectDir| GenHooksCmd[gen-hooks.md — commands/gen-hooks.md]:::created
+  GenHooksCmd -->|ScanInput rootDir| GenHooksScript[gen_hooks.py — scripts/gen_hooks.py]:::created
+  GenHooksScript -->|reads YAML frontmatter| SkillsMDs[all .md files — recursive project scan]:::unchanged
+  SkillsMDs -->|FrontmatterHook list| GenHooksScript
+  GenHooksScript -->|MergeInput settingsPath + newHooks| SettingsJSON[settings.json — .claude/settings.json]:::unchanged
+  SettingsJSON -->|existing HookEventMap| GenHooksScript
+  GenHooksScript -->|MergeOutput addedCount + skippedCount| GenHooksCmd
+  GenHooksCmd -->|CommandOutput message| User
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef updated fill:#ffe58a,stroke:#666,stroke-width:1px;
+classDef deleted fill:#f4a6a6,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Flows
+
+- Flow naming rule: ``### Flow: `<flowname>` ``
+- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+
+HookEntry {
+  type: "command"
+  command: string (the shell command string to execute)
+}
+
+HookMatcher {
+  matcher: string (glob/regex matcher; defaults to "" for match-all)
+  hooks: HookEntry[]
+}
+
+HookEventMap {
+  PreToolUse?: HookMatcher[]
+  PostToolUse?: HookMatcher[]
+  Stop?: HookMatcher[]
+  SubagentStop?: HookMatcher[]
+  PreCompact?: HookMatcher[]
+}
+```
+
+### Flow: `scanFrontmatter`
+- Test files: `tests/test_gen_hooks.py`
+- Core files: `commands/gen-hooks.md`, `scripts/gen_hooks.py`
+
+#### Types
+
+```txt
+ScanInput {
+  rootDir: string (absolute path to the project root being scanned)
+}
+
+FrontmatterHook {
+  eventType: string (e.g. "PreToolUse")
+  command: string (raw value from the YAML key)
+  matcher: string (defaults to "")
+  sourceFile: string (path to the .md file declaring the hook)
+}
+
+ScanOutput {
+  hooks: FrontmatterHook[]
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `scanFrontmatter.success` | `ScanInput` | `ScanOutput` | `happy path` | Found 0 or more hook declarations | |
+| `scanFrontmatter.no-md-files` | `ScanInput` | `ScanOutput{hooks:[]}` | `happy path` | No .md files with hook keys found | |
+| `scanFrontmatter.invalid-yaml` | `ScanInput` | `StandardError` | `error` | A .md file has malformed YAML frontmatter | |
+
+#### Pseudocode
+
+```
+scanFrontmatter(rootDir):
+  results = []
+  for each .md file found recursively under rootDir (all subdirectories):
+    frontmatter = parse_yaml_frontmatter(file)
+    if frontmatter is None: continue
+    for each key in frontmatter:
+      if key in HOOK_TYPES:
+        values = ensure_list(frontmatter[key])   # handle single or list values
+        for value in values:
+          results.append(FrontmatterHook(eventType=key, command=value, matcher="", sourceFile=file))
+  return ScanOutput(hooks=results)
+```
+
+### Flow: `mergeIntoSettings`
+- Test files: `tests/test_gen_hooks.py`
+- Core files: `scripts/gen_hooks.py`
+
+#### Types
+
+```txt
+MergeInput {
+  settingsPath: string (absolute path to .claude/settings.json)
+  newHooks: FrontmatterHook[]
+}
+
+MergeOutput {
+  addedCount: int
+  skippedCount: int (duplicates already present)
+  settingsPath: string
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `mergeIntoSettings.success` | `MergeInput` | `MergeOutput` | `happy path` | Hooks merged without deleting existing entries | |
+| `mergeIntoSettings.settings-missing` | `MergeInput` | `MergeOutput` | `happy path` | settings.json doesn't exist yet — create it with just the hooks key | |
+| `mergeIntoSettings.all-duplicates` | `MergeInput` | `MergeOutput{addedCount:0}` | `happy path` | All declared hooks already present; no-op | |
+| `mergeIntoSettings.write-error` | `MergeInput` | `StandardError` | `error` | File system write fails | |
+
+#### Pseudocode
+
+```
+mergeIntoSettings(settingsPath, newHooks):
+  settings = read_json(settingsPath) if exists else {}
+  existing = settings.get("hooks", {})
+  added = 0
+  skipped = 0
+  for hook in newHooks:
+    event_list = existing.setdefault(hook.eventType, [])
+    command_str = "bash " + hook.command
+    # check for duplicate by exact command string across all matchers in this event
+    already_present = any(
+      entry["command"] == command_str
+      for matcher_obj in event_list
+      for entry in matcher_obj.get("hooks", [])
+    )
+    if already_present:
+      skipped += 1
+      continue
+    event_list.append({
+      "matcher": hook.matcher,
+      "hooks": [{"type": "command", "command": command_str}]
+    })
+    added += 1
+  settings["hooks"] = existing
+  write_json(settingsPath, settings)
+  return MergeOutput(addedCount=added, skippedCount=skipped, settingsPath=settingsPath)
+```
+
+### Flow: `genHooksCommand`
+- Test files: `tests/test_gen_hooks.py`
+- Core files: `commands/gen-hooks.md`, `scripts/gen_hooks.py`
+
+#### Types
+
+```txt
+CommandInput {
+  projectDir: string (CWD when the command is invoked — the user's project root)
+}
+
+CommandOutput {
+  addedCount: int
+  skippedCount: int
+  settingsPath: string
+  message: string (human-readable summary)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `genHooksCommand.success` | `CommandInput` | `CommandOutput` | `happy path` | Scanned + merged; prints summary to user | |
+| `genHooksCommand.nothing-to-add` | `CommandInput` | `CommandOutput{addedCount:0}` | `happy path` | No YAML hook declarations found in any .md file | |
+| `genHooksCommand.error` | `CommandInput` | `StandardError` | `error` | Scan or merge step failed | |
+
+#### Pseudocode
+
+```
+genHooksCommand(projectDir):
+  scanResult = scanFrontmatter(projectDir)
+  if error: return StandardError
+
+  settingsPath = projectDir + "/.claude/settings.json"
+  mergeResult = mergeIntoSettings(settingsPath, scanResult.hooks)
+  if error: return StandardError
+
+  return CommandOutput(
+    addedCount=mergeResult.addedCount,
+    skippedCount=mergeResult.skippedCount,
+    settingsPath=mergeResult.settingsPath,
+    message="Added " + mergeResult.addedCount + " hook(s), skipped " + mergeResult.skippedCount + " duplicate(s)."
+  )
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| gen-hooks script | stdout (printed to user terminal) |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment — ships as a plugin command + Python script
+  ```
+- Notes: After implementing, run `/dark-factory:install` to pick up the new command.
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Handoff to Related Plan Reconciliation
+
+After all stages are approved, apply `.agent/skills/reconcile-plans/SKILL.md` to propagate contract updates across linked plans.

--- a/scripts/gen_hooks.py
+++ b/scripts/gen_hooks.py
@@ -30,7 +30,7 @@ HOOK_TYPES = {"PreToolUse", "PostToolUse", "Stop", "SubagentStop", "PreCompact"}
 
 
 def _parse_yaml_frontmatter(file_path: str) -> Optional[Dict[str, Any]]:
-    """Extract YAML frontmatter from a markdown file."""
+    """Extract YAML frontmatter from a markdown file. Raises exception on invalid YAML."""
     try:
         with open(file_path, 'r', encoding='utf-8') as f:
             content = f.read()
@@ -52,11 +52,14 @@ def _parse_yaml_frontmatter(file_path: str) -> Optional[Dict[str, Any]]:
 
         # Extract frontmatter
         frontmatter_str = '\n'.join(lines[1:closing_index])
-        frontmatter = yaml.safe_load(frontmatter_str)
+        try:
+            frontmatter = yaml.safe_load(frontmatter_str)
+        except yaml.YAMLError as e:
+            raise ValueError(f"Invalid YAML in {file_path}: {str(e)}")
 
         return frontmatter if isinstance(frontmatter, dict) else None
-    except Exception:
-        # Return None for unparseable files
+    except (IOError, OSError) as e:
+        # File read errors are not frontmatter issues, skip silently
         return None
 
 
@@ -71,6 +74,7 @@ def scanFrontmatter(rootDir: str) -> Dict[str, Any]:
     """
     Flow: scanFrontmatter
     Parse YAML frontmatter from all .md files and extract hook declarations
+    Returns error dict on invalid YAML or other unrecoverable errors.
     """
     results = []
 
@@ -81,7 +85,12 @@ def scanFrontmatter(rootDir: str) -> Dict[str, Any]:
 
         # Recursively scan all .md files
         for md_file in root_path.rglob('*.md'):
-            frontmatter = _parse_yaml_frontmatter(str(md_file))
+            try:
+                frontmatter = _parse_yaml_frontmatter(str(md_file))
+            except ValueError as e:
+                # Invalid YAML detected - return error per plan
+                return {"message": str(e)}
+
             if frontmatter is None:
                 continue
 
@@ -97,8 +106,8 @@ def scanFrontmatter(rootDir: str) -> Dict[str, Any]:
                             sourceFile=str(md_file)
                         )
                         results.append(hook)
-    except Exception:
-        pass
+    except Exception as e:
+        return {"message": f"Error scanning frontmatter: {str(e)}"}
 
     return {"hooks": results}
 
@@ -106,72 +115,87 @@ def scanFrontmatter(rootDir: str) -> Dict[str, Any]:
 def mergeIntoSettings(settingsPath: str, newHooks: List[FrontmatterHook]) -> Dict[str, Any]:
     """
     Flow: mergeIntoSettings
-    Merge new hooks into existing settings.json without deleting existing entries
+    Merge new hooks into existing settings.json without deleting existing entries.
+    Returns error dict on write failure.
     """
+    # Read existing settings or create empty dict
+    settings = {}
+    settings_path = Path(settingsPath)
     try:
-        # Read existing settings or create empty dict
-        settings = {}
-        settings_path = Path(settingsPath)
         if settings_path.exists():
             try:
                 with open(settings_path, 'r', encoding='utf-8') as f:
                     settings = json.load(f)
-            except Exception:
-                settings = {}
+            except json.JSONDecodeError as e:
+                # If settings.json is corrupt, return error
+                return {
+                    "message": f"Corrupt settings.json: {str(e)}"
+                }
+            except IOError as e:
+                # If settings.json can't be read, return error
+                return {
+                    "message": f"Cannot read settings.json: {str(e)}"
+                }
+    except (OSError, IOError) as e:
+        # If we can't even check if file exists (permission issues), return error
+        return {
+            "message": f"Cannot access settings path: {str(e)}"
+        }
 
-        # Get or create hooks key
-        if "hooks" not in settings:
-            settings["hooks"] = {}
+    # Get or create hooks key
+    if "hooks" not in settings:
+        settings["hooks"] = {}
 
-        existing = settings["hooks"]
-        added = 0
-        skipped = 0
+    existing = settings["hooks"]
+    added = 0
+    skipped = 0
 
-        for hook in newHooks:
-            # Create event list if needed
-            if hook.eventType not in existing:
-                existing[hook.eventType] = []
+    for hook in newHooks:
+        # Create event list if needed
+        if hook.eventType not in existing:
+            existing[hook.eventType] = []
 
-            event_list = existing[hook.eventType]
+        event_list = existing[hook.eventType]
 
-            # Build command string
-            command_str = f"bash {hook.command}"
+        # Build command string
+        command_str = f"bash {hook.command}"
 
-            # Check for duplicate
-            already_present = False
-            for matcher_obj in event_list:
-                for entry in matcher_obj.get("hooks", []):
-                    if entry.get("command") == command_str:
-                        already_present = True
-                        break
-                if already_present:
+        # Check for duplicate
+        already_present = False
+        for matcher_obj in event_list:
+            for entry in matcher_obj.get("hooks", []):
+                if entry.get("command") == command_str:
+                    already_present = True
                     break
-
             if already_present:
-                skipped += 1
-            else:
-                # Add new hook entry
-                event_list.append({
-                    "matcher": hook.matcher,
-                    "hooks": [{"type": "command", "command": command_str}]
-                })
-                added += 1
+                break
 
-        # Write updated settings
-        settings["hooks"] = existing
+        if already_present:
+            skipped += 1
+        else:
+            # Add new hook entry
+            event_list.append({
+                "matcher": hook.matcher,
+                "hooks": [{"type": "command", "command": command_str}]
+            })
+            added += 1
+
+    # Write updated settings
+    settings["hooks"] = existing
+    try:
         settings_path.parent.mkdir(parents=True, exist_ok=True)
         with open(settings_path, 'w', encoding='utf-8') as f:
             json.dump(settings, f, indent=2)
+    except IOError as e:
+        return {
+            "message": f"Cannot write settings.json: {str(e)}"
+        }
 
-        return {
-            "addedCount": added,
-            "skippedCount": skipped,
-            "settingsPath": settingsPath
-        }
-    except Exception as e:
-        return {
-            "message": f"Error writing settings: {str(e)}"
-        }
+    return {
+        "addedCount": added,
+        "skippedCount": skipped,
+        "settingsPath": settingsPath
+    }
 
 
 def genHooksCommand(projectDir: str) -> Dict[str, Any]:

--- a/scripts/gen_hooks.py
+++ b/scripts/gen_hooks.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+gen_hooks.py - Scans YAML frontmatter for hook declarations and merges into .claude/settings.json
+
+Flows:
+- scanFrontmatter: Recursively scan .md files for hook declarations in YAML frontmatter
+- mergeIntoSettings: Merge discovered hooks into .claude/settings.json without deleting existing entries
+- genHooksCommand: Orchestrates scan + merge and returns summary to user
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+
+class FrontmatterHook:
+    """Represents a single hook declaration extracted from YAML frontmatter"""
+    def __init__(self, eventType: str, command: str, matcher: str, sourceFile: str):
+        self.eventType = eventType
+        self.command = command
+        self.matcher = matcher
+        self.sourceFile = sourceFile
+
+
+# Hook event types supported by Claude Code
+HOOK_TYPES = {"PreToolUse", "PostToolUse", "Stop", "SubagentStop", "PreCompact"}
+
+
+def _parse_yaml_frontmatter(file_path: str) -> Optional[Dict[str, Any]]:
+    """Extract YAML frontmatter from a markdown file."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        # Check if file starts with ---
+        if not content.startswith('---'):
+            return None
+
+        # Find the closing ---
+        lines = content.split('\n')
+        closing_index = None
+        for i in range(1, len(lines)):
+            if lines[i].strip() == '---':
+                closing_index = i
+                break
+
+        if closing_index is None:
+            return None
+
+        # Extract frontmatter
+        frontmatter_str = '\n'.join(lines[1:closing_index])
+        frontmatter = yaml.safe_load(frontmatter_str)
+
+        return frontmatter if isinstance(frontmatter, dict) else None
+    except Exception:
+        # Return None for unparseable files
+        return None
+
+
+def _ensure_list(value: Any) -> List[Any]:
+    """Convert single value to list, or return list as-is."""
+    if isinstance(value, list):
+        return value
+    return [value] if value is not None else []
+
+
+def scanFrontmatter(rootDir: str) -> Dict[str, Any]:
+    """
+    Flow: scanFrontmatter
+    Parse YAML frontmatter from all .md files and extract hook declarations
+    """
+    results = []
+
+    try:
+        root_path = Path(rootDir)
+        if not root_path.exists():
+            return {"hooks": []}
+
+        # Recursively scan all .md files
+        for md_file in root_path.rglob('*.md'):
+            frontmatter = _parse_yaml_frontmatter(str(md_file))
+            if frontmatter is None:
+                continue
+
+            # Look for hook declarations in frontmatter
+            for key in frontmatter:
+                if key in HOOK_TYPES:
+                    values = _ensure_list(frontmatter[key])
+                    for value in values:
+                        hook = FrontmatterHook(
+                            eventType=key,
+                            command=value,
+                            matcher="",
+                            sourceFile=str(md_file)
+                        )
+                        results.append(hook)
+    except Exception:
+        pass
+
+    return {"hooks": results}
+
+
+def mergeIntoSettings(settingsPath: str, newHooks: List[FrontmatterHook]) -> Dict[str, Any]:
+    """
+    Flow: mergeIntoSettings
+    Merge new hooks into existing settings.json without deleting existing entries
+    """
+    try:
+        # Read existing settings or create empty dict
+        settings = {}
+        settings_path = Path(settingsPath)
+        if settings_path.exists():
+            try:
+                with open(settings_path, 'r', encoding='utf-8') as f:
+                    settings = json.load(f)
+            except Exception:
+                settings = {}
+
+        # Get or create hooks key
+        if "hooks" not in settings:
+            settings["hooks"] = {}
+
+        existing = settings["hooks"]
+        added = 0
+        skipped = 0
+
+        for hook in newHooks:
+            # Create event list if needed
+            if hook.eventType not in existing:
+                existing[hook.eventType] = []
+
+            event_list = existing[hook.eventType]
+
+            # Build command string
+            command_str = f"bash {hook.command}"
+
+            # Check for duplicate
+            already_present = False
+            for matcher_obj in event_list:
+                for entry in matcher_obj.get("hooks", []):
+                    if entry.get("command") == command_str:
+                        already_present = True
+                        break
+                if already_present:
+                    break
+
+            if already_present:
+                skipped += 1
+            else:
+                # Add new hook entry
+                event_list.append({
+                    "matcher": hook.matcher,
+                    "hooks": [{"type": "command", "command": command_str}]
+                })
+                added += 1
+
+        # Write updated settings
+        settings["hooks"] = existing
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(settings_path, 'w', encoding='utf-8') as f:
+            json.dump(settings, f, indent=2)
+
+        return {
+            "addedCount": added,
+            "skippedCount": skipped,
+            "settingsPath": settingsPath
+        }
+    except Exception as e:
+        return {
+            "message": f"Error writing settings: {str(e)}"
+        }
+
+
+def genHooksCommand(projectDir: str) -> Dict[str, Any]:
+    """
+    Flow: genHooksCommand
+    Orchestrate scanFrontmatter + mergeIntoSettings and return summary
+    """
+    try:
+        # Step 1: Scan for frontmatter hooks
+        scan_result = scanFrontmatter(projectDir)
+        if "message" in scan_result:
+            return scan_result
+
+        hooks = scan_result.get("hooks", [])
+
+        # Step 2: Merge into settings.json
+        settings_path = os.path.join(projectDir, ".claude", "settings.json")
+        merge_result = mergeIntoSettings(settings_path, hooks)
+
+        if "message" in merge_result:
+            return merge_result
+
+        added_count = merge_result.get("addedCount", 0)
+        skipped_count = merge_result.get("skippedCount", 0)
+
+        message = f"Added {added_count} hook(s), skipped {skipped_count} duplicate(s)."
+
+        return {
+            "addedCount": added_count,
+            "skippedCount": skipped_count,
+            "settingsPath": settings_path,
+            "message": message
+        }
+    except Exception as e:
+        return {
+            "message": f"Error: {str(e)}"
+        }
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        projectDir = sys.argv[1]
+    else:
+        projectDir = os.getcwd()
+    result = genHooksCommand(projectDir)
+    print(result)

--- a/skills/additive-merge-settings-json/SKILL.md
+++ b/skills/additive-merge-settings-json/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: additive-merge-settings-json
+description: "When writing hooks or other structured data into .claude/settings.json, always read the existing file, merge new entries, and deduplicate — never overwrite the whole file."
+user-invocable: false
+---
+## When to use
+
+Any time a script or agent needs to add entries to `.claude/settings.json` — particularly the `hooks` key — without clobbering existing entries that were placed there by the user, another plugin, or a previous run.
+
+## Steps
+
+1. Read the existing file if it exists; treat a missing file as an empty object `{}`:
+   ```python
+   import json
+   from pathlib import Path
+
+   settings_path = Path(project_dir) / ".claude" / "settings.json"
+   settings = {}
+   if settings_path.exists():
+       with open(settings_path, "r") as f:
+           settings = json.load(f)
+   ```
+
+2. Navigate to the target key without replacing sibling keys:
+   ```python
+   if "hooks" not in settings:
+       settings["hooks"] = {}
+   existing = settings["hooks"]
+   ```
+
+3. Append new entries; deduplicate by the field that uniquely identifies an entry. For hook entries, deduplicate by exact command string across all matcher objects in the event list:
+   ```python
+   command_str = f"bash {hook_path}"
+   already_present = any(
+       entry.get("command") == command_str
+       for matcher_obj in existing.get(event_type, [])
+       for entry in matcher_obj.get("hooks", [])
+   )
+   if not already_present:
+       existing.setdefault(event_type, []).append({
+           "matcher": "",
+           "hooks": [{"type": "command", "command": command_str}]
+       })
+   ```
+
+4. Write the full settings dict back (not just the mutated sub-key):
+   ```python
+   settings["hooks"] = existing
+   settings_path.parent.mkdir(parents=True, exist_ok=True)
+   with open(settings_path, "w") as f:
+       json.dump(settings, f, indent=2)
+   ```
+
+## Notes
+
+- Always write the full `settings` dict back to disk, not just the sub-key you modified. Writing only `settings["hooks"]` to the file would delete all other top-level keys (e.g., `permissions`, `model`).
+- `settings_path.parent.mkdir(parents=True, exist_ok=True)` handles the case where `.claude/` does not yet exist.
+- Deduplication by command string is intentional: the same script path registered twice (e.g., from two `gen-hooks` runs) produces only one entry. If you need multiple different matchers for the same script, they will have different `matcher` values and will both be kept.
+- For corrupted JSON, return an error rather than silently overwriting — a corrupt `settings.json` likely indicates a user error that should not be masked.
+- The canonical implementation of this pattern lives in `scripts/gen_hooks.py` (`mergeIntoSettings` function).

--- a/skills/declare-hooks-in-md-frontmatter/SKILL.md
+++ b/skills/declare-hooks-in-md-frontmatter/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: declare-hooks-in-md-frontmatter
+description: "Users can declare Claude Code hooks (PreToolUse, PostToolUse, Stop, SubagentStop, PreCompact) in YAML frontmatter of any .md file; running /dark-factory:gen-hooks activates them in .claude/settings.json."
+user-invocable: false
+---
+## When to use
+
+Any time you need to attach a shell script to a Claude Code hook event (PreToolUse, PostToolUse, Stop, SubagentStop, PreCompact) and want the declaration to live alongside the skill, agent, or command file that owns it — rather than editing `.claude/settings.json` directly.
+
+Also use this skill when explaining to users how to register their own hook scripts without touching plugin internals.
+
+## Steps
+
+1. In the YAML frontmatter of any `.md` file (skill, agent, command, or any project markdown), add a key matching one of the supported hook event names with the script path as the value:
+
+   ```yaml
+   ---
+   name: my-skill
+   PreToolUse: ./hooks/pre-use.sh
+   PostToolUse: ./hooks/post-use.sh
+   ---
+   ```
+
+2. Multiple hooks of the same type are supported — declare them as a YAML list:
+
+   ```yaml
+   ---
+   name: my-skill
+   PreToolUse:
+     - ./hooks/first.sh
+     - ./hooks/second.sh
+   ---
+   ```
+
+   Note: YAML does not support duplicate keys in a single mapping. Use a list for multiple values under the same event type.
+
+3. Run `/dark-factory:gen-hooks` from the project root. The command scans all `.md` files recursively and merges any discovered hook declarations into `.claude/settings.json` under the `hooks` key.
+
+4. Verify by inspecting `.claude/settings.json` — each declared hook appears as:
+   ```json
+   {
+     "matcher": "",
+     "hooks": [{ "type": "command", "command": "bash ./hooks/pre-use.sh" }]
+   }
+   ```
+   The `matcher` defaults to `""` (matches all tools/events).
+
+## Notes
+
+- The `gen-hooks` command is additive: it never deletes existing hooks in `settings.json`. Re-running it after adding new declarations is safe.
+- Deduplication is by exact command string (`bash <path>`). Running `gen-hooks` twice does not add duplicate entries.
+- This mechanism writes to the user-local `.claude/settings.json` (project-level settings). It is distinct from the plugin-level `hooks/hooks.json` mechanism (see `skills/register-plugin-hooks-in-hooks-json/SKILL.md`), which ships hooks with the installed plugin.
+- The supported hook event names are exactly: `PreToolUse`, `PostToolUse`, `Stop`, `SubagentStop`, `PreCompact`. Any other frontmatter key is ignored by `gen-hooks`.
+- The backing implementation is `scripts/gen_hooks.py`. The slash command is `commands/gen-hooks.md`.

--- a/tests/test_gen_hooks.py
+++ b/tests/test_gen_hooks.py
@@ -1,0 +1,157 @@
+"""
+Unit tests for gen_hooks.py
+
+Tests for three flows:
+- scanFrontmatter: Extract hook declarations from YAML frontmatter
+- mergeIntoSettings: Merge hooks into settings.json without deleting existing entries
+- genHooksCommand: Orchestrate scan and merge
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scripts.gen_hooks import FrontmatterHook, scanFrontmatter, mergeIntoSettings, genHooksCommand
+
+
+class TestScanFrontmatter:
+    """Tests for scanFrontmatter flow"""
+
+    def test_scanFrontmatter_success(self):
+        """Plan path: scanFrontmatter.success"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            md_file = Path(tmpdir) / "test.md"
+            md_file.write_text("""---
+name: test
+PreToolUse: ./hooks/pre-use.sh
+---
+# Test""")
+            result = scanFrontmatter(tmpdir)
+            assert result is not None
+            assert "hooks" in result
+            assert len(result["hooks"]) > 0
+
+    def test_scanFrontmatter_no_md_files(self):
+        """Plan path: scanFrontmatter.no-md-files"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scanFrontmatter(tmpdir)
+            assert result is not None
+            assert "hooks" in result
+            assert len(result["hooks"]) == 0
+
+    def test_scanFrontmatter_invalid_yaml(self):
+        """Plan path: scanFrontmatter.invalid-yaml"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            md_file = Path(tmpdir) / "test.md"
+            md_file.write_text("""---
+name: test
+invalid: [
+---
+# Test""")
+            result = scanFrontmatter(tmpdir)
+            # Should either return empty or error, not crash
+            assert result is not None
+
+
+class TestMergeIntoSettings:
+    """Tests for mergeIntoSettings flow"""
+
+    def test_mergeIntoSettings_success(self):
+        """Plan path: mergeIntoSettings.success"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_path = Path(tmpdir) / "settings.json"
+            existing_settings = {"hooks": {"PreToolUse": []}}
+            settings_path.write_text(json.dumps(existing_settings))
+
+            new_hooks = [FrontmatterHook("PreToolUse", "./hooks/pre-use.sh", "", "test.md")]
+            result = mergeIntoSettings(str(settings_path), new_hooks)
+
+            assert result is not None
+            assert "addedCount" in result
+            assert result["addedCount"] >= 0
+
+    def test_mergeIntoSettings_settings_missing(self):
+        """Plan path: mergeIntoSettings.settings-missing"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_path = Path(tmpdir) / "settings.json"
+
+            new_hooks = [FrontmatterHook("PreToolUse", "./hooks/pre-use.sh", "", "test.md")]
+            result = mergeIntoSettings(str(settings_path), new_hooks)
+
+            assert result is not None
+            assert settings_path.exists()
+
+    def test_mergeIntoSettings_all_duplicates(self):
+        """Plan path: mergeIntoSettings.all-duplicates"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_path = Path(tmpdir) / "settings.json"
+            existing_settings = {
+                "hooks": {
+                    "PreToolUse": [
+                        {"matcher": "", "hooks": [{"type": "command", "command": "bash ./hooks/pre-use.sh"}]}
+                    ]
+                }
+            }
+            settings_path.write_text(json.dumps(existing_settings))
+
+            new_hooks = [FrontmatterHook("PreToolUse", "./hooks/pre-use.sh", "", "test.md")]
+            result = mergeIntoSettings(str(settings_path), new_hooks)
+
+            assert result is not None
+            assert "skippedCount" in result
+            assert result["addedCount"] == 0
+
+    def test_mergeIntoSettings_write_error(self):
+        """Plan path: mergeIntoSettings.write-error"""
+        # Use a path that's not writable
+        settings_path = "/root/nonexistent/settings.json"
+        new_hooks = [FrontmatterHook("PreToolUse", "./hooks/pre-use.sh", "", "test.md")]
+
+        # Should handle error gracefully or return error
+        try:
+            result = mergeIntoSettings(settings_path, new_hooks)
+            # If no exception, result should indicate error
+            assert result is not None
+        except (OSError, IOError):
+            # Also acceptable - function can raise
+            pass
+
+
+class TestGenHooksCommand:
+    """Tests for genHooksCommand flow"""
+
+    def test_genHooksCommand_success(self):
+        """Plan path: genHooksCommand.success"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a .md file with hook declaration
+            md_file = Path(tmpdir) / "test.md"
+            md_file.write_text("""---
+name: test
+PreToolUse: ./hooks/pre-use.sh
+---
+# Test""")
+
+            result = genHooksCommand(tmpdir)
+
+            assert result is not None
+            assert "addedCount" in result or "message" in result
+
+    def test_genHooksCommand_nothing_to_add(self):
+        """Plan path: genHooksCommand.nothing-to-add"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = genHooksCommand(tmpdir)
+
+            assert result is not None
+            # Should return result even if nothing added
+            assert "addedCount" in result or "message" in result
+
+    def test_genHooksCommand_error(self):
+        """Plan path: genHooksCommand.error"""
+        # Use invalid directory
+        result = genHooksCommand("/nonexistent/directory")
+
+        # Should handle error gracefully
+        assert result is not None

--- a/tests/test_gen_hooks.py
+++ b/tests/test_gen_hooks.py
@@ -52,8 +52,9 @@ invalid: [
 ---
 # Test""")
             result = scanFrontmatter(tmpdir)
-            # Should either return empty or error, not crash
+            # Should return error message per plan
             assert result is not None
+            assert "message" in result, "Invalid YAML should return error message"
 
 
 class TestMergeIntoSettings:
@@ -110,14 +111,10 @@ class TestMergeIntoSettings:
         settings_path = "/root/nonexistent/settings.json"
         new_hooks = [FrontmatterHook("PreToolUse", "./hooks/pre-use.sh", "", "test.md")]
 
-        # Should handle error gracefully or return error
-        try:
-            result = mergeIntoSettings(settings_path, new_hooks)
-            # If no exception, result should indicate error
-            assert result is not None
-        except (OSError, IOError):
-            # Also acceptable - function can raise
-            pass
+        # Should return error dict with message (not raise exception)
+        result = mergeIntoSettings(settings_path, new_hooks)
+        assert result is not None
+        assert "message" in result, "Write error should return error message dict"
 
 
 class TestGenHooksCommand:


### PR DESCRIPTION
## Description

# YAML-Declared Hooks in gen-hooks Command

## System Intent

- What is being built: A new `/dark-factory:gen-hooks` slash command (and backing command file) that scans all skill, agent, and command `.md` files for hook declarations in their YAML frontmatter (e.g., `PreToolUse: ./commit.sh`) and writes those hooks into `.claude/settings.json` — additively, without disturbing any pre-existing hooks.
- Primary consumer(s): Plugin users who want to attach custom shell scripts to Claude Code hook events (PreToolUse, PostToolUse, Stop, SubagentStop, PreCompact, etc.) by declaring them directly in the YAML frontmatter of a skill or agent file they own, then running `gen-hooks` to activate them.
- Boundary (black-box scope only): `gen-hooks` reads `.md` frontmatter and writes `.claude/settings.json`. It does not modify plugin-level `hooks/hooks.json`, does not delete existing hooks entries from `settings.json`, and does not execute the declared scripts.

### Supported hook types

All hook events documented at https://code.claude.com/docs/en/hooks:
- `PreToolUse`
- `PostToolUse`
- `Stop`
- `SubagentStop`
- `PreCompact`

### YAML frontmatter syntax

Users declare hooks inside the `---` frontmatter block of any `.md` file anywhere in the project directory (scanned recursively):

```yaml
---
name: my-skill
PreToolUse: ./hooks/pre-use.sh
PostToolUse: ./hooks/post-use.sh
PreToolUse: ./hooks/pre-use-2.sh   # second entry — both are registered
---
```

Multiple declarations of the same hook key are allowed; each produces a separate hook entry in `settings.json`.

The `matcher` field defaults to `""` (matches everything) unless the user also declares `matcher: <value>` directly below the hook line (exact syntax TBD in flows).

### Output target

Hooks are written to `.claude/settings.json` under the `hooks` key, following the same structure Claude Code uses natively:

```json
{
  "hooks": {
    "PreToolUse": [
      { "matcher": "", "hooks": [{ "type": "command", "command": "bash ./hooks/pre-use.sh" }] }
    ]
  }
}
```

Existing entries are preserved; only new entries derived from the YAML scan are appended (deduplication by exact command string).

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [x] Stage 3 Logs + Deployment approved or skipped

## Files Changed

- `commands/gen-hooks.md` — new `/dark-factory:gen-hooks` slash command
- `scripts/gen_hooks.py` — scans all `.md` files recursively for YAML frontmatter hook declarations and merges them into `.claude/settings.json` without deleting existing hooks
- `tests/test_gen_hooks.py` — 10 unit tests, all passing
- `docs/docs/gen-hooks.md` — new system documentation
- `docs/docs/commands.md` — updated to include gen-hooks
- `skills/declare-hooks-in-md-frontmatter/SKILL.md` — new skill
- `skills/additive-merge-settings-json/SKILL.md` — new skill

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
rootdir: /home/lewibs/github/dark_factory/dark_factory-yaml-hooks-in-gen-hooks
collecting ... collected 10 items

tests/test_gen_hooks.py::TestScanFrontmatter::test_scanFrontmatter_success PASSED [ 10%]
tests/test_gen_hooks.py::TestScanFrontmatter::test_scanFrontmatter_no_md_files PASSED [ 20%]
tests/test_gen_hooks.py::TestScanFrontmatter::test_scanFrontmatter_invalid_yaml PASSED [ 30%]
tests/test_gen_hooks.py::TestMergeIntoSettings::test_mergeIntoSettings_success PASSED [ 40%]
tests/test_gen_hooks.py::TestMergeIntoSettings::test_mergeIntoSettings_settings_missing PASSED [ 50%]
tests/test_gen_hooks.py::TestMergeIntoSettings::test_mergeIntoSettings_all_duplicates PASSED [ 60%]
tests/test_gen_hooks.py::TestMergeIntoSettings::test_mergeIntoSettings_write_error PASSED [ 70%]
tests/test_gen_hooks.py::TestGenHooksCommand::test_genHooksCommand_success PASSED [ 80%]
tests/test_gen_hooks.py::TestGenHooksCommand::test_genHooksCommand_nothing_to_add PASSED [ 90%]
tests/test_gen_hooks.py::TestGenHooksCommand::test_genHooksCommand_error PASSED [100%]

============================== 10 passed in 0.03s ==============================
```

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
