### PR TITLE
fix(metrics): write /tmp/dark-factory-work-dir pointer file so hooks can resolve WORK_DIR

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -57,6 +57,9 @@ dark-factory-agent(taskDescription, taskName):
 
   If brain-state-manager errors: report error and STOP
 
+  # Write pointer file so hook processes can resolve WORK_DIR without the env var
+  bash("printf '%s' \"$WORK_DIR\" > /tmp/dark-factory-work-dir")
+
   # Step 4 — route to worker agent
   featureBranch = "feature/" + taskName
 
@@ -128,6 +131,7 @@ dark-factory-agent(taskDescription, taskName):
   # Step 12 — flush metrics then cleanup
   bash("python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py\" --csv \"$projectDir/metrics.csv\" --brain \"$WORK_DIR/brain.json\" || true")
   invoke brain-state-manager({ operation: "delete", workDir: WORK_DIR })
+  bash("rm -f /tmp/dark-factory-work-dir")
   bash("${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh \"$WORK_DIR\" \"$taskName\"")
 
   Report: "Done. PR: " + prUrl + ". Worktree " + WORK_DIR + " removed."
@@ -138,6 +142,7 @@ dark-factory-agent(taskDescription, taskName):
 
 ```
 invoke brain-state-manager({ operation: "delete", workDir: WORK_DIR })
+bash("rm -f /tmp/dark-factory-work-dir")
 bash "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh" "$WORK_DIR" "$taskName"
 ```
 

--- a/skills/brain-hook-driven-state/SKILL.md
+++ b/skills/brain-hook-driven-state/SKILL.md
@@ -13,11 +13,11 @@ When adding a new sub-agent to the dark-factory pipeline, or when modifying how 
 
 1. After `prep-feature-dir.sh` captures `WORK_DIR`, write `$WORK_DIR/brain.json` with all fields initialized. The `phases` object must have every phase pair (`*-running` / `*-complete`) set to `false`, except `prep-complete: true`.
 
-2. Export the env var so hook scripts (child processes) can find brain.json:
+2. Write the work dir to the pointer file so hook processes can resolve it. Do NOT rely on `export` inside a Bash tool call — env vars set that way die with the subprocess and are never seen by hook processes (which inherit Claude Code's environment, not the LLM tool-call shell). The pointer file is the authoritative channel:
    ```bash
-   export DARK_FACTORY_WORK_DIR=<WORK_DIR>
+   printf '%s' "$WORK_DIR" > /tmp/dark-factory-work-dir
    ```
-   The variable must be `export`-ed — not merely set — because hooks run as separate processes.
+   See the `claude-code-hook-env-isolation` skill for a full explanation of why `export` fails here.
 
 3. Invoke sub-agents normally. Do NOT pass brainPath as an argument; the pre-hook injects brain state automatically.
 
@@ -79,7 +79,7 @@ Hooks are registered via the plugin's `hooks/hooks.json` file (referenced from `
 - Phase sequencing is implicit: the pre-hook always picks the first unstarted phase in declaration order. If a sub-agent runs more than once (e.g., retries), the hook will attempt to start the next unstarted phase — ensure phase names and ordering in brain.json match the actual invocation order.
 - `jq -s '.[0] * .[1]'` does a shallow merge. Nested objects are replaced wholesale, not deeply merged. If a patch needs deep merge, the post-hook logic must be extended.
 - Hook scripts must be executable (`chmod +x`). The allowed-tools list in the agent frontmatter must include `Bash(jq *)`, `Bash(rm -f *)`, and `Bash(export *)` for the orchestrator to create/delete brain.json and export the env var.
-- The `DARK_FACTORY_WORK_DIR` env var is the sole coupling point between the orchestrator and the hook scripts. If this var is not exported before the first Agent tool call, all hooks will silently pass through.
+- The pointer file `/tmp/dark-factory-work-dir` is the authoritative coupling point between the orchestrator and the hook scripts. It must be written immediately after `brain.json` is created (Step 2) and deleted in both the happy-path cleanup and every error-path `cleanup()` function. If the pointer file is absent and the env var is also unset (the common in-process case), all hooks will silently pass through and metrics will never accumulate.
 - `brain.json.workDir` is the path to the ephemeral git worktree, which is deleted by `cleanup-worktree.sh`. If any cleanup step must write a permanent file to the real project root (e.g., a metrics CSV), capture `PROJECT_DIR=$(git rev-parse --show-toplevel)` before entering the worktree, store it as `brain.json.projectDir`, and read it back in the cleanup step before deleting brain.json. See the `capture-project-dir-before-worktree` skill for the full pattern.
 - When hooks fire at multiple nesting depths (e.g., feature-agent calls repair-agent which calls a helper), multiple hook processes can write brain.json concurrently. Wrap every read-modify-write block with `flock` inside a subshell. See the `flock-shared-file-in-hooks` skill for the exact pattern.
 - Phase transitions (`*-running` / `*-complete`) must only fire for top-level orchestration agents, not for nested sub-agents. Use a `PHASE_AGENTS` allowlist regex in both hook scripts to guard phase-transition blocks while still accumulating metrics for all agents. See the `phase-agent-allowlist` skill for the exact pattern.


### PR DESCRIPTION
## Description

Fix the metrics.csv never-written bug: hooks cannot see DARK_FACTORY_WORK_DIR because export in a Bash subprocess does not propagate to the Claude Code parent process. Fix: write a pointer file at /tmp/dark-factory-work-dir after brain.json is created; hooks fall back to reading this file when the env var is unset; cleanup removes the pointer file.

### Root Cause

`export DARK_FACTORY_WORK_DIR=<WORK_DIR>` was executed inside a Bash tool call (a subprocess launched by Claude Code). When that subprocess exits, the exported variable is gone. Hook processes (pre-tool-use / post-tool-use) inherit Claude Code's own environment — not the environment of any LLM tool-call shell — so they never saw `DARK_FACTORY_WORK_DIR`. As a result, every hook call hit the "no brain found" path, metrics were never written to `brain.json`, and `metrics.csv` was never updated.

### Fix

1. **`agents/dark-factory/agents/dark-factory-agent.md`** — After brain.json is created (Step 3), write the work dir path to a pointer file:
   ```bash
   printf '%s' "$WORK_DIR" > /tmp/dark-factory-work-dir
   ```
   In both the happy-path cleanup (Step 12) and the error-path `cleanup()` function, remove the pointer file:
   ```bash
   rm -f /tmp/dark-factory-work-dir
   ```

2. **`skills/brain-hook-driven-state/SKILL.md`** — Replace the `export` guidance with the pointer-file approach. Update the coupling-point note to reflect that `/tmp/dark-factory-work-dir` is now authoritative. Reference the `claude-code-hook-env-isolation` skill for the full explanation.

The pre- and post-tool-use hook scripts already contain fallback logic to read the pointer file when the env var is unset, so no hook-script changes are needed.

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
