### PR TITLE
docs(agents): add individual docs for 9 manufacture pipeline agents

### DIFF
--- a/docs/docs/code-review-orchestrator-agent.md
+++ b/docs/docs/code-review-orchestrator-agent.md
@@ -1,0 +1,163 @@
+# code-review-orchestrator-agent
+
+**Role**: Orchestrator for automated code review process.
+
+**Model**: Haiku (lightweight orchestration and state management).
+
+**User-Invocable**: No (invoked by dark-factory-agent after feature implementation).
+
+## Overview
+
+The code-review-orchestrator-agent manages the full automated code review workflow. It spawns two parallel reviewers (high-level and low-level), collects their feedback into an issues list, then loops a resolver agent until all issues are resolved. The orchestrator ensures that review cycles are complete before the code proceeds to documentation updates and PR.
+
+## Input
+
+- `planFilePath` (string, required) — Absolute path to the approved plan file (used for context by reviewers)
+- `codePath` (string, required) — Directory path or branch name containing the code to review
+
+## Orchestration Flow (6 Steps)
+
+### Step 1: Initialize Issues File
+
+Uses `manage-issues-file` command with `operation: "create"`:
+- Creates `<codePath>/issues.md` with empty review points array
+- Ready for reviewers to append findings
+
+### Step 2: Spawn Parallel Reviewers
+
+Spawns two reviewers in parallel:
+
+**High-Level Review Agent**:
+- Inputs: `planFilePath`, `codePath`
+- Checks: architectural decisions, design patterns, code organization, adherence to plan
+
+**Low-Level Review Agent**:
+- Input: `codePath`
+- Checks: code style, readability, potential bugs, test coverage, performance
+
+Both append their findings to `issues.md` as checklist items.
+
+### Step 3: Wait for Reviewers & Handle Errors
+
+1. Waits for both reviewers to complete
+2. If **either reviewer returns an error**:
+   - Surfaces the error immediately
+   - **Does NOT start the resolver loop**
+   - Halts orchestration
+3. If **both succeed**:
+   - Proceeds to Step 4 (resolver loop)
+
+### Step 4: Resolver Loop
+
+Enters iterative resolution loop:
+
+1. Spawns `resolver-agent` with:
+   - `issuesFilePath: <codePath>/issues.md` (absolute path)
+
+2. Waits for resolver to return
+
+3. **If resolver returns an error**:
+   - Surfaces error and halts (loop exits)
+
+4. **If resolver returns `anyRemaining: false`**:
+   - All issues resolved; exit loop
+   - Proceed to Step 5
+
+5. **If resolver returns `anyRemaining: true`**:
+   - Issues remain unchecked
+   - **Re-enter the loop** (re-spawn resolver)
+   - Continue until `anyRemaining: false` or error
+
+**Loop guard**: If resolver loop runs more than **10 iterations** without clearing all items, halt with error describing stuck items.
+
+### Step 5: Delete Issues File
+
+Uses `manage-issues-file` command with `operation: "delete"`:
+- Removes `<codePath>/issues.md` (cleanup)
+- Confirms successful completion
+
+### Step 6: Return Success
+
+Returns:
+```json
+{
+  "status": "complete"
+}
+```
+
+## Happy Paths
+
+### orchestrateReview.success
+- Both reviewers complete successfully
+- Resolver loop runs until `anyRemaining: false`
+- All issues resolved
+- issues.md deleted
+
+### orchestrateReview.no-issues
+- Both reviewers find no issues (empty checklist)
+- Resolver sees empty checklist, no-ops
+- issues.md deleted immediately
+- Returns success
+
+## Error Paths
+
+### orchestrateReview.reviewer-error
+- One or both parallel reviewers return an error
+- Orchestrator surfaces error without starting resolver
+- issues.md may be partially filled
+
+### orchestrateReview.resolver-loop-error
+- Resolver returns an error on any iteration
+- Orchestrator halts and surfaces the error
+- issues.md remains for investigation
+
+### orchestrateReview.resolver-loop-stuck
+- Resolver loop runs >10 iterations
+- Some items still unchecked
+- Orchestrator halts with error describing stuck items
+
+## Key Design Rules
+
+1. **Parallel reviewer spawn** — Both reviewers run simultaneously to save time
+2. **Never skip resolver if reviewer fails** — Do not start resolver if either reviewer errored
+3. **Loop guard at 10 iterations** — Prevent infinite loops on unresolvable issues
+4. **Always delete issues.md on success** — Clean up before returning to caller
+5. **Surface all errors** — Never suppress reviewer or resolver errors
+
+## Dependencies
+
+- **Commands**: manage-issues-file (create, delete operations)
+- **Sub-agents**: high-level-review-agent, low-level-review-agent, resolver-agent
+
+## Tools
+
+- Read, Write, Edit, Bash, Agent, Command
+
+## Return Value
+
+**Success**:
+```json
+{
+  "status": "complete"
+}
+```
+
+**Error**:
+```json
+{
+  "message": "<error description>"
+}
+```
+
+## Artifacts
+
+- `<codePath>/issues.md` — Created during review, deleted after resolution
+  - Format: markdown checklist of review points
+  - Example: `- [ ] Function too long (line 45-67 in main.py)`
+
+## Integration with dark-factory-agent
+
+1. Called after feature-agent completes (or debugger/repair finish)
+2. Must complete before update-documentation-agent
+3. If returns error: dark-factory-agent halts, cleans up, reports failure
+4. If returns success: dark-factory-agent continues to documentation and PR

