### PR TITLE
fix(pr-agent): check for existing PR before creating duplicate

### DIFF
--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -21,6 +21,16 @@ A file path or description string for the PR body. If neither provided, use the 
 ```
 pr-agent(planFilePath or description):
 
+  # Step 0 — Check if a PR already exists for the current branch
+  existingPr = run: gh pr view --json url --jq '.url' 2>/dev/null
+  if existingPr is non-empty (branch already has an open PR):
+    # Commit the changes with a descriptive message instead of opening a new PR
+    run: git -C "$WORK_DIR" add --all
+    build a commit message summarising what was changed (use planFilePath or description as context)
+    run: git -C "$WORK_DIR" commit -m "<descriptive commit message explaining the fix>"
+    run: git -C "$WORK_DIR" push
+    RETURN { prUrl: existingPr, status: "ready" }
+
   # Step 1 — Build PR body
   Read agents/pr/templates/pr-template.md for structure.
   Populate Description from planFilePath (or description string).

--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -22,13 +22,17 @@ A file path or description string for the PR body. If neither provided, use the 
 pr-agent(planFilePath or description):
 
   # Step 0 — Check if a PR already exists for the current branch
-  existingPr = run: gh pr view --json url --jq '.url' 2>/dev/null
+  existingPr = run: cd "$WORK_DIR" && gh pr view --json url --jq '.url' 2>/dev/null
   if existingPr is non-empty (branch already has an open PR):
     # Commit the changes with a descriptive message instead of opening a new PR
     run: git -C "$WORK_DIR" add --all
-    build a commit message summarising what was changed (use planFilePath or description as context)
-    run: git -C "$WORK_DIR" commit -m "<descriptive commit message explaining the fix>"
-    run: git -C "$WORK_DIR" push
+    result = run: git -C "$WORK_DIR" commit -m "<descriptive commit message summarizing the changes>"
+    if commit fails (e.g., nothing to commit): 
+      write $DARK_FACTORY_WORK_DIR/brain-patch.json: { "prUrl": existingPr } (skip silently if unset)
+      RETURN { prUrl: existingPr, status: "ready" }
+    result = run: git -C "$WORK_DIR" push origin HEAD
+    if push fails: STOP with error "Failed to push changes to existing PR"
+    write $DARK_FACTORY_WORK_DIR/brain-patch.json: { "prUrl": existingPr } (skip silently if unset)
     RETURN { prUrl: existingPr, status: "ready" }
 
   # Step 1 — Build PR body

--- a/docs/docs/pr-agent.md
+++ b/docs/docs/pr-agent.md
@@ -18,7 +18,24 @@ The PR lifecycle is fully automated except for the final merge decision, enablin
 - Or `taskDescription` (string) — Plain description of the work if no plan exists
 - If neither: uses git diff
 
-## Orchestration Flow (5 Steps)
+## Orchestration Flow (6 Steps)
+
+### Step 0: Check for Existing PR
+
+Before doing anything else, pr-agent checks whether the current branch already has an open PR.
+
+1. **Runs** `gh pr view --json url --jq '.url'` in `$WORK_DIR`
+2. **If an existing PR is found** (non-empty output):
+   - Stages all changes: `git -C "$WORK_DIR" add --all`
+   - Commits with a descriptive message: `git -C "$WORK_DIR" commit -m "<summary>"`
+   - If commit fails (nothing to commit): skips commit, proceeds to push skip
+   - Pushes to the existing branch: `git -C "$WORK_DIR" push origin HEAD`
+   - If push fails: STOPS with error "Failed to push changes to existing PR"
+   - Writes brain-patch.json: `{ "prUrl": existingPr }`
+   - **Returns early**: `{ prUrl: existingPr, status: "ready" }` — skips Steps 1–5
+3. **If no existing PR**: continues to Step 1
+
+This prevents duplicate PRs when pr-agent is invoked on a branch that was already submitted for review.
 
 ### Step 1: Build PR Body
 
@@ -122,14 +139,15 @@ The PR body includes (from `agents/pr/templates/pr-template.md`):
 
 ## Key Design Rules
 
-1. **Code is already implemented** — Assume fix is complete; don't re-apply
-2. **Always use git -C "$WORK_DIR"** — WORK_DIR is injected by pre-hook
-3. **Write body to /tmp/pr-body.md** — Use standard gh cli pattern
-4. **Delegate CI watching** — Use ci-watch-runner, don't implement watch loop inline
-5. **Delegate comment resolution** — Use comment-resolution-runner, don't implement loop inline
-6. **Do NOT merge** — Stop at "ready" status; human makes the merge decision
-7. **Write brain-patch after PR opens** — Captures prUrl for downstream use
-8. **Skip brain-patch silently if DARK_FACTORY_WORK_DIR unset** — No error
+1. **Check for existing PR first (Step 0)** — If the current branch already has an open PR, commit and push directly to it; do not open a duplicate PR
+2. **Code is already implemented** — Assume fix is complete; don't re-apply
+3. **Always use git -C "$WORK_DIR"** — WORK_DIR is injected by pre-hook
+4. **Write body to /tmp/pr-body.md** — Use standard gh cli pattern
+5. **Delegate CI watching** — Use ci-watch-runner, don't implement watch loop inline
+6. **Delegate comment resolution** — Use comment-resolution-runner, don't implement loop inline
+7. **Do NOT merge** — Stop at "ready" status; human makes the merge decision
+8. **Write brain-patch after PR opens or after Step 0 commit** — Captures prUrl for downstream use
+9. **Skip brain-patch silently if DARK_FACTORY_WORK_DIR unset** — No error
 
 ## Dependencies
 
@@ -181,6 +199,7 @@ The pr-agent intentionally stops at "ready" (CI green, reviews resolved) and doe
 
 ## Error Handling
 
+- If existing PR branch push fails (Step 0): surfaces "Failed to push changes to existing PR" and STOPS
 - If PR creation fails: surfaces error and STOPS
 - If CI never stabilizes (yellow for all iterations): returns failure
 - If review comments can't be resolved (pending after 5 iterations): returns failure

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -15,7 +15,34 @@ new branch — committing from the main worktree CWD on a new `fix/` branch woul
 to land on `main` instead of `feature/<taskName>`. All git commands must use `-C "$WORK_DIR"`
 to operate on the feature worktree.
 
-1. Confirm the current branch in the worktree:
+### Step 0 — Check for an existing PR (idempotency guard)
+
+Before doing anything else, check whether the branch already has an open PR:
+
+```bash
+existingPr=$(cd "$WORK_DIR" && gh pr view --json url --jq '.url' 2>/dev/null)
+```
+
+If `existingPr` is non-empty, the branch already has an open PR. Do NOT call `gh pr create`.
+Instead:
+
+1. Stage and commit any new changes:
+   ```bash
+   git -C "$WORK_DIR" add --all
+   git -C "$WORK_DIR" commit -m "<descriptive commit message>"
+   # If nothing to commit, skip silently
+   ```
+2. Push to the existing PR branch:
+   ```bash
+   git -C "$WORK_DIR" push origin HEAD
+   ```
+3. Write `$DARK_FACTORY_WORK_DIR/brain-patch.json` with `{ "prUrl": "<existingPr>" }` (skip if env var unset).
+4. Return `{ prUrl: existingPr, status: "ready" }` — do not proceed to PR creation steps.
+
+This guard prevents duplicate PRs when a manufacture run or repair loop re-invokes pr-agent on
+a branch that was already promoted to a PR.
+
+### Step 1 — Confirm the current branch in the worktree:
    ```bash
    git -C "$WORK_DIR" branch --show-current
    # Expected output: feature/<taskName>


### PR DESCRIPTION
## Description

# Fix PR Agent Existing PR Check

## Problem

The pr-agent was creating a new PR even when the current branch already had an open PR. This caused duplicate PRs to be opened for the same feature or fix.

## Solution

Add a Step 0 that checks for an existing PR using `gh pr view` before attempting to create a new one. If a PR exists:
1. Commit the changes directly to the existing PR's branch
2. Push the changes
3. Return early with the existing PR URL

If no PR exists, proceed with the normal flow (Steps 1-5).

## Changes

- Modified `agents/pr/agents/pr-agent.md` to add Step 0 check for existing PR
- If `gh pr view` returns a URL, the agent commits and pushes changes instead of creating a new PR
- Returns early with the existing PR URL and status "ready"
- Updated `docs/docs/pr-agent.md` to document the new Step 0 flow
- Updated `skills/create-pr/SKILL.md` with idempotency guard pattern

## Testing

- Verify behavior when running pr-agent on a branch without an existing PR (should create new PR as before)
- Verify behavior when running pr-agent on a branch with an existing open PR (should commit to existing PR and return)

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
