### PR TITLE
fix(pr-agent): remove early return when existing PR detected

### DIFF
--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -21,14 +21,24 @@ A file path or description string for the PR body. If neither provided, use the 
 ```
 pr-agent(planFilePath or description):
 
+  # Step 0 — Check for existing PR on current branch
+  existingPr = gh pr view --json url --jq '.url' 2>/dev/null || null
+  if existingPr is not null:
+    git -C "$WORK_DIR" add --all
+    git -C "$WORK_DIR" commit -m "<short description of fix>"
+    git -C "$WORK_DIR" push
+    pr_url = existingPr
+  # (if no existing PR, pr_url will be set in Step 2 below)
+
   # Step 1 — Build PR body
   Read agents/pr/templates/pr-template.md for structure.
   Populate Description from planFilePath (or description string).
   Run tests if a test suite exists; include output in Test Plan, or omit section if none.
   Write body to /tmp/pr-body.md.
 
-  # Step 2 — Open PR (delegate to create-pr skill)
-  pr_url = invoke create-pr({ bodyFile: "/tmp/pr-body.md" })
+  # Step 2 — Open PR (delegate to create-pr skill) if no existing PR
+  if existingPr is null:
+    pr_url = invoke create-pr({ bodyFile: "/tmp/pr-body.md" })
   write $DARK_FACTORY_WORK_DIR/brain-patch.json: { "prUrl": pr_url }
 
   # Step 3 — Watch CI (delegate to ci-watch-runner command)

--- a/docs/docs/pr-agent.md
+++ b/docs/docs/pr-agent.md
@@ -18,7 +18,16 @@ The PR lifecycle is fully automated except for the final merge decision, enablin
 - Or `taskDescription` (string) — Plain description of the work if no plan exists
 - If neither: uses git diff
 
-## Orchestration Flow (5 Steps)
+## Orchestration Flow (6 Steps)
+
+### Step 0: Check for Existing PR
+
+1. **Runs `gh pr view`** to check if a PR already exists for the current branch
+2. **If a PR exists**:
+   - Commits all staged changes with a short description (`git -C "$WORK_DIR" add --all && git -C "$WORK_DIR" commit && git -C "$WORK_DIR" push`)
+   - Sets `pr_url` to the existing PR URL
+   - Does **not** return early — continues to Step 1
+3. **If no PR exists**: `pr_url` is left unset; will be set in Step 2
 
 ### Step 1: Build PR Body
 
@@ -34,55 +43,58 @@ The PR lifecycle is fully automated except for the final merge decision, enablin
    - Omits "Test Plan" section if no test suite found
 4. **Writes body** to `/tmp/pr-body.md` (ready for gh cli)
 
-### Step 2: Open PR
+### Step 2: Open PR (conditional)
 
-1. **Delegates to create-pr skill** with `bodyFile: "/tmp/pr-body.md"`
-2. Receives `prUrl` back from skill
-3. **Writes brain-patch.json** in DARK_FACTORY_WORK_DIR:
+1. **Only runs if no existing PR was found in Step 0** (`pr_url` is unset)
+2. **Delegates to create-pr skill** with `bodyFile: "/tmp/pr-body.md"`
+3. Receives `prUrl` back from skill
+4. **Writes brain-patch.json** in DARK_FACTORY_WORK_DIR regardless of path (new or existing PR):
    ```json
    { "prUrl": "<github PR URL>" }
    ```
    (Skip silently if DARK_FACTORY_WORK_DIR is unset)
 
-### Step 3: Watch CI
+### Step 3: Watch CI (always runs)
 
-1. **Delegates to ci-watch-runner command** with:
+1. **Always runs** — whether the PR was newly created (Step 2) or already existed (Step 0)
+2. **Delegates to ci-watch-runner command** with:
    - `prUrl: <the PR URL>`
    - `maxIterations: 5`
 
-2. Command polls PR CI status repeatedly:
+3. Command polls PR CI status repeatedly:
    - Checks status at regular intervals
    - Reports when CI is green, yellow (pending), or red (failed)
    - Stops after maxIterations or when status stabilizes
 
-3. **If ciResult.status == "fail"**: returns error, STOPS
+4. **If ciResult.status == "fail"**: returns error, STOPS
    - CI failed; human review of failures required
    - PR remains open for investigation
 
-4. **If ciResult.status == "pass"**: proceeds to Step 4
+5. **If ciResult.status == "pass"**: proceeds to Step 4
 
-### Step 4: Resolve Review Comments
+### Step 4: Resolve Review Comments (always runs)
 
-1. **Gets PR node ID**:
+1. **Always runs** — whether the PR was newly created (Step 2) or already existed (Step 0)
+2. **Gets PR node ID**:
    - Uses `gh api graphql` to fetch `pr.id` from prUrl
 
-2. **Delegates to comment-resolution-runner command** with:
+3. **Delegates to comment-resolution-runner command** with:
    - `prUrl: <the PR URL>`
    - `prNodeId: <the PR node ID>`
    - `maxIterations: 5`
 
-3. Command iterates through review comments:
+4. Command iterates through review comments:
    - Reads each comment thread
    - Attempts to resolve by responding (if automated resolution applies)
    - Or requests human clarification
    - Marks threads resolved when addressed
    - Stops after maxIterations or when all threads are resolved
 
-4. **If commentResult.status == "failed"**: returns error, STOPS
+5. **If commentResult.status == "failed"**: returns error, STOPS
    - Review comments could not be resolved
    - PR remains open with pending threads
 
-5. **If commentResult.status == "success"**: all threads resolved, proceeds to Step 5
+6. **If commentResult.status == "success"**: all threads resolved, proceeds to Step 5
 
 ### Step 5: Return Success
 
@@ -130,6 +142,8 @@ The PR body includes (from `agents/pr/templates/pr-template.md`):
 6. **Do NOT merge** — Stop at "ready" status; human makes the merge decision
 7. **Write brain-patch after PR opens** — Captures prUrl for downstream use
 8. **Skip brain-patch silently if DARK_FACTORY_WORK_DIR unset** — No error
+9. **Step 0 does NOT return early** — When an existing PR is found, commit+push and set pr_url, then continue; CI watching and comment resolution always run on both the new-PR and existing-PR paths
+10. **gh pr create is conditional** — Only called when no existing PR was found in Step 0
 
 ## Dependencies
 

--- a/skills/converge-existing-resource-path/SKILL.md
+++ b/skills/converge-existing-resource-path/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: converge-existing-resource-path
+description: "When an agent detects that a long-lived resource (PR, branch, deployment) already exists, perform the side effects for that path (commit, push, record the existing URL) and fall through to the shared continuation — never early-return and skip the remaining steps."
+user-invocable: false
+---
+## When to use
+
+Any time an agent has a Step 0 / pre-check that detects an already-existing resource before attempting to create one. Common cases:
+
+- A PR already exists on the current branch when pr-agent runs
+- A deployment or release already exists when a deploy agent runs
+- A remote branch already exists when a branch-create step runs
+
+The wrong instinct is to early-return once the resource is found ("it already exists, nothing to do"). The correct pattern is to complete the side effects that belong to the "existing" path and then converge with the "new" path so that all downstream steps (CI watching, comment resolution, status reporting) still execute.
+
+## Steps
+
+1. At the top of the agent flow, check for the existing resource:
+   ```
+   existingResource = <lookup command> 2>/dev/null || null
+   ```
+
+2. If the resource exists, perform any side effects that are still needed (e.g., commit and push pending changes) and record the resource identifier:
+   ```
+   if existingResource is not null:
+     git add --all
+     git commit -m "<short description of pending changes>"
+     git push
+     resource_url = existingResource
+   # (if resource does not exist, resource_url will be set in the creation step below)
+   ```
+
+3. Gate the creation step on the resource not yet existing — do NOT return early:
+   ```
+   if existingResource is null:
+     resource_url = <create resource>
+   ```
+
+4. Continue with all downstream steps unconditionally using `resource_url`:
+   ```
+   write brain-patch.json: { "resourceUrl": resource_url }
+   # watch CI, resolve comments, etc.
+   ```
+
+## Notes
+
+- The bug this pattern prevents: early-returning after detecting the existing resource causes all downstream steps (CI watching, comment resolution, merging) to be skipped. The PR sits open and unmonitored forever.
+- Both branches (existing and new) must set `resource_url` before the downstream steps; downstream steps are always unconditional.
+- If the pending commit in Step 2 produces nothing to commit (working tree clean), the `git commit` will fail with "nothing to commit" — guard with `git status --porcelain` before committing, or use `git commit --allow-empty` only if an explicit marker commit is desired.
+- This pattern was introduced in the 2026-05-04 fix to `agents/pr/agents/pr-agent.md` to fix pr-agent skipping CI watching when an existing PR was detected.


### PR DESCRIPTION
## Description

Fix pr-agent bug where Step 0 (existing PR check) was returning early and skipping CI watching and comment resolution.

**Root cause:** When `gh pr view` found an existing PR on the current branch, the agent was setting `pr_url` and then implicitly stopping — the subsequent CI and comment-resolution steps were gated inside an `else` block that never executed on the existing-PR path.

**Fix:** Restructured the orchestration so that Step 0 only commits, pushes, and sets `pr_url`. The `gh pr create` call is now conditional (`if existingPr is null`). Steps 3 (CI watching) and 4 (comment resolution) are unconditional and run on both the new-PR and existing-PR paths.

**Files changed:**

- `agents/pr/agents/pr-agent.md` — removed early return, made `gh pr create` conditional, CI/comment steps unconditional
- `docs/docs/pr-agent.md` — updated to reflect both paths always run CI watching and comment resolution
- `skills/converge-existing-resource-path/SKILL.md` — new skill capturing the convergence pattern (set URL on both paths, then fall through to shared downstream steps)

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