--- a/docs/docs/dark-factory-agent.md
+++ b/docs/docs/dark-factory-agent.md
@@ -1,0 +1,135 @@
+# dark-factory-agent
+
+**Role**: Top-level dark-factory orchestrator and entry point for all manufacturing tasks.
+
+**Model**: Haiku (lightweight state/routing only, no heavy reasoning).
+
+**User-Invocable**: Yes (primary command-line entry point).
+
+## Overview
+
+The dark-factory-agent is the single entry point for all autonomous feature work, bug debugging, fix flows, and repair operations. It orchestrates an entire unit of work end-to-end: classifying the task, isolating work in a fresh directory, delegating to the appropriate worker agent, reviewing results, keeping documentation current, opening a PR, and cleaning up.
+
+The agent never writes or modifies code itself — it delegates entirely to specialized workers based on task classification.
+
+## Input
+
+- `taskDescription` — Verbatim user request (what to build, fix, or investigate)
+- `taskName` (optional) — Short slug for the work directory (e.g. `add-oauth`, `fix-login-bug`). If not provided, derived from taskDescription (lowercase, hyphens, ≤30 chars)
+
+## Orchestration Flow (12 Steps)
+
+### Step 1: Classify Task
+- Delegates to `task-classifier` skill
+- Skill determines if task is:
+  - `"feature"` — New feature or enhancement
+  - `"fix-flow"` — Known-broken integration flow
+  - `"debugger"` — Non-obvious/state-dependent bug
+  - `"repair"` — Lightweight targeted change
+- If classification is ambiguous: sends PushNotification, awaits AskUserQuestion response
+
+### Step 2: Prep Isolated Work Directory
+- Calls bash: `prep-feature-dir.sh <taskName>`
+- Creates isolated git worktree for the task
+- Stops immediately if worktree creation fails (no cleanup needed yet)
+- Extracts `WORK_DIR` from script output
+
+### Step 3: Create brain.json State File
+- Delegates to `brain-state-manager` skill with `operation: "create"`
+- Initializes state tracking for the entire task lifecycle
+- Stores: taskDescription, taskName, WORK_DIR, PROJECT_DIR, classification
+- Stops if brain creation fails
+
+### Step 4: Route to Worker Agent
+Routes based on classification:
+- **"feature"** → `feature-agent` (multi-turn loop: handles planning, question/answer exchanges until `status: "done"`)
+  - Handles planning phases, diagram generation, flow approval, and execution
+  - May return `status: "question"` requiring user feedback (PushNotification + AskUserQuestion)
+  - May return `status: "hard-stop"` (triggers cleanup before halting)
+  - Returns `status: "done"` when feature implementation complete
+  
+- **"fix-flow"** → `fix-flow-orchestrator`
+  - Investigates broken flow, generates fix scripts, applies targeted fixes
+  
+- **"debugger"** → `debugger-agent`
+  - Systematic debugging for non-obvious bugs
+  
+- **"repair"** → `repair-agent`
+  - Lightweight, targeted fixes without full plan file
+
+If non-feature worker returns error or hard-stop: runs cleanup, reports error, STOPS
+
+### Step 5: Branch-Drift Guard
+- Verifies feature branch has commits ahead of main
+- Bash: `git -C "$WORK_DIR" log main..feature/<taskName> --oneline`
+- Halts with error if no new commits found (cleanup runs first)
+
+### Step 6: Read Plan File Path
+- Delegates to `brain-state-manager` with `operation: "read"`
+- Extracts `planFilePath` from brain.json (may be null for debugger/repair routes)
+
+### Step 7: Code Review
+- Invokes `code-review-orchestrator-agent` with:
+  - `planFilePath` (or `"Task: " + taskDescription` if null)
+  - `codePath: WORK_DIR`
+- Ensures all changes meet review standards
+- Halts with cleanup if review fails
+
+### Step 8: Update Documentation
+- Invokes `update-documentation-agent` with `planFilePath`
+- Updates or creates doc files to reflect implemented changes
+- Must complete before PR is opened
+
+### Step 9: Harvest Skills (Non-Fatal)
+- Tries to invoke `skill-update-agent` with planFilePath, WORK_DIR, taskDescription
+- If it fails: logs warning but continues to PR (non-fatal step)
+- Extracts reusable patterns for future use
+
+### Step 10: Open Pull Request
+- Invokes `pr-agent` with planFilePath (or taskDescription if null)
+- Creates PR in the feature worktree
+- Halts with cleanup if PR creation fails
+
+### Step 11: Read PR Metadata
+- Delegates to `brain-state-manager` with `operation: "read"`
+- Extracts `prUrl` and `projectDir` from brain.json for final report
+
+### Step 12: Metrics & Cleanup
+- Flushes metrics: `python3 update-metrics.py --csv metrics.csv --brain brain.json`
+- Deletes brain.json via brain-state-manager
+- Removes worktree via: `cleanup-worktree.sh WORK_DIR taskName`
+- Reports final success with PR URL
+
+## Helper: cleanup(WORK_DIR, taskName)
+
+Called on any error path after worktree creation:
+1. Deletes brain.json via `brain-state-manager({ operation: "delete", workDir: WORK_DIR })`
+2. Removes worktree via `cleanup-worktree.sh WORK_DIR taskName`
+
+## Key Design Rules
+
+1. **Never write or scaffold code** — All code changes delegate to workers or dependent agents
+2. **Always cleanup on error** — Except on prep failure (worktree doesn't exist yet)
+3. **Delegate classification logic** — Use task-classifier skill, don't implement inline
+4. **Delegate brain.json management** — Use brain-state-manager skill, never write brain.json directly
+5. **Handle null planFilePath** — When worker produces no plan, pass taskDescription as fallback to downstream agents
+6. **Read brain state after sub-agents** — Use brain-state-manager to extract outputs, don't parse agent return values directly
+7. **Rely on pre-hook injection** — The pre-hook injects brain context into every Agent tool call automatically; don't manually pass brain fields
+
+## Dependencies
+
+- **Skills**: task-classifier, brain-state-manager
+- **Sub-agents**: feature-agent, fix-flow-orchestrator, debugger-agent, repair-agent, code-review-orchestrator-agent, update-documentation-agent, skill-update-agent, pr-agent
+- **Scripts**: prep-feature-dir.sh, cleanup-worktree.sh
+
+## Tools
+
+- Read, Bash, Agent, PushNotification, AskUserQuestion, Skill
+
+## State Management
+
+All state persists in `brain.json` within WORK_DIR, managed by brain-state-manager skill:
+- Initial creation in Step 3
+- Read after feature-agent returns (Step 6)
+- Read after pr-agent returns (Step 11)
+- Deleted during cleanup (Step 12)

--- a/docs/docs/debugger-agent.md
+++ b/docs/docs/debugger-agent.md
@@ -1,0 +1,142 @@
+# debugger-agent
+
+**Role**: Systematic debugger for non-obvious, state-dependent, or intermittent bugs.
+
+**Model**: Sonnet (heavy reasoning for bug investigation and analysis).
+
+**User-Invocable**: No (invoked by dark-factory-agent).
+
+## Overview
+
+The debugger-agent runs systematic debugging following a rigorous checklist-based methodology. It is designed for bugs that are non-obvious, state-dependent, intermittent, or of unknown cause — not simple syntax errors or obvious logic bugs. The agent follows the debug skill checklist step-by-step without skipping, producing a bug audit log and a verified fix.
+
+## Input
+
+- `taskDescription` (string) — Description of the bug to debug (what is failing, expected behavior, actual behavior)
+
+## Debugging Workflow (6 Steps)
+
+### Step 1: Confirm Bug Warrants Systematic Debugging
+
+Verify the bug is:
+- Non-obvious (root cause not immediately clear)
+- State-dependent (behavior depends on system state, timing, or conditions)
+- Intermittent (fails inconsistently)
+- Unknown cause (not obviously a typo or simple logic error)
+
+If the bug is obviously simple, report it and STOP (use repair-agent instead for simple fixes).
+
+### Step 2: Search for Existing Bug File
+
+1. Searches `docs/bugs/` for an existing file with the same failure signature
+2. If found: uses existing file, appends findings
+3. If not found: creates `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` (dated, hyphenated slug of bug description)
+
+### Step 3: Read All Relevant Evidence Before Touching Code
+
+**Critical rule**: Do not modify code until evidence is understood.
+
+1. Reads all relevant logs, stack traces, and error messages
+2. Examines reproduction steps and failure conditions
+3. Identifies all test runs that exhibit the failure
+4. Gathers system state snapshots if applicable
+
+### Step 4: Fill Bug Audit Log
+
+Uses `bug-audit-log-template` to document:
+- **Failure Signature**: Exact error or failure mode observed
+- **Reproduction Steps**: Steps to reliably trigger the bug
+- **Expected Behavior**: What should happen
+- **Actual Behavior**: What actually happens
+- **Environment**: System, OS, Python/Node version, etc.
+- **Relevant Logs**: Stack traces, error messages, logs from failing runs
+- **Hypotheses**: Theories about root cause based on evidence (not yet confirmed)
+
+### Step 5: Run Debugging Checklist
+
+Follows this sequence in strict order:
+
+1. **Write a failing reproduction test**
+   - Minimal test case that reproduces the bug
+   - Arrange inputs per failure conditions
+   - Assert expected behavior
+   - Confirm test fails (assertion error, not import/syntax error)
+
+2. **Confirm the test fails before any fix**
+   - Run test on unmodified code
+   - Verify it fails consistently (not intermittent test failure)
+   - Note the failure signature in bug file
+
+3. **Identify root cause from evidence**
+   - Examine code paths involved in failure
+   - Review logs and stack traces from step 3
+   - Form hypothesis about root cause
+   - Validate hypothesis against all evidence
+
+4. **Fix the root problem**
+   - Apply minimal fix targeting identified root cause
+   - Do not apply workarounds or papering over symptoms
+   - Do not change unrelated code
+
+5. **Confirm the test passes**
+   - Run the reproduction test on fixed code
+   - Verify it passes consistently
+   - Document the fix in bug file
+
+6. **Remove the fix and confirm it fails again** (when safe)
+   - Revert fix to unmodified code
+   - Re-run reproduction test
+   - Verify it fails as before (confirms fix actually addresses the issue, not coincidence)
+   - Re-apply fix
+
+### Step 6: Record Root Cause and Verification
+
+Update bug file with:
+- **Root Cause**: Explanation of why the bug occurred (reference code locations)
+- **Fix Summary**: What was changed and why (reference commit or diff)
+- **Verification**: Test name and results confirming the fix
+
+## Brain Patch Output
+
+After all bug files are written and debugging checklist is complete:
+
+Writes `$DARK_FACTORY_WORK_DIR/brain-patch.json`:
+```json
+{
+  "bugFiles": [
+    "/absolute/path/to/bug-file-1.md",
+    "/absolute/path/to/bug-file-2.md"
+  ]
+}
+```
+
+## Key Design Rules
+
+1. **Follow the checklist in strict order** — Do not skip steps; each step validates the previous one
+2. **Read all evidence before coding** — Understand the bug completely before touching code
+3. **Write tests before fixing** — Test-first ensures the fix is actually necessary
+4. **Verify fix is necessary** — Remove fix and confirm test fails again (except when unsafe)
+5. **Do NOT read brain.json** — Context is already injected by pre-hook
+6. **Do NOT write brain.json directly** — Only write brain-patch.json
+7. **Skip brain-patch silently if DARK_FACTORY_WORK_DIR unset** — No error if environment variable missing
+
+## Dependencies
+
+- **Skills**: systematic-debugging (contains debug checklist)
+- **Templates**: bug-audit-log-template
+
+## Tools
+
+- Read, Write, Edit, Bash, Glob, Agent
+
+## Error Handling
+
+- If bug is obviously simple (not non-obvious/state-dependent): report and STOP
+- If test cannot be written: report blocker and STOP
+- If root cause cannot be identified after evidence review: document findings in bug file and report inconclusive
+- If fix cannot be applied: document blocker and STOP
+
+## Artifacts Produced
+
+- `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` — Bug audit log (persisted in repository)
+- `$DARK_FACTORY_WORK_DIR/brain-patch.json` — Metadata linking to bug files

--- a/docs/docs/feature-agent.md
+++ b/docs/docs/feature-agent.md
@@ -1,0 +1,164 @@
+# feature-agent
+
+**Role**: End-to-end feature orchestrator for interactive planning and execution.
+
+**Model**: Haiku (lightweight orchestration, no heavy reasoning).
+
+**User-Invocable**: No (invoked by dark-factory-agent).
+
+## Overview
+
+The feature-agent orchestrates feature work end-to-end using a five-phase planning flow followed by delegation to execution-agent. It is the only place where human approval gates live — the planning-agent generates content, feature-agent gates on approval, and execution-agent implements. This separation ensures that planning decisions are always human-approved before any code is written.
+
+The agent manages a multi-turn dialogue: users review each planning section (System Intent, Mermaid Diagram, Flows) and either approve or request changes. Once all sections are approved, it delegates to execution-agent.
+
+## Input
+
+- `taskDescription` (string, nullable) — User's request; null on re-invocation
+- `answer` (string, nullable) — User's response to a previous question; null on first invocation
+- `planPath` (string, nullable) — Path to existing plan file; null on first invocation, provided on re-invocation
+
+## Orchestration Flow (5 Phases)
+
+### Phase 1: Draft Plan
+
+**Condition**: First invocation OR resuming from unchecked "Stage 1 Mermaid approved" gate.
+
+1. Invokes `planning-agent` with `phase: "draft_plan"`, `planPath: null`, `feedback: taskDescription`
+2. Receives `{ planPath, summary }`
+3. If error or no planPath: reports error and STOPS
+4. Renders "## System Intent" section via `render-plan-section` command
+5. Sends PushNotification: "Draft Plan Ready"
+6. **Returns** `status: "question"` with System Intent content and options:
+   - "Looks good — continue to Mermaid diagram"
+   - "Request Changes"
+
+### Phase 2: Mermaid Diagram
+
+**Condition**: Resuming with "Stage 1 Mermaid approved" unchecked; user selected "Looks good — continue to Mermaid diagram"
+
+1. Invokes `planning-agent` with `phase: "mermaid"`, `planPath`, `feedback: answer ?? "none"`
+2. Receives `{ planPath, url, summary }`
+3. If URL is present: sends PushNotification with diagram link
+4. Renders "## Mermaid Diagram" section via `render-plan-section`
+5. **Returns** `status: "question"` with Mermaid diagram and options:
+   - "Approve — continue to flows"
+   - "Request Changes"
+
+### Phase 3: Flows (Iterative, One at a Time)
+
+**Condition**: Resuming with "Stage 2 Flows approved" unchecked; user selected "Approve — continue to flows"
+
+Iterates through all flows in the plan, one per turn:
+
+1. Parses all flow names from plan file
+2. Loads current flow state via `flow-state-manager` skill
+3. If user answered "Approve — continue to next flow": marks current flow as approved in state manager
+4. If user requested changes: invokes `planning-agent` with `phase: "flows"` and the change request
+5. Finds next unapproved flow via flow-state-manager
+6. If all flows approved: **GOTO Phase 4**
+7. Sets current flow in state manager
+8. Renders next flow section via `render-plan-section`
+9. **Returns** `status: "question"` with flow content and options:
+   - "Approve — continue to next flow"
+   - "Request Changes"
+
+### Phase 4: Final Approval Gate
+
+**Condition**: All flows approved (entering execution phase) AND user hasn't yet selected "Approve and Execute"
+
+1. Reads full plan file content
+2. **Returns** `status: "question"` with complete plan and options:
+   - "Approve and Execute"
+   - "Abort"
+
+**If user selects "Abort"**:
+- **Returns** `status: "aborted"` with reason
+
+### Phase 5: Execute
+
+**Condition**: User selected "Approve and Execute" at final gate
+
+1. Invokes `execution-agent` with `planPath`
+2. If execution-agent returns `hardStop: true`:
+   - **Returns** `status: "hard-stop"` with reason; does NOT re-invoke execution-agent
+3. If execution-agent succeeds:
+   - Writes `brain-patch.json` in DARK_FACTORY_WORK_DIR: `{ "planFilePath": planPath }`
+   - **Returns** `status: "done"` with planPath
+
+## Resume Logic via Stage Gate Tracker
+
+Feature-agent determines current phase by reading checkboxes in plan's Stage Gate Tracker:
+
+- "Stage 1 Mermaid approved" unchecked → Resume at Phase 2 (mermaid)
+- "Stage 2 Flows approved" unchecked → Resume at Phase 3 (flows)
+- All stages checked → Jump to Phase 4 (final approval) or Phase 5 (execute)
+
+This allows users to re-invoke feature-agent mid-workflow if interrupted.
+
+## Return Values
+
+### status: "question"
+```json
+{
+  "status": "question",
+  "question": "<rendered section or full plan>",
+  "options": ["option1", "option2"],
+  "planPath": "<path to plan file>",
+  "phase": "<phase name>"
+}
+```
+Indicates dark-factory-agent should send PushNotification and await AskUserQuestion response.
+
+### status: "done"
+```json
+{
+  "status": "done",
+  "planPath": "<path to plan file>"
+}
+```
+Feature work complete; brain-patch.json written.
+
+### status: "hard-stop"
+```json
+{
+  "status": "hard-stop",
+  "reason": "<error description>"
+}
+```
+Execution paused; user must review and resume.
+
+### status: "aborted"
+```json
+{
+  "status": "aborted",
+  "reason": "User aborted at final approval gate",
+  "planPath": "<path to plan file>"
+}
+```
+
+## Key Design Rules
+
+1. **Never call AskUserQuestion directly** — Return `status: "question"` instead; dark-factory-agent asks at depth-2
+2. **Never invoke pr-agent** — Caller (dark-factory-agent) handles the PR
+3. **Delegate flow state** — Use flow-state-manager skill for all flow approval tracking
+4. **Delegate rendering** — Use render-plan-section command to format plan sections
+5. **Handle hard-stop gracefully** — When execution-agent returns hard-stop, return it upstream; don't retry
+6. **Write brain-patch.json only after execution succeeds** — Skip silently if DARK_FACTORY_WORK_DIR is unset
+
+## Dependencies
+
+- **Skills**: flow-state-manager
+- **Commands**: render-plan-section
+- **Sub-agents**: planning-agent, execution-agent
+
+## Tools
+
+- Read, Agent, PushNotification, Skill, Command
+
+## State Persistence
+
+Flow approval state persists in DARK_FACTORY_WORK_DIR via flow-state-manager:
+- Tracks which flows are approved
+- Tracks current flow being reviewed
+- Allows safe interruption and resumption

--- a/docs/docs/fix-flow-orchestrator.md
+++ b/docs/docs/fix-flow-orchestrator.md
@@ -1,0 +1,102 @@
+# fix-flow-orchestrator
+
+**Role**: Autonomously drives a failing integration flow to green status.
+
+**Model**: Haiku (lightweight orchestration, no heavy reasoning).
+
+**User-Invocable**: No (invoked by dark-factory-agent).
+
+## Overview
+
+The fix-flow-orchestrator is a specialized orchestrator for fixing broken integration flows. It systematically investigates the flow, generates debugging and test scripts, and loops through fix-and-push cycles until the flow passes. The flow name is required and must be provided as an argument.
+
+## Input
+
+- `flowName` (string, required) — Name of the failing integration flow (e.g., "login-flow", "checkout-flow")
+- If not provided: sends PushNotification requesting flow name, awaits AskUserQuestion response
+
+## Orchestration Flow (3 Phases)
+
+### Phase 1: Understand System
+
+**Objective**: Build system documentation and create a working plan.
+
+1. Validates flow name is provided
+   - If missing: sends PushNotification ("Input Required", "The fix-flow orchestrator needs a flow name to proceed.")
+   - Uses AskUserQuestion to request flow name or allow cancel/reinvocation
+   - Stops and waits for response
+
+2. Spawns `investigation-agent` with the flow name
+
+3. Waits for investigation-agent to return path to documentation file (in `docs/docs/`)
+
+4. Writes `docs/plans/system-diagram.md` using the documentation as the working plan for this session
+
+5. **Does NOT proceed to Phase 2 until** `docs/plans/system-diagram.md` exists
+
+### Phase 2: Setup
+
+**Objective**: Generate test trigger, log fetching, and deployment scripts.
+
+1. Spawns `setup-wizard` sub-agent with:
+   - Path to `docs/plans/system-diagram.md`
+
+2. Waits for setup-wizard to return paths to generated scripts:
+   - Trigger script
+   - Fetch-logs script
+   - Wait-for-completion script
+
+3. **Does NOT proceed to Phase 3 until** all required scripts are verified to exist
+
+### Phase 3: Fix and Push
+
+**Objective**: Loop through fix attempts until flow passes; create single PR with all fixes.
+
+1. Spawns `ralph-fix-and-push` sub-agent with:
+   - Paths to all generated scripts from Phase 2
+   - branchName (e.g., "feature/fix-flow-<flow-name>")
+
+2. Waits for ralph-fix-and-push to complete
+
+3. ralph-fix-and-push returns `all-green: true` when flow passes
+
+## Completion
+
+When ralph-fix-and-push returns `all-green: true`:
+
+1. Reports success to developer with PR URL
+2. Notes that `docs/plans/system-diagram.md` and any `docs/bugs/*.md` files are kept as persistent project documentation (not deleted)
+
+## Key Design Rules
+
+1. **Flow name is mandatory** — Request via AskUserQuestion if missing; do not proceed without it
+2. **Strict phase sequencing** — Never advance to next phase until current phase has produced required artifacts
+3. **Verify Phase 2 scripts exist** — Before invoking ralph-fix-and-push, confirm all generated scripts are present
+4. **Persist documentation** — system-diagram.md and bug audit logs remain in the repository after fixes complete
+5. **Single PR output** — ralph-fix-and-push produces one PR with all accumulated fixes across multiple debug loops
+
+## Dependencies
+
+- **Sub-agents**: investigation-agent, setup-wizard, ralph-fix-and-push
+- **Artifacts**: docs/plans/system-diagram.md (created by phase 1), generated debug scripts (created by phase 2)
+
+## Tools
+
+- Read, Bash, PushNotification, AskUserQuestion
+
+## Return Value
+
+```json
+{
+  "success": true,
+  "prUrl": "<github PR URL>",
+  "flowName": "<flow name>"
+}
+```
+
+## Error Handling
+
+- If investigation-agent fails: reports error and STOPS
+- If setup-wizard fails: reports error and STOPS
+- If any generated script doesn't exist: halts before Phase 3, reports error
+- If ralph-fix-and-push fails: reports error (PR may still have been created)

--- a/docs/docs/pr-agent.md
+++ b/docs/docs/pr-agent.md
@@ -1,0 +1,187 @@
+# pr-agent
+
+**Role**: PR lifecycle manager for completed work.
+
+**Model**: Sonnet (heavy reasoning for PR body composition and comment resolution).
+
+**User-Invocable**: No (invoked by dark-factory-agent after all work is complete).
+
+## Overview
+
+The pr-agent manages the complete PR lifecycle for code that has already been implemented, reviewed, and documented. It opens a PR with a comprehensive body, watches CI until it's green, resolves review comments collaboratively, and stops once CI passes and all threads are resolved. Critically, **the agent does not merge** — it stops at "ready" status, leaving the final merge decision to human judgment.
+
+The PR lifecycle is fully automated except for the final merge decision, enabling code to move from implementation through CI and code review without manual intervention while preserving human control over the merge.
+
+## Input
+
+- `planFilePath` (string, nullable) — Path to the plan file; if null, uses taskDescription
+- Or `taskDescription` (string) — Plain description of the work if no plan exists
+- If neither: uses git diff
+
+## Orchestration Flow (5 Steps)
+
+### Step 1: Build PR Body
+
+1. **Reads PR template** from `agents/pr/templates/pr-template.md` for structure
+2. **Populates Description section**:
+   - If planFilePath provided: extracts summary from plan
+   - If taskDescription provided: uses description directly
+   - If neither: builds from git diff
+3. **Runs tests** (if test suite exists):
+   - Detects test runner (pytest, npm test, go test, etc.)
+   - Runs full test suite
+   - Includes output in "Test Plan" section
+   - Omits "Test Plan" section if no test suite found
+4. **Writes body** to `/tmp/pr-body.md` (ready for gh cli)
+
+### Step 2: Open PR
+
+1. **Delegates to create-pr skill** with `bodyFile: "/tmp/pr-body.md"`
+2. Receives `prUrl` back from skill
+3. **Writes brain-patch.json** in DARK_FACTORY_WORK_DIR:
+   ```json
+   { "prUrl": "<github PR URL>" }
+   ```
+   (Skip silently if DARK_FACTORY_WORK_DIR is unset)
+
+### Step 3: Watch CI
+
+1. **Delegates to ci-watch-runner command** with:
+   - `prUrl: <the PR URL>`
+   - `maxIterations: 5`
+
+2. Command polls PR CI status repeatedly:
+   - Checks status at regular intervals
+   - Reports when CI is green, yellow (pending), or red (failed)
+   - Stops after maxIterations or when status stabilizes
+
+3. **If ciResult.status == "fail"**: returns error, STOPS
+   - CI failed; human review of failures required
+   - PR remains open for investigation
+
+4. **If ciResult.status == "pass"**: proceeds to Step 4
+
+### Step 4: Resolve Review Comments
+
+1. **Gets PR node ID**:
+   - Uses `gh api graphql` to fetch `pr.id` from prUrl
+
+2. **Delegates to comment-resolution-runner command** with:
+   - `prUrl: <the PR URL>`
+   - `prNodeId: <the PR node ID>`
+   - `maxIterations: 5`
+
+3. Command iterates through review comments:
+   - Reads each comment thread
+   - Attempts to resolve by responding (if automated resolution applies)
+   - Or requests human clarification
+   - Marks threads resolved when addressed
+   - Stops after maxIterations or when all threads are resolved
+
+4. **If commentResult.status == "failed"**: returns error, STOPS
+   - Review comments could not be resolved
+   - PR remains open with pending threads
+
+5. **If commentResult.status == "success"**: all threads resolved, proceeds to Step 5
+
+### Step 5: Return Success
+
+Returns:
+```json
+{
+  "prUrl": "<github PR URL>",
+  "status": "ready"
+}
+```
+
+Status "ready" indicates:
+- CI is passing (all checks green)
+- All review comment threads are resolved
+- PR is ready for merge (but **not merged** by this agent)
+
+## PR Body Template
+
+The PR body includes (from `agents/pr/templates/pr-template.md`):
+
+```markdown
+## Summary
+- Brief description of changes
+
+## Approach
+- How/why this solution was chosen
+- Any design decisions
+
+## Test Plan
+- [if test suite exists]
+- Test output showing all tests passing
+- Coverage information if applicable
+
+## Related
+- Links to related issues, PRs, or documentation
+```
+
+## Key Design Rules
+
+1. **Code is already implemented** — Assume fix is complete; don't re-apply
+2. **Always use git -C "$WORK_DIR"** — WORK_DIR is injected by pre-hook
+3. **Write body to /tmp/pr-body.md** — Use standard gh cli pattern
+4. **Delegate CI watching** — Use ci-watch-runner, don't implement watch loop inline
+5. **Delegate comment resolution** — Use comment-resolution-runner, don't implement loop inline
+6. **Do NOT merge** — Stop at "ready" status; human makes the merge decision
+7. **Write brain-patch after PR opens** — Captures prUrl for downstream use
+8. **Skip brain-patch silently if DARK_FACTORY_WORK_DIR unset** — No error
+
+## Dependencies
+
+- **Skills**: create-pr (opens the PR)
+- **Commands**: ci-watch-runner (polls CI status), comment-resolution-runner (resolves review threads)
+- **Templates**: agents/pr/templates/pr-template.md
+
+## Tools
+
+- Read, Bash, Write, Edit, Command
+
+## Return Value
+
+**Success**:
+```json
+{
+  "prUrl": "<github PR URL>",
+  "status": "ready"
+}
+```
+
+**Error**:
+```json
+{
+  "message": "<error description>"
+}
+```
+
+## SubagentStop Hook
+
+When pr-agent finishes, triggers: `${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pr-agent-cleanup-hook.sh`
+
+This hook performs cleanup specific to PR operations (e.g., removing temporary files, updating metrics).
+
+## Integration with dark-factory-agent
+
+1. Called after all other steps (feature/debug, code review, documentation, skills) complete
+2. Blocks on CI passing and review threads resolved
+3. If returns error: dark-factory-agent logs the PR URL and error, continues to cleanup
+4. If returns success: dark-factory-agent reports final success with PR URL
+
+## Why No Merge?
+
+The pr-agent intentionally stops at "ready" (CI green, reviews resolved) and does not merge. This preserves a critical human decision point: merging to main. Even though all automated checks pass, humans should review the final PR before merge. This pattern:
+- Maintains code ownership and accountability
+- Allows last-minute vetoes or questions
+- Provides a natural place to add human documentation/release notes
+- Prevents mass-merging of features without awareness
+
+## Error Handling
+
+- If PR creation fails: surfaces error and STOPS
+- If CI never stabilizes (yellow for all iterations): returns failure
+- If review comments can't be resolved (pending after 5 iterations): returns failure
+- If git operations fail: surfaces error and STOPS

--- a/docs/docs/repair-agent.md
+++ b/docs/docs/repair-agent.md
@@ -1,0 +1,141 @@
+# repair-agent
+
+**Role**: Lightweight, targeted change agent for simple fixes and updates.
+
+**Model**: Sonnet (heavy reasoning for targeted problem-solving).
+
+**User-Invocable**: No (invoked by dark-factory-agent).
+
+## Overview
+
+The repair-agent applies targeted changes from plain-language task descriptions without requiring a full plan file. It is designed for simple, focused fixes: correcting a string, updating a configuration, fixing a broken import, or patching a known issue. The agent runs the test suite, fixes any breakage iteratively (up to 5 attempts), and reports success or failure.
+
+Unlike the debugging agent, repair-agent does not use a systematic debug methodology — it applies a minimal fix and validates it with tests. It is also non-fatal: if repair fails, dark-factory-agent continues to code review and PR instead of halting.
+
+## Input
+
+- `taskDescription` (string) — Plain-language description of what to change or fix (no plan file)
+
+## Workflow (6 Steps)
+
+### Step 1: Understand Scope
+
+1. Reads relevant files based on task description
+2. Identifies the minimal set of files that need to change
+3. **Does NOT refactor or expand scope** beyond what is asked
+4. Determines: "What is the smallest change that satisfies this request?"
+
+### Step 2: Run Baseline Tests
+
+1. Detects test runner by checking for:
+   - `pytest` (Python)
+   - `npm test` or `npm run test` (Node.js)
+   - `go test` (Go)
+   - Other common runners
+
+2. If no test suite found: **skips to Step 4** (no tests to validate)
+
+3. If test suite found: runs full suite once
+   - Records which tests are **already failing** (pre-existing)
+   - These failures are NOT counted against the repair
+
+### Step 3: Apply Targeted Change
+
+1. Makes the minimal change described in taskDescription
+2. Focuses modifications on identified files
+3. Keeps changes tight and focused (no refactoring)
+4. Does not introduce new abstractions, helpers, or patterns outside the task scope
+
+### Step 4: Assess Significance
+
+Sets `significantChange` flag based on whether any modified file is:
+
+**Significant if changed**:
+- Agent instruction file (`*.md` inside `agents/`)
+- Skill definition (`SKILL.md`)
+- User-facing command (inside `commands/`)
+- Public API or interface boundary
+
+**Not significant otherwise**:
+- Data files
+- Configuration files
+- Comments-only changes
+- Internal implementation details
+
+### Step 5: Fix Failures
+
+1. Runs test suite again
+2. Identifies **new failures** (not in pre-existing baseline)
+3. **Iterative loop** (up to 5 attempts):
+   - If new failures found:
+     - Diagnose the failure
+     - Apply a targeted fix
+     - Re-run test suite
+     - Check for new failures
+   - If no new failures: proceed to Step 6
+
+4. **After 5 attempts**: if new test failures still exist:
+   - Returns `{ success: false, significantChange, error: { message: "<last failure summary>" } }`
+   - Notes pre-existing failures but doesn't count them
+
+### Step 6: Return Result
+
+**Success**:
+```json
+{
+  "success": true,
+  "significantChange": true|false
+}
+```
+
+**Failure**:
+```json
+{
+  "success": false,
+  "significantChange": true|false,
+  "error": {
+    "message": "<summary of last test failure>"
+  }
+}
+```
+
+## Key Design Rules
+
+1. **Stay minimal** — Do not refactor or clean up code outside the repair scope
+2. **No new abstractions** — Don't introduce helpers or patterns not required by the task
+3. **All passing tests must remain passing** — Success only when all pre-passing tests still pass (or no suite exists)
+4. **Pre-existing failures are noted, not counted** — Only new failures caused by the change block success
+5. **5-attempt limit** — Stop iterating after 5 tries; return failure
+6. **No plan file required** — This is the lightweight alternative to feature-agent
+
+## Dependencies
+
+- **Test runners**: pytest, npm test, go test (auto-detected)
+- **No skills or sub-agents required**
+
+## Tools
+
+- Read, Write, Edit, Bash, Glob
+
+## Error Handling
+
+- If no test suite exists: skips test validation; repair still succeeds if code is syntactically valid
+- If repair breaks tests and 5 iterations don't fix it: returns `success: false`
+- If target file doesn't exist: reports error and STOPS
+- If task description is ambiguous: returns error (repair requires clear, minimal scope)
+
+## Lifecycle in dark-factory-agent
+
+1. Invoked by dark-factory-agent as non-fatal step
+2. If returns `success: false`: logged but dark-factory-agent continues to code review and PR
+3. If returns `success: true`: continues to code review
+4. No brain-patch.json written (repair-agent produces no artifacts for downstream use)
+
+## Use Cases
+
+- Fix a typo or string constant
+- Update a configuration value
+- Correct a broken import
+- Patch a known one-liner issue
+- Update a version pin
+- Fix a small bug with clear solution

--- a/docs/docs/skill-update-agent.md
+++ b/docs/docs/skill-update-agent.md
@@ -1,0 +1,195 @@
+# skill-update-agent
+
+**Role**: Post-implementation skill harvester and knowledge extractor.
+
+**Model**: Sonnet (heavy reasoning for pattern detection and generalization).
+
+**User-Invocable**: No (invoked by dark-factory-agent as non-fatal step).
+
+## Overview
+
+The skill-update-agent reviews completed work and harvests non-obvious, recurring patterns into reusable skill files. Skills are micro-tutorials capturing "how to do X in this codebase" — they accelerate future agents by codifying knowledge learned during manufacture runs. However, the agent is strict about quality: it only writes skills when a pattern is genuinely non-obvious AND likely to recur. Prefer returning an empty list over writing noise.
+
+Unlike other agents, skill-update-agent is **non-fatal**: if it fails, dark-factory-agent logs a warning and continues to the PR step. This allows manufacturing to complete even if skill extraction fails.
+
+## Input
+
+- `planFilePath` (string, nullable) — Path to the approved and implemented plan file; may be null (e.g., for repair or debugger routes)
+- `workDir` (string) — Absolute path to the isolated work directory
+- `taskSummary` (string) — Brief human-readable description of what was accomplished
+
+## Orchestration Flow (5 Steps)
+
+### Step 1: Gather Context
+
+1. **If planFilePath is not null**: reads plan to understand what flows were implemented and why
+2. **Runs git commands** in workDir:
+   - `git diff HEAD~1` or `git diff` to see code changes
+   - `git log --oneline -5` to review recent commits
+3. **Builds understanding** of what was done and what challenges were overcome
+
+### Step 2: Identify Candidate Patterns
+
+Scans the work for non-obvious patterns, workarounds, and discoveries.
+
+**Detection signals**:
+- Comments with "NOTE", "WORKAROUND", "HACK", "non-obvious"
+- Repeated lookups in plan pseudocode (indicates something non-obvious)
+- Deviations from standard patterns that were discovered and resolved
+- Things the agent had to figure out that aren't documented elsewhere
+- Tricky setup or configuration steps
+- Interaction between systems that surprised the agent
+
+**Examples of candidates**:
+- "How to handle git conflicts when working in worktrees"
+- "Pattern for calling Claude Code agents from bash"
+- "When to use flow-state-manager vs brain-state-manager"
+- "Proper error handling for non-fatal sub-agents"
+
+**Examples to exclude** (too specific, not general):
+- "How to fix the login bug in this specific codebase" (too specific to one bug)
+- "The quirk of this particular service's API response" (specific data migration)
+- "Workaround for this one edge case in our code" (not generalizable)
+
+### Step 3: Recurrence Filter
+
+For each candidate pattern, asks:
+
+**"Is this specific to this one task, or would a future agent hit the same wall?"**
+
+**Keep** (likely to recur):
+- General patterns applicable to many tasks
+- Setup/integration knowledge relevant to future work
+- Common gotchas encountered
+- Framework/tool knowledge that transfers across projects
+
+**Discard** (task-specific):
+- One-off data migrations
+- Task-specific business logic fixes
+- Project-specific quirks
+- Edge cases unlikely to repeat
+
+**Pragmatic principle**: Prefer returning `skillsWritten: []` (zero skills) if unsure. It's better to not write than to pollute the skills directory with noise.
+
+### Step 4: Write/Update Skill Files
+
+For each pattern passing the recurrence filter:
+
+1. **Create kebab-case slug** (e.g., "handle-git-conflicts", "debug-cloudbuild-logs")
+2. **Determine path**: `skills/<slug>/SKILL.md` (relative to workDir)
+3. **Check if exists**:
+   - **If already exists**: read existing skill, merge new knowledge, write updated file; record `action: "updated"`
+   - **If new**: write new SKILL.md using template below; record `action: "created"`
+
+### Step 5: Return Result
+
+Returns:
+```json
+{
+  "skillsWritten": [
+    { "path": "skills/handle-git-conflicts/SKILL.md", "action": "created" },
+    { "path": "skills/debug-cloudbuild/SKILL.md", "action": "updated" }
+  ]
+}
+```
+
+**If no patterns qualified**: returns `{ skillsWritten: [] }` (empty list).
+
+## Skill Template
+
+When creating a new skill file, use this format:
+
+```markdown
+---
+name: <kebab-case-slug>
+description: "<one sentence: what this skill does and when to use it>"
+user-invocable: false
+---
+
+## When to use
+
+<Condition or situation that triggers the need for this skill>
+
+Examples:
+- "When working with git worktrees in dark-factory"
+- "When a Claude Code pre-hook needs to intercept an Agent tool call"
+
+## Steps
+
+<Numbered steps describing how to do the thing>
+
+1. First step
+2. Second step
+3. ...
+
+## Notes
+
+<Any caveats, gotchas, or edge cases>
+
+Examples:
+- "Remember to handle the null case in step 2"
+- "Only use this for X; don't use for Y"
+- "This pattern requires Z to be installed"
+```
+
+## Key Design Rules
+
+1. **Only write for non-obvious, recurring patterns** — Filter aggressively; prefer empty list over noise
+2. **Don't modify files outside skills/** — Leave agent files, plans, and code untouched
+3. **Merge when updating** — Preserve existing skill content and add new knowledge; don't overwrite
+4. **Non-fatal failures** — If plan file can't be read or git fails, report error but don't block dark-factory-agent
+5. **Write brain-patch only if skills written** — If `skillsWritten` is empty, omit brain-patch entirely
+
+## Brain Patch Output
+
+If any skills were written or updated, write `$DARK_FACTORY_WORK_DIR/brain-patch.json`:
+```json
+{
+  "skillsWritten": [
+    "skills/handle-git-conflicts/SKILL.md",
+    "skills/debug-cloudbuild/SKILL.md"
+  ]
+}
+```
+
+**Rules**:
+- Only write brain-patch if `skillsWritten` is non-empty
+- Skip writing silently if `DARK_FACTORY_WORK_DIR` is unset
+- Do not read brain.json directly (context is injected by pre-hook)
+- Do not write brain.json (only write brain-patch.json)
+
+## Dependencies
+
+- **No skills or sub-agents required**
+- **Templates**: skill-template (used when creating new skills)
+
+## Tools
+
+- Read, Write, Edit, Bash (for git commands)
+
+## Integration with dark-factory-agent
+
+1. Invoked after update-documentation-agent completes
+2. **Non-fatal**: if it returns error or times out, dark-factory-agent logs warning and continues to PR
+3. No blocking — always proceeds to pr-agent regardless of skill-update result
+4. Output (skillsWritten) is used by dark-factory-agent for metrics and attribution
+
+## Error Handling
+
+- If plan file is unreadable: reports error (non-fatal, caller continues)
+- If git commands fail: reports error (non-fatal, caller continues)
+- If skill template doesn't exist: reports error (non-fatal, caller continues)
+- If workDir doesn't exist: reports error (non-fatal, caller continues)
+
+## Use Case Examples
+
+**Good candidates**:
+- "How to parse Claude Code's pre-hook JSON format"
+- "Pattern for delegating to flow-state-manager"
+- "Debugging checklist for state-dependent bugs"
+- "How to write agent tests with dark-factory"
+
+**Poor candidates**:
+- "The specific bug we fixed in this one task"
+- "This project's particular API quirk"
+- "Workaround for this vendor's rate limit"

--- a/docs/docs/update-documentation-agent.md
+++ b/docs/docs/update-documentation-agent.md
@@ -1,0 +1,119 @@
+# update-documentation-agent
+
+**Role**: Post-implementation documentation updater.
+
+**Model**: Sonnet (heavy reasoning for documentation analysis and writing).
+
+**User-Invocable**: No (invoked by dark-factory-agent after code review).
+
+## Overview
+
+The update-documentation-agent automatically updates project documentation after a plan has been implemented and reviewed. It reads the approved plan, identifies all created and modified flows/services/components, locates affected documentation files, and updates them to reflect the implementation. It also creates new doc files for any flows that don't yet have documentation.
+
+The agent is a critical part of keeping documentation in sync with code — it ensures that every implemented flow/service has current, accurate documentation.
+
+## Input
+
+- `planFilePath` (string, nullable) — Absolute path to the implemented and approved plan file
+- If not provided: sends PushNotification ("Input Required"), awaits AskUserQuestion for path or skip option
+
+## Orchestration Flow (3 Phases)
+
+### Phase 1: Identify Flows
+
+1. Reads the plan file at `planFilePath`
+2. Extracts every flow, service, or component that was created or modified
+3. Builds `tmp/update-docs-flows.md` checklist:
+   ```markdown
+   # Flows Checklist
+   - [ ] <flow-name> — created/modified
+   - [ ] <service-name> — created/modified
+   - [ ] <component-name> — created/modified
+   ```
+
+### Phase 2: Identify Affected Docs
+
+1. Invokes `find-affected-docs` command with flow names from Phase 1
+2. Command searches `docs/docs/` for existing files that mention the flows
+3. Appends to `tmp/update-docs-flows.md`:
+   ```markdown
+   # Affected Docs Checklist
+   - [ ] docs/docs/existing-flow.md — touches <flow-name>
+   - [ ] docs/docs/service-integration.md — touches <flow-name>
+   - [ ] NEW — <new-flow-name> has no existing doc
+   - [ ] NEW — <new-service-name> has no existing doc
+   ```
+
+### Phase 3: Update Docs
+
+For each item in Phase 2 checklist:
+
+**For existing doc files**:
+1. Opens the doc file
+2. Identifies sections affected by implementation changes
+3. **Deletes removed behavior** — Removes descriptions of features that were deleted or refactored out
+4. **Updates modified** — Changes sections to reflect implementation details that changed
+5. **Adds new** — Inserts descriptions of new flows, endpoints, methods, or behaviors added by the implementation
+6. Marks checklist item `[x]` when complete
+
+**For new flows** (marked as "NEW"):
+1. Creates `docs/docs/<flow-name>.md` as a new file
+2. Uses the `documentation` skill to generate comprehensive documentation
+3. Includes: purpose, inputs, outputs, workflow, error handling, dependencies
+4. Marks checklist item `[x]` when complete
+
+## Completion
+
+After all docs are updated or created, writes `$DARK_FACTORY_WORK_DIR/brain-patch.json`:
+```json
+{
+  "docsWritten": [
+    "/absolute/path/to/docs/docs/flow-1.md",
+    "/absolute/path/to/docs/docs/flow-2.md",
+    "/absolute/path/to/docs/docs/service.md"
+  ]
+}
+```
+
+**Note**: Skip writing brain-patch.json silently if `DARK_FACTORY_WORK_DIR` is unset.
+
+## Key Design Rules
+
+1. **Read plan before touching docs** — Understand all changes before updating
+2. **Delete removed behavior** — Don't leave documentation for features that no longer exist
+3. **Update, don't rewrite** — For existing docs, edit sections; don't rebuild the whole file
+4. **Create new docs for new flows** — Don't assume documentation exists for new flows
+5. **Use documentation skill** — Delegate doc generation for new flows to the skill
+6. **Track all changes** — Write brain-patch.json with paths to every file touched
+7. **Skip brain-patch silently** — If DARK_FACTORY_WORK_DIR is unset, don't error
+
+## Dependencies
+
+- **Commands**: find-affected-docs (identifies which existing docs mention which flows)
+- **Skills**: documentation (generates new flow documentation)
+
+## Tools
+
+- Read, Bash, Write, Edit, PushNotification, AskUserQuestion, Command
+
+## Artifacts Produced
+
+- `tmp/update-docs-flows.md` — Checklist of flows and affected docs
+- `docs/docs/<flow-name>.md` — New doc files created for flows without docs
+- Modified existing doc files in `docs/docs/`
+- `$DARK_FACTORY_WORK_DIR/brain-patch.json` — Metadata of all files written/updated
+
+## Integration with dark-factory-agent
+
+1. Called after code-review-orchestrator-agent completes
+2. Must complete before skill-update-agent
+3. If returns error: dark-factory-agent halts, cleans up, reports failure
+4. If succeeds: dark-factory-agent continues to skill-update and PR
+5. Output (docsWritten) is used by dark-factory-agent for metrics and attribution
+
+## Error Handling
+
+- If plan file not provided: requests via AskUserQuestion; halts if user skips
+- If plan file unreadable: reports error and halts
+- If find-affected-docs command fails: reports error and halts
+- If doc writing fails: reports which file failed and halts

--- a/docs/plans/2026-05-04-doc-sub-agents-manufacture.md
+++ b/docs/plans/2026-05-04-doc-sub-agents-manufacture.md
@@ -1,0 +1,423 @@
+# Doc Sub-Agents Manufacture
+
+## System Intent
+
+- **What is being built**: Individual documentation files in `docs/docs/` for dark-factory-agent and its 8 direct child agents. Each agent currently lacks a dedicated doc; they are only described inline in `docs/docs/manufacture.md`. This feature creates one authoritative doc per agent using the existing documentation template. Sub-sub-agents (planning-agent, sub-planning-agent, execution-agent, skeleton-agent, testing-agent, implementation-agent, high-level-review-agent, low-level-review-agent, resolver-agent) are explicitly out of scope.
+- **Primary consumer(s)**: Future agents (investigation-agent, update-documentation-agent) that look up `docs/docs/<system>.md` before modifying a system. Also human developers onboarding to the pipeline.
+- **Boundary (black-box scope only)**: Read-only analysis of agent `.md` files under `agents/`; write new `.md` files under `docs/docs/`. No agent source files are modified. Exactly 9 doc files will be created: dark-factory-agent, feature-agent, fix-flow-orchestrator, debugger-agent, repair-agent, code-review-orchestrator-agent, update-documentation-agent, skill-update-agent, pr-agent.
+
+## Stage Gate Tracker
+
+- [x] Stage 1 Mermaid approved
+- [x] Stage 2 Flows approved
+- [x] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+> Use the skill at `skills/create-mermaid-diagram/SKILL.md` to generate this diagram.
+
+```mermaid
+graph TD
+  PlanFile["2026-05-04-doc-sub-agents-manufacture.md"]:::unchanged
+  AgentSources["agents/ — existing agent .md files"]:::unchanged
+
+  PlanFile -->|"drives"| DocWriter["update-documentation-agent\n(this run)"]:::unchanged
+
+  AgentSources -->|"read for content"| DocWriter
+
+  DocWriter -->|"creates"| DFA["docs/docs/dark-factory-agent.md"]:::created
+  DocWriter -->|"creates"| FA["docs/docs/feature-agent.md"]:::created
+  DocWriter -->|"creates"| FFO["docs/docs/fix-flow-orchestrator.md"]:::created
+  DocWriter -->|"creates"| DBA["docs/docs/debugger-agent.md"]:::created
+  DocWriter -->|"creates"| REP["docs/docs/repair-agent.md"]:::created
+  DocWriter -->|"creates"| CRO["docs/docs/code-review-orchestrator-agent.md"]:::created
+  DocWriter -->|"creates"| UDA["docs/docs/update-documentation-agent.md"]:::created
+  DocWriter -->|"creates"| SKU["docs/docs/skill-update-agent.md"]:::created
+  DocWriter -->|"creates"| PRA["docs/docs/pr-agent.md"]:::created
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+## Flows
+
+- Flow naming rule: ``### Flow: `<flowname>` ``
+- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+
+AgentDocInput {
+  agentFilePath: string (absolute path to the source agent .md file)
+  outputDocPath: string (absolute path to the destination docs/docs/*.md file)
+}
+
+AgentDocOutput {
+  path: string (absolute path to the written doc file)
+  action: "created"
+}
+```
+
+---
+
+### Flow: `doc.dark-factory-agent`
+
+- Test files: `N/A`
+- Core files: `docs/docs/dark-factory-agent.md`
+
+#### Types
+
+```txt
+Input: AgentDocInput {
+  agentFilePath: "agents/dark-factory/agents/dark-factory-agent.md"
+  outputDocPath: "docs/docs/dark-factory-agent.md"
+}
+Output: AgentDocOutput
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `doc.dark-factory-agent.success` | `AgentDocInput` | `AgentDocOutput` | `happy path` | doc written covering: classification, prep-feature-dir, brain.json lifecycle, worker routing (feature/fix-flow/debugger/repair), branch-drift guard, code-review, update-documentation, skill-update, pr-agent, cleanup | |
+| `doc.dark-factory-agent.write-error` | `AgentDocInput` | `StandardError` | `error` | unable to write output file | |
+
+#### Pseudocode
+
+```
+Read agents/dark-factory/agents/dark-factory-agent.md
+Document:
+  - Role: top-level haiku orchestrator
+  - Model: haiku (state/routing only, no heavy reasoning)
+  - Input: taskDescription, taskName
+  - 12-step orchestration loop (classify → prep → brain → route → drift-guard → code-review → update-docs → skill-update → pr → metrics → cleanup)
+  - Worker routes: feature-agent, fix-flow-orchestrator, debugger-agent, repair-agent
+  - cleanup() helper definition
+  - Key rules: never write code, always cleanup on error, brain state via brain-state-manager
+Write docs/docs/dark-factory-agent.md
+```
+
+---
+
+### Flow: `doc.feature-agent`
+
+- Test files: `N/A`
+- Core files: `docs/docs/feature-agent.md`
+
+#### Types
+
+```txt
+Input: AgentDocInput {
+  agentFilePath: "agents/featurework/agents/feature-agent.md"
+  outputDocPath: "docs/docs/feature-agent.md"
+}
+Output: AgentDocOutput
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `doc.feature-agent.success` | `AgentDocInput` | `AgentDocOutput` | `happy path` | doc written covering: 5-phase planning loop (draft_plan → mermaid → flows → final gate → execute), return-question protocol, flow-state-manager delegation | |
+| `doc.feature-agent.write-error` | `AgentDocInput` | `StandardError` | `error` | unable to write output file | |
+
+#### Pseudocode
+
+```
+Read agents/featurework/agents/feature-agent.md
+Document:
+  - Role: end-to-end feature orchestrator (haiku)
+  - Input: taskDescription, answer, planPath
+  - Resume logic: reads Stage Gate Tracker checkboxes to determine current phase
+  - Phase 1 (draft_plan): invokes planning-agent, returns status:"question"
+  - Phase 2 (mermaid): invokes planning-agent, sends PushNotification with diagram URL
+  - Phase 3 (flows): one-flow-at-a-time approval via flow-state-manager
+  - Phase 4 (final gate): shows full plan, waits for Approve and Execute
+  - Phase 5 (execute): invokes execution-agent, writes brain-patch.json on success
+  - Key rule: never call AskUserQuestion — return status:"question" instead
+Write docs/docs/feature-agent.md
+```
+
+---
+
+### Flow: `doc.code-review-orchestrator-agent`
+
+- Test files: `N/A`
+- Core files: `docs/docs/code-review-orchestrator-agent.md`
+
+#### Types
+
+```txt
+Input: AgentDocInput {
+  agentFilePath: "agents/code-review/agents/code-review-orchestrator-agent.md"
+  outputDocPath: "docs/docs/code-review-orchestrator-agent.md"
+}
+Output: AgentDocOutput
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `doc.code-review-orchestrator-agent.success` | `AgentDocInput` | `AgentDocOutput` | `happy path` | doc written covering: parallel reviewer spawn, resolver loop, issues.md lifecycle, 10-iteration guard | |
+| `doc.code-review-orchestrator-agent.write-error` | `AgentDocInput` | `StandardError` | `error` | unable to write output file | |
+
+#### Pseudocode
+
+```
+Read agents/code-review/agents/code-review-orchestrator-agent.md
+Document:
+  - Role: haiku orchestrator for code review
+  - Input: planFilePath, codePath
+  - Flow: manage-issues-file create → spawn HLR + LLR in parallel → wait → resolver loop until anyRemaining=false → manage-issues-file delete
+  - Guard: halt if resolver runs > 10 iterations
+  - Output: {status: "complete"}
+  - Error paths: reviewer error (before resolver), resolver error (during loop)
+Write docs/docs/code-review-orchestrator-agent.md
+```
+
+---
+
+### Flow: `doc.fix-flow-orchestrator`
+
+- Test files: `N/A`
+- Core files: `docs/docs/fix-flow-orchestrator.md`
+
+#### Types
+
+```txt
+Input: AgentDocInput {
+  agentFilePath: "agents/fix-flow/agents/fix-flow-orchestrator.md"
+  outputDocPath: "docs/docs/fix-flow-orchestrator.md"
+}
+Output: AgentDocOutput
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `doc.fix-flow-orchestrator.success` | `AgentDocInput` | `AgentDocOutput` | `happy path` | doc written covering: 3 phases (investigate → setup → fix-and-push), required flow-name argument, ralph-fix-and-push loop | |
+| `doc.fix-flow-orchestrator.write-error` | `AgentDocInput` | `StandardError` | `error` | unable to write output file | |
+
+#### Pseudocode
+
+```
+Read agents/fix-flow/agents/fix-flow-orchestrator.md
+Document:
+  - Role: haiku orchestrator for fix-flow route
+  - Input: flow-name (required; asks user if missing)
+  - Phase 1: investigation-agent → docs/plans/system-diagram.md
+  - Phase 2: setup-wizard → generated scripts (trigger, fetch-logs, wait-for-completion)
+  - Phase 3: ralph-fix-and-push → single PR with all accumulated fixes
+  - Artifacts persisted: docs/plans/system-diagram.md, docs/bugs/*.md
+Write docs/docs/fix-flow-orchestrator.md
+```
+
+---
+
+### Flow: `doc.debugger-agent`
+
+- Test files: `N/A`
+- Core files: `docs/docs/debugger-agent.md`
+
+#### Types
+
+```txt
+Input: AgentDocInput {
+  agentFilePath: "agents/debugger/agents/debugger-agent.md"
+  outputDocPath: "docs/docs/debugger-agent.md"
+}
+Output: AgentDocOutput
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `doc.debugger-agent.success` | `AgentDocInput` | `AgentDocOutput` | `happy path` | doc written covering: systematic debug checklist, bug audit log lifecycle, brain-patch.json output | |
+| `doc.debugger-agent.write-error` | `AgentDocInput` | `StandardError` | `error` | unable to write output file | |
+
+#### Pseudocode
+
+```
+Read agents/debugger/agents/debugger-agent.md
+Document:
+  - Role: systematic debugger (sonnet) for non-obvious/state-dependent bugs
+  - Input: taskDescription
+  - Steps in order: confirm bug warrants systematic debug → check docs/bugs/ for existing log → read logs before touching code → fill bug-audit-log-template → run debug checklist (write failing test → confirm fails → identify root cause → fix → confirm passes → optionally remove fix and confirm fails)
+  - Output: brain-patch.json with bugFiles array
+  - Key rule: do not touch code before reading all relevant logs
+Write docs/docs/debugger-agent.md
+```
+
+---
+
+### Flow: `doc.repair-agent`
+
+- Test files: `N/A`
+- Core files: `docs/docs/repair-agent.md`
+
+#### Types
+
+```txt
+Input: AgentDocInput {
+  agentFilePath: "agents/repair/agents/repair-agent.md"
+  outputDocPath: "docs/docs/repair-agent.md"
+}
+Output: AgentDocOutput
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `doc.repair-agent.success` | `AgentDocInput` | `AgentDocOutput` | `happy path` | doc written covering: baseline test run, targeted apply, significantChange flag, 5-attempt fix loop | |
+| `doc.repair-agent.write-error` | `AgentDocInput` | `StandardError` | `error` | unable to write output file | |
+
+#### Pseudocode
+
+```
+Read agents/repair/agents/repair-agent.md
+Document:
+  - Role: lightweight targeted change agent (sonnet) — no plan file required
+  - Input: taskDescription
+  - Steps: understand scope → baseline test run (record pre-existing failures) → apply minimal change → assess significantChange flag → fix loop up to 5 attempts for new failures
+  - significantChange=true if: agent .md, SKILL.md, command, or public API boundary changed
+  - Output: {success: true, significantChange} or {success: false, significantChange, error}
+  - Key rule: pre-existing failures are noted but not counted against repair
+Write docs/docs/repair-agent.md
+```
+
+---
+
+### Flow: `doc.update-documentation-agent`
+
+- Test files: `N/A`
+- Core files: `docs/docs/update-documentation-agent.md`
+
+#### Types
+
+```txt
+Input: AgentDocInput {
+  agentFilePath: "agents/documentation/agents/update-documentation-agent.md"
+  outputDocPath: "docs/docs/update-documentation-agent.md"
+}
+Output: AgentDocOutput
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `doc.update-documentation-agent.success` | `AgentDocInput` | `AgentDocOutput` | `happy path` | doc written covering: 3-phase flow (identify flows → identify affected docs → update docs), find-affected-docs command, brain-patch.json | |
+| `doc.update-documentation-agent.write-error` | `AgentDocInput` | `StandardError` | `error` | unable to write output file | |
+
+#### Pseudocode
+
+```
+Read agents/documentation/agents/update-documentation-agent.md
+Document:
+  - Role: post-execution doc updater (sonnet)
+  - Input: planFilePath
+  - Phase 1: extract flows/services/components from plan → build tmp/update-docs-flows.md
+  - Phase 2: invoke find-affected-docs command → append affected doc list to checklist
+  - Phase 3: for each existing doc edit in place; for each new flow create docs/docs/<flow-name>.md using documentation skill
+  - Output: brain-patch.json with docsWritten array
+Write docs/docs/update-documentation-agent.md
+```
+
+---
+
+### Flow: `doc.skill-update-agent`
+
+- Test files: `N/A`
+- Core files: `docs/docs/skill-update-agent.md`
+
+#### Types
+
+```txt
+Input: AgentDocInput {
+  agentFilePath: "agents/skill-update/agents/skill-update-agent.md"
+  outputDocPath: "docs/docs/skill-update-agent.md"
+}
+Output: AgentDocOutput
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `doc.skill-update-agent.success` | `AgentDocInput` | `AgentDocOutput` | `happy path` | doc written covering: candidate pattern detection, recurrence filter, skill template, brain-patch.json | |
+| `doc.skill-update-agent.write-error` | `AgentDocInput` | `StandardError` | `error` | unable to write output file | |
+
+#### Pseudocode
+
+```
+Read agents/skill-update/agents/skill-update-agent.md
+Document:
+  - Role: post-execution skill harvester (sonnet) — non-fatal step in dark-factory-agent
+  - Input: planFilePath (nullable), workDir, taskSummary
+  - Steps: gather context (plan + git diff) → identify candidate patterns (NOTEs, WORKAROUNDs, HACKs, repeated lookups) → recurrence filter (task-specific vs general) → write/update skills/<slug>/SKILL.md
+  - Output: {skillsWritten: SkillFile[]} + brain-patch.json if skillsWritten non-empty
+  - Key rule: only write when pattern is non-obvious AND likely to recur; prefer empty list over noise
+Write docs/docs/skill-update-agent.md
+```
+
+---
+
+### Flow: `doc.pr-agent`
+
+- Test files: `N/A`
+- Core files: `docs/docs/pr-agent.md`
+
+#### Types
+
+```txt
+Input: AgentDocInput {
+  agentFilePath: "agents/pr/agents/pr-agent.md"
+  outputDocPath: "docs/docs/pr-agent.md"
+}
+Output: AgentDocOutput
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `doc.pr-agent.success` | `AgentDocInput` | `AgentDocOutput` | `happy path` | doc written covering: 5-step PR lifecycle, ci-watch-runner and comment-resolution-runner delegation, does-not-merge rule | |
+| `doc.pr-agent.write-error` | `AgentDocInput` | `StandardError` | `error` | unable to write output file | |
+
+#### Pseudocode
+
+```
+Read agents/pr/agents/pr-agent.md
+Document:
+  - Role: PR lifecycle manager (sonnet)
+  - Input: planFilePath or description string
+  - Steps: build PR body from plan/description → invoke create-pr skill → write brain-patch.json with prUrl → ci-watch-runner (max 5 iterations) → comment-resolution-runner (max 5 iterations)
+  - Output: {prUrl, status: "ready"}
+  - SubagentStop hook: pr-agent-cleanup-hook.sh
+  - Key rule: does NOT merge — stops at status ready; always uses git -C "$WORK_DIR"
+Write docs/docs/pr-agent.md
+```
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| N/A | This feature produces only static documentation files; no runtime logs are generated. |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  # No deployment — files are committed to the repository as documentation.
+  # After manufacture completes, the new docs/docs/*.md files will be in the PR.
+  ```
+- Notes: All 9 new doc files land in `docs/docs/` and are committed as part of the manufacture PR. No runtime or infra changes.


### PR DESCRIPTION
## Description

# Doc Sub-Agents Manufacture

## System Intent

- **What is being built**: Individual documentation files in `docs/docs/` for dark-factory-agent and its 8 direct child agents. Each agent currently lacks a dedicated doc; they are only described inline in `docs/docs/manufacture.md`. This feature creates one authoritative doc per agent using the existing documentation template. Sub-sub-agents (planning-agent, sub-planning-agent, execution-agent, skeleton-agent, testing-agent, implementation-agent, high-level-review-agent, low-level-review-agent, resolver-agent) are explicitly out of scope.
- **Primary consumer(s)**: Future agents (investigation-agent, update-documentation-agent) that look up `docs/docs/<system>.md` before modifying a system. Also human developers onboarding to the pipeline.
- **Boundary (black-box scope only)**: Read-only analysis of agent `.md` files under `agents/`; write new `.md` files under `docs/docs/`. No agent source files are modified. Exactly 9 doc files created: dark-factory-agent, feature-agent, fix-flow-orchestrator, debugger-agent, repair-agent, code-review-orchestrator-agent, update-documentation-agent, skill-update-agent, pr-agent.

## New Doc Files

| File | Agent |
|------|-------|
| `docs/docs/dark-factory-agent.md` | top-level haiku orchestrator |
| `docs/docs/feature-agent.md` | end-to-end feature orchestrator |
| `docs/docs/fix-flow-orchestrator.md` | fix-flow route orchestrator |
| `docs/docs/debugger-agent.md` | systematic debugger |
| `docs/docs/repair-agent.md` | lightweight targeted change agent |
| `docs/docs/code-review-orchestrator-agent.md` | code review orchestrator |
| `docs/docs/update-documentation-agent.md` | post-execution doc updater |
| `docs/docs/skill-update-agent.md` | post-execution skill harvester |
| `docs/docs/pr-agent.md` | PR lifecycle manager |

## Stage Gate Tracker

- [x] Stage 1 Mermaid approved
- [x] Stage 2 Flows approved
- [x] Stage 3 Logs + Deployment approved or skipped

## Deployment

No deployment required — files are committed to the repository as documentation. No runtime or infra changes.

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
