### PR TITLE
fix(agents): use /tmp/dark-factory-work-dir fallback for brain-patch.json writes

### DIFF
--- a/agents/debugger/agents/debugger-agent.md
+++ b/agents/debugger/agents/debugger-agent.md
@@ -29,14 +29,20 @@ You are a systematic debugger. Your only job is to follow the steps in `flows/de
 
 After the bug file(s) have been written and the debugging checklist is complete:
 
-Write `$DARK_FACTORY_WORK_DIR/brain-patch.json` with:
-```json
-{
-  "bugFiles": ["<absolute path to each bug audit log file written>"]
-}
+Resolve WORK_DIR:
+```
+WORK_DIR = $DARK_FACTORY_WORK_DIR
+if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+if WORK_DIR is still empty: skip writing the patch silently
+else: Write `$WORK_DIR/brain-patch.json` with:
+  ```json
+  {
+    "bugFiles": ["<absolute path to each bug audit log file written>"]
+  }
+  ```
 ```
 
 Rules:
 - Do NOT read `brain.json` directly — your context is already injected by the pre-hook.
 - Do NOT write `brain.json` directly — only write `brain-patch.json`.
-- If `DARK_FACTORY_WORK_DIR` is not set or empty, skip writing the patch silently.
+- Use pointer file fallback (`/tmp/dark-factory-work-dir`) if DARK_FACTORY_WORK_DIR is unset.

--- a/agents/documentation/agents/update-documentation-agent.md
+++ b/agents/documentation/agents/update-documentation-agent.md
@@ -49,8 +49,13 @@ Mark each checklist item `[x]` when done.
 
 ## Completion
 
-Write `$DARK_FACTORY_WORK_DIR/brain-patch.json`:
-```json
-{ "docsWritten": ["<absolute path to each file written or updated>"] }
+Resolve WORK_DIR:
 ```
-Skip silently if DARK_FACTORY_WORK_DIR is unset.
+WORK_DIR = $DARK_FACTORY_WORK_DIR
+if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+if WORK_DIR is still empty: skip silently
+else: Write `$WORK_DIR/brain-patch.json`:
+  ```json
+  { "docsWritten": ["<absolute path to each file written or updated>"] }
+  ```
+```

--- a/agents/featurework/agents/feature-agent.md
+++ b/agents/featurework/agents/feature-agent.md
@@ -111,7 +111,10 @@ feature-agent(taskDescription, answer, planPath):
   if execution-agent returns hardStop:
     RETURN { status: "hard-stop", reason: execution-agent reason }
 
-  write $DARK_FACTORY_WORK_DIR/brain-patch.json: { "planFilePath": planPath }
+  WORK_DIR = $DARK_FACTORY_WORK_DIR
+  if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+  if WORK_DIR is still empty: skip silently
+  else: write $WORK_DIR/brain-patch.json: { "planFilePath": planPath }
 
   RETURN { status: "done", planPath }
 ```
@@ -123,4 +126,4 @@ feature-agent(taskDescription, answer, planPath):
 - Delegate flow state reads/writes to flow-state-manager skill.
 - Delegate section rendering to render-plan-section command.
 - After a hard-stop, return `{ status: "hard-stop" }` — do not re-invoke execution-agent.
-- Write brain-patch.json only after execution-agent succeeds; skip silently if DARK_FACTORY_WORK_DIR is unset.
+- Write brain-patch.json only after execution-agent succeeds; use pointer file fallback if DARK_FACTORY_WORK_DIR is unset.

--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -39,7 +39,11 @@ pr-agent(planFilePath or description):
   # Step 2 — Open PR (delegate to create-pr skill) if no existing PR
   if existingPr is null:
     pr_url = invoke create-pr({ bodyFile: "/tmp/pr-body.md" })
