### PR TITLE
refactor(hooks): move SubagentStop declarations into agent YAML frontmatter

### DIFF
--- a/agents/featurework/execution/agents/implementation-agent.md
+++ b/agents/featurework/execution/agents/implementation-agent.md
@@ -6,6 +6,7 @@ tools: Read, Write, Edit, Bash, Glob, Agent, PushNotification, AskUserQuestion
 skills: deviation-protocol, logging
 model: sonnet
 allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(bash *), Bash(mkdir -p *), Bash(find *), Bash(grep -r *)
+SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
 ---
 
 You are the implementation-agent. Your job is Phase 3 of plan execution: implement each flow from the flows checklist one at a time, run its tests, and confirm they pass before moving on.

--- a/agents/featurework/execution/agents/skeleton-agent.md
+++ b/agents/featurework/execution/agents/skeleton-agent.md
@@ -5,6 +5,7 @@ description: Phase 1 of plan execution. Reads a plan file, builds a files checkl
 tools: Read, Write, Edit, Bash, Glob
 model: sonnet
 allowed-tools: Bash(mkdir -p *), Bash(touch *), Bash(find *)
+SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
 ---
 
 You are the skeleton-agent. Your job is Phase 1 of plan execution: read the plan, identify every file that needs to exist, and create them all as skeletons with no implementation logic.

--- a/agents/featurework/execution/agents/testing-agent.md
+++ b/agents/featurework/execution/agents/testing-agent.md
@@ -5,6 +5,7 @@ description: Phase 2 of plan execution. Reads a plan file, builds a flows checkl
 tools: Read, Write, Edit, Bash, Glob
 model: sonnet
 allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(bash *), Bash(find *)
+SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
 ---
 
 You are the testing-agent. Your job is Phase 2 of plan execution: read every flow in the plan, write tests for each path row, and confirm all new tests fail before returning.

--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -7,6 +7,7 @@ skills: create-pr
 commands: ci-watch-runner, comment-resolution-runner
 allowed-tools: Bash(gh pr create *), Bash(gh pr view *), Bash(gh api graphql *), Bash(git -C * push *), Bash(git -C * add *), Bash(git -C * commit *), Bash(git -C * status *), Bash(git -C * log *), Bash(cat > /tmp/pr-body.md *)
 model: sonnet
+SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pr-agent-cleanup-hook.sh"
 ---
 
 You are the pr-agent. Take a fix already applied to the working tree and shepherd it through the PR lifecycle: open, watch CI, resolve review comments. Stop once CI is green and all threads are resolved — do not merge.

--- a/docs/docs/brain-hooks.md
+++ b/docs/docs/brain-hooks.md
@@ -244,7 +244,7 @@ post-tool-use-hook.sh:
 
 ### Flow: `plugin-hooks`
 
-- Core files: `hooks/hooks.json`, `plugin.json`
+- Core files: `hooks/hooks.json`, `plugin.json`, `agents/featurework/execution/agents/skeleton-agent.md`, `agents/featurework/execution/agents/testing-agent.md`, `agents/featurework/execution/agents/implementation-agent.md`, `agents/pr/agents/pr-agent.md`
 - Test files: N/A
 
 #### Types
@@ -253,6 +253,8 @@ post-tool-use-hook.sh:
 HookConfig {
   // hooks/hooks.json — registered in plugin.json as "hooks": "./hooks/hooks.json"
   // All script paths use ${CLAUDE_PLUGIN_ROOT} so hooks work from any install location.
+  // SubagentStop hooks are NOT declared here — they are declared in YAML frontmatter
+  // of individual agent .md files (skeleton-agent, testing-agent, implementation-agent, pr-agent).
   hooks: {
     PreToolUse: [
       {
@@ -269,6 +271,19 @@ HookConfig {
     Stop: [{ matcher: "", hooks: [{ type: "command", command: string }] }]
   }
 }
+
+AgentFrontmatterSubagentStop {
+  // Declared in YAML frontmatter of individual agent .md files.
+  // Claude Code reads this field and fires the command when the agent's subagent stops.
+  // skeleton-agent.md:
+  SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
+  // testing-agent.md:
+  SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
+  // implementation-agent.md:
+  SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
+  // pr-agent.md:
+  SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pr-agent-cleanup-hook.sh"
+}
 ```
 
 #### Paths
@@ -279,6 +294,8 @@ HookConfig {
 | `hooks.pre-agent` | Agent tool call | modified prompt with brain context + start_ms written to brain.json | happy path | PreToolUse hook matched to "Agent" tool; script path uses `${CLAUDE_PLUGIN_ROOT}` |
 | `hooks.post-agent` | Agent tool result | brain.json updated (patch merge + phase flags + metrics accumulation) | happy path | PostToolUse hook matched to "Agent" tool; script path uses `${CLAUDE_PLUGIN_ROOT}` |
 | `hooks.stop-cleanup` | Claude stop event | cleanup-worktree.sh called if DARK_FACTORY_WORK_DIR and DARK_FACTORY_TASK_NAME set | happy path | Stop hook fires on session end; script path uses `${CLAUDE_PLUGIN_ROOT}` |
+| `hooks.subagent-stop-commit` | skeleton-agent, testing-agent, or implementation-agent subagent stops | commit-on-subagent-stop.sh runs, committing staged changes | happy path | Declared via `SubagentStop` YAML frontmatter in each agent .md; not in hooks.json |
+| `hooks.subagent-stop-pr-cleanup` | pr-agent subagent stops | pr-agent-cleanup-hook.sh runs | happy path | Declared via `SubagentStop` YAML frontmatter in pr-agent.md; not in hooks.json |
 
 ---
 
@@ -551,4 +568,4 @@ Each test creates an isolated `tempfile.TemporaryDirectory`, writes a minimal `b
   pytest tests/test_generate_checklist.py -v
   pytest tests/test_phase_order_enforcement_hook.py -v
   ```
-- Notes: Hook scripts must be executable (`chmod +x`). Hooks are registered via `hooks/hooks.json` (referenced in `plugin.json`) and are activated automatically when the plugin is installed — no manual `.claude/settings.json` edits needed. All script paths in `hooks/hooks.json` use `${CLAUDE_PLUGIN_ROOT}` so hooks resolve correctly from any install location. `DARK_FACTORY_WORK_DIR` must be exported by dark-factory-agent before any Agent tool calls — if it is unset, both hooks are no-ops. `scripts/generate_checklist.sh` must be executable and accessible — the pre-tool-use-hook resolves its path relative to the hook's own directory using `BASH_SOURCE[0]`. `phase-order-enforcement-hook.sh` runs before `pre-tool-use-hook.sh` in the PreToolUse chain and is a no-op for agents not in its allowlist. All transient files managed by these hooks (`brain.json`, `brain.json.lock`, `brain-patch.json`, `flows-state.json`) are listed in the root `.gitignore` and are never committed to git.
+- Notes: Hook scripts must be executable (`chmod +x`). Hooks are registered via `hooks/hooks.json` (referenced in `plugin.json`) and are activated automatically when the plugin is installed — no manual `.claude/settings.json` edits needed. All script paths in `hooks/hooks.json` use `${CLAUDE_PLUGIN_ROOT}` so hooks resolve correctly from any install location. `DARK_FACTORY_WORK_DIR` must be exported by dark-factory-agent before any Agent tool calls — if it is unset, both hooks are no-ops. `scripts/generate_checklist.sh` must be executable and accessible — the pre-tool-use-hook resolves its path relative to the hook's own directory using `BASH_SOURCE[0]`. `phase-order-enforcement-hook.sh` runs before `pre-tool-use-hook.sh` in the PreToolUse chain and is a no-op for agents not in its allowlist. All transient files managed by these hooks (`brain.json`, `brain.json.lock`, `brain-patch.json`, `flows-state.json`) are listed in the root `.gitignore` and are never committed to git. `SubagentStop` hooks for skeleton-agent, testing-agent, implementation-agent, and pr-agent are declared in the `SubagentStop` YAML frontmatter field of each agent's `.md` file — they are not registered in `hooks/hooks.json`. This means each agent carries its own stop-hook declaration co-located with its instructions, rather than relying on a central matcher pattern in hooks.json.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,26 +1,6 @@
 {
   "description": "dark-factory plugin hooks — brain state management for agent orchestration",
   "hooks": {
-    "SubagentStop": [
-      {
-        "matcher": "skeleton-agent|testing-agent|implementation-agent",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh\""
-          }
-        ]
-      },
-      {
-        "matcher": "pr-agent",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pr-agent-cleanup-hook.sh\""
-          }
-        ]
-      }
-    ],
     "Stop": [
       {
         "matcher": "",

--- a/skills/register-plugin-hooks-in-hooks-json/SKILL.md
+++ b/skills/register-plugin-hooks-in-hooks-json/SKILL.md
@@ -5,7 +5,9 @@ user-invocable: false
 ---
 ## When to use
 
-Any time you add, remove, or modify a Claude Code PreToolUse, PostToolUse, Stop, or SubagentStop hook that belongs to the dark-factory plugin — as opposed to a project-local hook that a user configures themselves.
+Any time you add, remove, or modify a Claude Code PreToolUse, PostToolUse, or Stop hook that belongs to the dark-factory plugin — as opposed to a project-local hook that a user configures themselves.
+
+**SubagentStop hooks are NOT declared in hooks.json.** They are declared in the YAML frontmatter of the individual agent `.md` file. See the `subagent-stop-in-agent-frontmatter` skill for how to declare them.
 
 ## Steps
 
@@ -36,4 +38,4 @@ Any time you add, remove, or modify a Claude Code PreToolUse, PostToolUse, Stop,
 - `.claude/settings.json` hooks use bare relative paths (e.g. `bash agents/dark-factory/scripts/foo.sh`) which only work when the CWD matches the plugin repo root. `hooks/hooks.json` hook commands using `${CLAUDE_PLUGIN_ROOT}` resolve correctly regardless of CWD.
 - If you need a hook for a one-project use case (not part of the plugin), use `.claude/settings.json` as normal — this rule applies only to hooks that are part of the plugin itself.
 - After modifying `hooks/hooks.json`, reinstall the plugin with `/dark-factory:install` to pick up the changes.
-- For `SubagentStop` hooks: the matcher is a regex matched against the subagent tool name. Use a pipe-separated pattern (e.g. `"skeleton-agent|testing-agent"`) to match multiple agents in one entry. The hook script receives the matched agent name as plain text on stdin — not JSON. See the `subagent-stop-hook-stdin-format` skill for details.
+- `SubagentStop` hooks are NOT in `hooks/hooks.json`. They live in the YAML frontmatter of the individual agent `.md` file as a `SubagentStop:` key. This keeps each agent's stop-hook co-located with its instructions rather than relying on a central regex matcher. See the `subagent-stop-in-agent-frontmatter` skill for the correct approach.

--- a/skills/subagent-stop-hook-stdin-format/SKILL.md
+++ b/skills/subagent-stop-hook-stdin-format/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: false
 ---
 ## When to use
 
-When writing a bash script that is registered as a `SubagentStop` hook in `hooks/hooks.json`. Use this to correctly read which agent fired the hook and to avoid confusing the plain-text stdin format with the JSON format used by other hook types.
+When writing a bash script that is wired as a `SubagentStop` hook for an agent. Use this to correctly read which agent fired the hook and to avoid confusing the plain-text stdin format with the JSON format used by other hook types.
 
 ## Steps
 
@@ -39,24 +39,20 @@ When writing a bash script that is registered as a `SubagentStop` hook in `hooks
    }
    ```
 
-4. Register the hook with a pipe-separated matcher in `hooks/hooks.json` to match multiple agents:
-   ```json
-   "SubagentStop": [
-     {
-       "matcher": "skeleton-agent|testing-agent|implementation-agent",
-       "hooks": [
-         {
-           "type": "command",
-           "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/your-hook.sh\""
-         }
-       ]
-     }
-   ]
+4. Declare the hook in the agent's YAML frontmatter (NOT in `hooks/hooks.json`). Add a `SubagentStop:` key to the frontmatter of the agent `.md` file:
+   ```yaml
+   ---
+   name: skeleton-agent
+   description: "..."
+   tools: Read, Write, Edit, Bash
+   SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/your-hook.sh"
+   ---
    ```
+   This keeps the hook co-located with the agent's instructions. Each agent that needs a SubagentStop hook declares it directly in its own frontmatter rather than via a central regex matcher in `hooks/hooks.json`. See the `subagent-stop-in-agent-frontmatter` skill for full details on this pattern.
 
 ## Notes
 
-- The matcher value is a regex pattern matched against the subagent tool name. Pipe-separated alternatives work correctly.
 - The plain-text stdin format contrasts with `PreToolUse` and `PostToolUse` hooks, which receive the full tool call input as JSON on stdin. Do not call `jq` or `json.loads()` on SubagentStop stdin.
+- SubagentStop hooks are no longer declared in `hooks/hooks.json` with a regex matcher. They are declared per-agent in YAML frontmatter. This means each hook script is no longer responsible for branching on multiple agent names — one script per agent (or shared scripts that don't need to branch) is the expected shape.
 - In tests, pass the agent name as a plain string (not JSON-encoded) to the subprocess `input=` parameter. See the `test-bash-hook-scripts-with-pytest` skill for the test harness pattern.
 - `DARK_FACTORY_WORK_DIR` is still available as an environment variable in SubagentStop hooks, just as in other hook types.

--- a/skills/subagent-stop-in-agent-frontmatter/SKILL.md
+++ b/skills/subagent-stop-in-agent-frontmatter/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: subagent-stop-in-agent-frontmatter
+description: "SubagentStop hooks for dark-factory agents are declared in the YAML frontmatter of the agent's .md file, not in hooks/hooks.json — each agent carries its own stop-hook declaration."
+user-invocable: false
+---
+## When to use
+
+Whenever you need to wire a SubagentStop hook to a dark-factory agent (any file under `agents/**/*.md`). Also use this when you see a SubagentStop entry in `hooks/hooks.json` — that is the old pattern and should be migrated.
+
+## Steps
+
+1. Open the target agent's `.md` file (e.g., `agents/featurework/execution/agents/skeleton-agent.md`).
+
+2. In the YAML frontmatter block (between the `---` delimiters), add a `SubagentStop:` key whose value is the shell command to run:
+   ```yaml
+   ---
+   name: skeleton-agent
+   description: "..."
+   tools: Read, Write, Edit, Bash
+   SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
+   ---
+   ```
+   Use `${CLAUDE_PLUGIN_ROOT}` as the prefix for all plugin script paths so the hook resolves correctly from any install location.
+
+3. If multiple agents need the same hook script, add the identical `SubagentStop:` line to each agent's frontmatter independently. Do NOT add a single shared entry to `hooks/hooks.json`.
+
+4. If two agents need different hook scripts, each gets its own `SubagentStop:` line pointing to its own script.
+
+5. Do NOT add a `SubagentStop` entry to `hooks/hooks.json`. That file is for `PreToolUse`, `PostToolUse`, and `Stop` global hooks only.
+
+6. After editing, reinstall the plugin with `/dark-factory:install` to pick up the frontmatter changes.
+
+## Notes
+
+- The `SubagentStop:` YAML field is read directly by Claude Code from the agent frontmatter. It is not a custom dark-factory extension — it is a first-class Claude Code feature for per-agent stop hooks.
+- Keeping the hook declaration in the agent's own file means the hook is visible alongside the agent's instructions, tools, and skills, rather than being hidden in a central hooks.json with a regex matcher.
+- The hook script still receives the agent name as plain text on stdin (not JSON). See the `subagent-stop-hook-stdin-format` skill for how to read it. However, since each agent now has its own dedicated hook, branching on agent name inside the script is no longer necessary for the common case.
+- The existing scripts (`commit-on-subagent-stop.sh` and `pr-agent-cleanup-hook.sh`) were not changed during this migration — only where the hook is declared changed.
+- `${CLAUDE_PLUGIN_ROOT}` is available in the hook execution environment when the plugin is properly installed. Do not hardcode absolute paths.


### PR DESCRIPTION
## Description

Task: move SubagentStop hook declarations from hooks/hooks.json into YAML frontmatter of skeleton-agent.md, testing-agent.md, implementation-agent.md, and pr-agent.md

### Changes

- `agents/featurework/execution/agents/skeleton-agent.md` — SubagentStop YAML key added
- `agents/featurework/execution/agents/testing-agent.md` — SubagentStop YAML key added
- `agents/featurework/execution/agents/implementation-agent.md` — SubagentStop YAML key added
- `agents/pr/agents/pr-agent.md` — SubagentStop YAML key added
- `hooks/hooks.json` — SubagentStop block removed (Stop/PreToolUse/PostToolUse remain)
- `docs/docs/brain-hooks.md` — updated to document the new per-agent frontmatter pattern
- `skills/subagent-stop-in-agent-frontmatter/SKILL.md` — new skill documenting how to declare SubagentStop in agent frontmatter
- `skills/register-plugin-hooks-in-hooks-json/SKILL.md` — updated to clarify SubagentStop is not registered in hooks.json
- `skills/subagent-stop-hook-stdin-format/SKILL.md` — updated

### Motivation

Previously SubagentStop hooks were declared in `hooks/hooks.json` using a matcher pattern to match individual agents. This approach couples the hook configuration to a central file and requires knowledge of each agent's name at registration time.

By moving SubagentStop declarations into the YAML frontmatter of each agent's `.md` file, the hook is co-located with the agent's instructions. This is more maintainable: adding a new agent that needs a SubagentStop hook only requires adding the key to that agent's frontmatter, with no changes to the central `hooks/hooks.json`.

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