-  write $DARK_FACTORY_WORK_DIR/brain-patch.json: { "prUrl": pr_url }
+  
+  WORK_DIR = $DARK_FACTORY_WORK_DIR
+  if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+  if WORK_DIR is still empty: skip silently
+  else: write $WORK_DIR/brain-patch.json: { "prUrl": pr_url }
 
   # Step 3 — Watch CI (delegate to ci-watch-runner command)
   ciResult = invoke ci-watch-runner({ prUrl: pr_url, maxIterations: 5 })
@@ -62,4 +66,4 @@ pr-agent(planFilePath or description):
 - Delegate CI watching to ci-watch-runner — do not implement watch loop inline.
 - Delegate comment resolution to comment-resolution-runner — do not implement comment loop inline.
 - Do not merge.
-- Write brain-patch.json after PR is opened; skip silently if DARK_FACTORY_WORK_DIR is unset.
+- Write brain-patch.json after PR is opened; use pointer file fallback if DARK_FACTORY_WORK_DIR is unset.

--- a/agents/skill-update/agents/skill-update-agent.md
+++ b/agents/skill-update/agents/skill-update-agent.md
@@ -106,16 +106,22 @@ user-invocable: false
 
 After Step 5 (return), before returning to the caller:
 
-Write `$DARK_FACTORY_WORK_DIR/brain-patch.json` with:
-```json
-{
-  "skillsWritten": ["<relative path within workDir for each skill file written or updated>"]
-}
+Resolve WORK_DIR:
 ```
-
-If `skillsWritten` is empty (no skills were written), omit writing the patch entirely.
+WORK_DIR = $DARK_FACTORY_WORK_DIR
+if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+if WORK_DIR is still empty: skip writing the patch silently
+else:
+  Write `$WORK_DIR/brain-patch.json` with:
+  ```json
+  {
+    "skillsWritten": ["<relative path within workDir for each skill file written or updated>"]
+  }
+  ```
+  (If `skillsWritten` is empty, omit writing the patch entirely.)
+```
 
 Rules:
 - Do NOT read `brain.json` directly — your context is already injected by the pre-hook.
 - Do NOT write `brain.json` directly — only write `brain-patch.json`.
-- If `DARK_FACTORY_WORK_DIR` is not set or empty, skip writing the patch silently.
+- Use pointer file fallback (`/tmp/dark-factory-work-dir`) if DARK_FACTORY_WORK_DIR is unset.

--- a/docs/docs/debugger-agent.md
+++ b/docs/docs/debugger-agent.md
@@ -100,7 +100,7 @@ Update bug file with:
 
 After all bug files are written and debugging checklist is complete:
 
-Writes `$DARK_FACTORY_WORK_DIR/brain-patch.json`:
+Resolves WORK_DIR (see rule 7) and writes `$WORK_DIR/brain-patch.json`:
 ```json
 {
   "bugFiles": [
@@ -118,7 +118,7 @@ Writes `$DARK_FACTORY_WORK_DIR/brain-patch.json`:
 4. **Verify fix is necessary** — Remove fix and confirm test fails again (except when unsafe)
 5. **Do NOT read brain.json** — Context is already injected by pre-hook
 6. **Do NOT write brain.json directly** — Only write brain-patch.json
-7. **Skip brain-patch silently if DARK_FACTORY_WORK_DIR unset** — No error if environment variable missing
+7. **Resolve WORK_DIR via pointer file fallback** — Use `$DARK_FACTORY_WORK_DIR` if set; else read contents of `/tmp/dark-factory-work-dir`; skip brain-patch silently if both are empty
 
 ## Dependencies
 

--- a/docs/docs/feature-agent.md
+++ b/docs/docs/feature-agent.md
@@ -83,7 +83,7 @@ Iterates through all flows in the plan, one per turn:
 2. If execution-agent returns `hardStop: true`:
    - **Returns** `status: "hard-stop"` with reason; does NOT re-invoke execution-agent
 3. If execution-agent succeeds:
-   - Writes `brain-patch.json` in DARK_FACTORY_WORK_DIR: `{ "planFilePath": planPath }`
+   - Writes `brain-patch.json` resolving work dir via pointer file fallback: `{ "planFilePath": planPath }`
    - **Returns** `status: "done"` with planPath
 
 ## Resume Logic via Stage Gate Tracker
@@ -144,7 +144,7 @@ Execution paused; user must review and resume.
 3. **Delegate flow state** — Use flow-state-manager skill for all flow approval tracking
 4. **Delegate rendering** — Use render-plan-section command to format plan sections
 5. **Handle hard-stop gracefully** — When execution-agent returns hard-stop, return it upstream; don't retry
-6. **Write brain-patch.json only after execution succeeds** — Skip silently if DARK_FACTORY_WORK_DIR is unset
+6. **Write brain-patch.json only after execution succeeds** — Resolve WORK_DIR from `$DARK_FACTORY_WORK_DIR`, then fall back to contents of `/tmp/dark-factory-work-dir`; skip silently if both are empty
 
 ## Dependencies
 

--- a/docs/docs/pr-agent.md
+++ b/docs/docs/pr-agent.md
@@ -48,11 +48,11 @@ The PR lifecycle is fully automated except for the final merge decision, enablin
 1. **Only runs if no existing PR was found in Step 0** (`pr_url` is unset)
 2. **Delegates to create-pr skill** with `bodyFile: "/tmp/pr-body.md"`
 3. Receives `prUrl` back from skill
-4. **Writes brain-patch.json** in DARK_FACTORY_WORK_DIR regardless of path (new or existing PR):
+4. **Writes brain-patch.json** regardless of path (new or existing PR), resolving work dir via pointer file fallback:
    ```json
    { "prUrl": "<github PR URL>" }
    ```
-   (Skip silently if DARK_FACTORY_WORK_DIR is unset)
+   Work dir resolution: use `$DARK_FACTORY_WORK_DIR` if set; else read `/tmp/dark-factory-work-dir`; skip silently if both empty.
 
 ### Step 3: Watch CI (always runs)
 
@@ -141,7 +141,7 @@ The PR body includes (from `agents/pr/templates/pr-template.md`):
 5. **Delegate comment resolution** — Use comment-resolution-runner, don't implement loop inline
 6. **Do NOT merge** — Stop at "ready" status; human makes the merge decision
 7. **Write brain-patch after PR opens** — Captures prUrl for downstream use
-8. **Skip brain-patch silently if DARK_FACTORY_WORK_DIR unset** — No error
+8. **Resolve WORK_DIR via pointer file fallback** — Check `$DARK_FACTORY_WORK_DIR` first; if unset, read `/tmp/dark-factory-work-dir`; skip silently if both empty
 9. **Step 0 does NOT return early** — When an existing PR is found, commit+push and set pr_url, then continue; CI watching and comment resolution always run on both the new-PR and existing-PR paths
 10. **gh pr create is conditional** — Only called when no existing PR was found in Step 0
 

--- a/docs/docs/skill-update-agent.md
+++ b/docs/docs/skill-update-agent.md
@@ -142,7 +142,7 @@ Examples:
 
 ## Brain Patch Output
 
-If any skills were written or updated, write `$DARK_FACTORY_WORK_DIR/brain-patch.json`:
+If any skills were written or updated, write `$WORK_DIR/brain-patch.json`:
 ```json
 {
   "skillsWritten": [
@@ -154,7 +154,7 @@ If any skills were written or updated, write `$DARK_FACTORY_WORK_DIR/brain-patch
 
 **Rules**:
 - Only write brain-patch if `skillsWritten` is non-empty
-- Skip writing silently if `DARK_FACTORY_WORK_DIR` is unset
+- Resolve WORK_DIR: use `$DARK_FACTORY_WORK_DIR` if set; else read contents of `/tmp/dark-factory-work-dir`; skip silently if both are empty
 - Do not read brain.json directly (context is injected by pre-hook)
 - Do not write brain.json (only write brain-patch.json)
 

--- a/docs/docs/update-documentation-agent.md
+++ b/docs/docs/update-documentation-agent.md
@@ -64,7 +64,7 @@ For each item in Phase 2 checklist:
 
 ## Completion
 
-After all docs are updated or created, writes `$DARK_FACTORY_WORK_DIR/brain-patch.json`:
+After all docs are updated or created, resolves WORK_DIR and writes `$WORK_DIR/brain-patch.json`:
 ```json
 {
   "docsWritten": [
@@ -75,7 +75,7 @@ After all docs are updated or created, writes `$DARK_FACTORY_WORK_DIR/brain-patc
 }
 ```
 
-**Note**: Skip writing brain-patch.json silently if `DARK_FACTORY_WORK_DIR` is unset.
+**WORK_DIR resolution**: use `$DARK_FACTORY_WORK_DIR` if set; else read contents of `/tmp/dark-factory-work-dir` (if file exists); skip silently if both are empty.
 
 ## Key Design Rules
 
@@ -85,7 +85,7 @@ After all docs are updated or created, writes `$DARK_FACTORY_WORK_DIR/brain-patc
 4. **Create new docs for new flows** — Don't assume documentation exists for new flows
 5. **Use documentation skill** — Delegate doc generation for new flows to the skill
 6. **Track all changes** — Write brain-patch.json with paths to every file touched
-7. **Skip brain-patch silently** — If DARK_FACTORY_WORK_DIR is unset, don't error
+7. **Resolve WORK_DIR via pointer file fallback** — Check `$DARK_FACTORY_WORK_DIR`; if unset, read `/tmp/dark-factory-work-dir`; skip brain-patch silently if both empty
 
 ## Dependencies
 

--- a/docs/plans/2026-05-05-audit-brain-json.md
+++ b/docs/plans/2026-05-05-audit-brain-json.md
@@ -1,0 +1,60 @@
+# Plan: Fix brain-patch.json Silent Skip — Use Pointer File Fallback
+
+## Problem
+
+Every agent that writes `brain-patch.json` does so via `$DARK_FACTORY_WORK_DIR/brain-patch.json` and has the rule: **"skip silently if `DARK_FACTORY_WORK_DIR` is unset."**
+
+`DARK_FACTORY_WORK_DIR` is set once by dark-factory-agent but is **not propagated to sub-agents** (Claude Code resets env vars between Bash calls; sub-agents run in isolated processes). This means every single brain-patch.json write is silently skipped in practice — `prUrl`, `planFilePath`, `docsWritten`, and `skillsWritten` are never written to brain.json.
+
+The `/tmp/dark-factory-work-dir` pointer file exists as a documented fallback for exactly this case. Agents don't use it.
+
+## Root Cause
+
+Agents that write brain-patch.json:
+1. `feature-agent` — writes `planFilePath`
+2. `pr-agent` — writes `prUrl`
+3. `skill-update-agent` — writes `skillsWritten`
+4. `update-documentation-agent` — writes `docsWritten`
+5. `debugger-agent` — writes `bugFiles`
+
+All five silently skip if `DARK_FACTORY_WORK_DIR` is unset. None fall back to `/tmp/dark-factory-work-dir`.
+
+## Fix
+
+Update the brain-patch.json write instruction in all five agents to:
+
+```
+WORK_DIR = $DARK_FACTORY_WORK_DIR
+if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+if WORK_DIR is still empty: skip silently
+else: write $WORK_DIR/brain-patch.json: { ... }
+```
+
+## Flows
+
+### Flow 1: fix-feature-agent-brain-patch
+Update `agents/featurework/agents/feature-agent.md` brain-patch.json write rule to use pointer file fallback.
+
+### Flow 2: fix-pr-agent-brain-patch
+Update `agents/pr/agents/pr-agent.md` brain-patch.json write rule to use pointer file fallback.
+
+### Flow 3: fix-skill-update-agent-brain-patch
+Update `agents/skill-update/agents/skill-update-agent.md` brain-patch.json write rule to use pointer file fallback.
+
+### Flow 4: fix-update-documentation-agent-brain-patch
+Update `agents/documentation/agents/update-documentation-agent.md` brain-patch.json write rule to use pointer file fallback.
+
+### Flow 5: fix-debugger-agent-brain-patch
+Update `agents/debugger/agents/debugger-agent.md` brain-patch.json write rule to use pointer file fallback.
+
+### Flow 6: add-tests
+Add pytest tests verifying that each agent's brain-patch.json write instruction includes the pointer file fallback pattern.
+
+## Files
+
+- `agents/featurework/agents/feature-agent.md`
+- `agents/pr/agents/pr-agent.md`
+- `agents/skill-update/agents/skill-update-agent.md`
+- `agents/documentation/agents/update-documentation-agent.md`
+- `agents/debugger/agents/debugger-agent.md`
+- `tests/test_brain_patch_pointer_fallback.py` (new)

--- a/skills/brain-hook-driven-state/SKILL.md
+++ b/skills/brain-hook-driven-state/SKILL.md
@@ -49,11 +49,14 @@ When adding a new sub-agent to the dark-factory pipeline, or when modifying how 
 
 - Do NOT read brain.json directly — brain state is already injected into the prompt by the pre-hook.
 - Do NOT write brain.json directly.
-- After producing output, write ONLY your specific output fields to `$DARK_FACTORY_WORK_DIR/brain-patch.json`:
-  ```json
-  { "planFilePath": "/absolute/path/to/plan.md" }
+- After producing output, resolve the work directory first (the env var is never propagated to sub-agents — see the `subagent-brain-patch-pointer-fallback` skill for the exact pattern):
   ```
-- If `DARK_FACTORY_WORK_DIR` is not set or the sub-agent has no output to record, skip writing the patch entirely.
+  WORK_DIR = $DARK_FACTORY_WORK_DIR
+  if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+  if WORK_DIR is still empty: skip silently
+  else: write $WORK_DIR/brain-patch.json with ONLY your specific output fields:
+    { "planFilePath": "/absolute/path/to/plan.md" }
+  ```
 - The patch file is deleted by the post-hook after it is merged; sub-agents must not re-read it.
 
 ### Registering hooks via hooks/hooks.json

--- a/skills/subagent-brain-patch-pointer-fallback/SKILL.md
+++ b/skills/subagent-brain-patch-pointer-fallback/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: subagent-brain-patch-pointer-fallback
+description: "When a sub-agent writes brain-patch.json, it must resolve WORK_DIR via the /tmp/dark-factory-work-dir pointer file because $DARK_FACTORY_WORK_DIR is never propagated to sub-agent processes."
+user-invocable: false
+---
+## When to use
+
+Every time a sub-agent (feature-agent, pr-agent, skill-update-agent, update-documentation-agent, debugger-agent, or any new agent added to the pipeline) needs to write `brain-patch.json` at the end of its run.
+
+Do NOT use the bare `$DARK_FACTORY_WORK_DIR` approach without the pointer-file fallback. The env var is set by the orchestrator (dark-factory-agent) in one Bash subprocess and is never visible to sub-agents, which run in isolated processes.
+
+## The root cause
+
+`DARK_FACTORY_WORK_DIR` is exported by the orchestrator inside a Bash tool call. That call's subprocess exits immediately after, taking the env var with it. Sub-agents launched later (via the `Agent` tool) run in their own fresh environment and never inherit the value.
+
+`/tmp/dark-factory-work-dir` is written to disk by the orchestrator and survives across process boundaries, making it the correct resolution channel.
+
+## Steps
+
+In every sub-agent's brain-patch.json write block, use this exact resolution sequence:
+
+```
+WORK_DIR = $DARK_FACTORY_WORK_DIR
+if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+if WORK_DIR is still empty: skip writing the patch silently
+else: write $WORK_DIR/brain-patch.json with the sub-agent's output fields
+```
+
+In pseudocode / shell:
+
+```bash
+WORK_DIR="${DARK_FACTORY_WORK_DIR:-}"
+if [ -z "$WORK_DIR" ] && [ -f /tmp/dark-factory-work-dir ]; then
+  WORK_DIR=$(cat /tmp/dark-factory-work-dir)
+fi
+if [ -n "$WORK_DIR" ]; then
+  echo '{ "myField": "value" }' > "$WORK_DIR/brain-patch.json"
+fi
+```
+
+## Notes
+
+- This pattern is required for ALL five existing brain-patch writers and any new sub-agent added to the pipeline.
+- The pointer file is created by dark-factory-agent immediately after `brain.json` is written (see `brain-hook-driven-state` skill, Step 2) and deleted during cleanup.
+- Hook scripts (pre/post tool-use) use the same pointer-file fallback on the bash side — see `claude-code-hook-env-isolation` skill for the hook-specific pattern.
+- Never silently skip the write without first checking the pointer file — silent skips mean brain.json fields (`planFilePath`, `prUrl`, `docsWritten`, `skillsWritten`, `bugFiles`) are never populated and the orchestrator cannot hand values between pipeline phases.

--- a/tests/test_brain_patch_pointer_fallback.py
+++ b/tests/test_brain_patch_pointer_fallback.py
@@ -1,0 +1,74 @@
+"""
+Tests for brain-patch.json pointer file fallback pattern.
+
+Verifies that each agent's brain-patch.json write instruction includes
+the pointer file fallback pattern (references /tmp/dark-factory-work-dir).
+"""
+
+import os
+
+
+def _read_agent_file(agent_path):
+    """Helper to read an agent markdown file."""
+    abs_path = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        agent_path
+    )
+    with open(abs_path, 'r') as f:
+        return f.read()
+
+
+def _has_pointer_fallback(content):
+    """Check if content includes the pointer file fallback pattern."""
+    # Check for the fallback pattern that reads from /tmp/dark-factory-work-dir
+    return '/tmp/dark-factory-work-dir' in content
+
+
+def test_feature_agent_has_pointer_fallback():
+    """
+    # Plan path: fix-feature-agent-brain-patch
+    Verify feature-agent.md contains pointer file fallback in brain-patch.json write rule.
+    """
+    content = _read_agent_file('agents/featurework/agents/feature-agent.md')
+    assert _has_pointer_fallback(content), \
+        "feature-agent.md must include /tmp/dark-factory-work-dir fallback"
+
+
+def test_pr_agent_has_pointer_fallback():
+    """
+    # Plan path: fix-pr-agent-brain-patch
+    Verify pr-agent.md contains pointer file fallback in brain-patch.json write rule.
+    """
+    content = _read_agent_file('agents/pr/agents/pr-agent.md')
+    assert _has_pointer_fallback(content), \
+        "pr-agent.md must include /tmp/dark-factory-work-dir fallback"
+
+
+def test_skill_update_agent_has_pointer_fallback():
+    """
+    # Plan path: fix-skill-update-agent-brain-patch
+    Verify skill-update-agent.md contains pointer file fallback in brain-patch.json write rule.
+    """
+    content = _read_agent_file('agents/skill-update/agents/skill-update-agent.md')
+    assert _has_pointer_fallback(content), \
+        "skill-update-agent.md must include /tmp/dark-factory-work-dir fallback"
+
+
+def test_update_documentation_agent_has_pointer_fallback():
+    """
+    # Plan path: fix-update-documentation-agent-brain-patch
+    Verify update-documentation-agent.md contains pointer file fallback in brain-patch.json write rule.
+    """
+    content = _read_agent_file('agents/documentation/agents/update-documentation-agent.md')
+    assert _has_pointer_fallback(content), \
+        "update-documentation-agent.md must include /tmp/dark-factory-work-dir fallback"
+
+
+def test_debugger_agent_has_pointer_fallback():
+    """
+    # Plan path: fix-debugger-agent-brain-patch
+    Verify debugger-agent.md contains pointer file fallback in brain-patch.json write rule.
+    """
+    content = _read_agent_file('agents/debugger/agents/debugger-agent.md')
+    assert _has_pointer_fallback(content), \
+        "debugger-agent.md must include /tmp/dark-factory-work-dir fallback"


### PR DESCRIPTION
## Description

# Plan: Fix brain-patch.json Silent Skip — Use Pointer File Fallback

## Problem

Every agent that writes `brain-patch.json` does so via `$DARK_FACTORY_WORK_DIR/brain-patch.json` and has the rule: **"skip silently if `DARK_FACTORY_WORK_DIR` is unset."**

`DARK_FACTORY_WORK_DIR` is set once by dark-factory-agent but is **not propagated to sub-agents** (Claude Code resets env vars between Bash calls; sub-agents run in isolated processes). This means every single brain-patch.json write is silently skipped in practice — `prUrl`, `planFilePath`, `docsWritten`, and `skillsWritten` are never written to brain.json.

The `/tmp/dark-factory-work-dir` pointer file exists as a documented fallback for exactly this case. Agents don't use it.

## Root Cause

Agents that write brain-patch.json:
1. `feature-agent` — writes `planFilePath`
2. `pr-agent` — writes `prUrl`
3. `skill-update-agent` — writes `skillsWritten`
4. `update-documentation-agent` — writes `docsWritten`
5. `debugger-agent` — writes `bugFiles`

All five silently skip if `DARK_FACTORY_WORK_DIR` is unset. None fall back to `/tmp/dark-factory-work-dir`.

## Fix

Update the brain-patch.json write instruction in all five agents to:

```
WORK_DIR = $DARK_FACTORY_WORK_DIR
if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
if WORK_DIR is still empty: skip silently
else: write $WORK_DIR/brain-patch.json: { ... }
```

## Flows

- Flow 1: Update `agents/featurework/agents/feature-agent.md` — pointer file fallback for `planFilePath`
- Flow 2: Update `agents/pr/agents/pr-agent.md` — pointer file fallback for `prUrl`
- Flow 3: Update `agents/skill-update/agents/skill-update-agent.md` — pointer file fallback for `skillsWritten`
- Flow 4: Update `agents/documentation/agents/update-documentation-agent.md` — pointer file fallback for `docsWritten`
- Flow 5: Update `agents/debugger/agents/debugger-agent.md` — pointer file fallback for `bugFiles`
- Flow 6: Add `tests/test_brain_patch_pointer_fallback.py` — pytest tests verifying fallback pattern in all 5 agents

## Test Plan

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
rootdir: /home/lewibs/github/dark_factory/dark_factory-audit-brain-json
collected 5 items

tests/test_brain_patch_pointer_fallback.py::test_feature_agent_has_pointer_fallback PASSED [ 20%]
tests/test_brain_patch_pointer_fallback.py::test_pr_agent_has_pointer_fallback PASSED [ 40%]
tests/test_brain_patch_pointer_fallback.py::test_skill_update_agent_has_pointer_fallback PASSED [ 60%]
tests/test_brain_patch_pointer_fallback.py::test_update_documentation_agent_has_pointer_fallback PASSED [ 80%]
tests/test_brain_patch_pointer_fallback.py::test_debugger_agent_has_pointer_fallback PASSED [100%]

============================== 5 passed in 0.00s ===============================
```

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
