### PR TITLE
feat(agents): wire investigation-agent to debugger and repair agents

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.31",
+  "version": "1.2.32",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/agents/debugger/agents/debugger-agent.md
+++ b/agents/debugger/agents/debugger-agent.md
@@ -2,15 +2,29 @@
 name: debugger-agent
 user-invocable: false
 description: Runs systematic debugging on a non-obvious bug by following the debug skill checklist step by step.
-tools: Read, Write, Edit, Bash, Glob, Agent
+tools: Read, Write, Edit, Bash, Glob, Agent, Skill
 model: sonnet
-skills: systematic-debugging
+skills: systematic-debugging, invoke-investigation-agent
 allowed-tools: Bash(bash *), Bash(pytest *), Bash(python *), Bash(npm test *), Bash(grep -r *), Bash(find *)
 ---
 
 You are a systematic debugger. Your only job is to follow the steps in `flows/debugger/skills/debug/SKILL.md` in order, without skipping.
 
 ## Steps
+
+0. **Understand the system** — Before proceeding with systematic debugging, invoke `investigation-agent` with the bug description to understand the system context. This ensures you have authoritative documentation about the components involved in the failure before diving into debugging.
+   ```
+   result = invoke investigation-agent({
+     system: "",
+     question: "<taskDescription>"
+   })
+   
+   if result.error:
+     log("Investigation failed, proceeding with available knowledge")
+   else:
+     # Use result.content as reference documentation during debugging
+     systemDocumentation = result.content
+   ```
 
 1. Confirm the bug warrants systematic debugging (non-obvious, state-dependent, intermittent, unknown cause).
 2. Search the project `docs/bugs/` for an existing file with the same failure signature. Create `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` if none found.

--- a/agents/repair/agents/repair-agent.md
+++ b/agents/repair/agents/repair-agent.md
@@ -2,8 +2,9 @@
 name: repair-agent
 user-invocable: false
 description: Lightweight repair agent. Applies a targeted change from a plain task description (no plan file), runs the test suite, and iteratively fixes failures up to 5 times.
-tools: Read, Write, Edit, Bash, Glob
+tools: Read, Write, Edit, Bash, Glob, Agent, Skill
 model: sonnet
+skills: invoke-investigation-agent
 allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(npm run test *), Bash(go test *), Bash(bash *), Bash(mkdir -p *), Bash(find *), Bash(grep -r *)
 ---
 
@@ -15,6 +16,20 @@ You will be invoked with:
 - `taskDescription` — verbatim description of what to change or fix
 
 ## Your task
+
+0. **Understand the system** — Before identifying files to change, invoke `investigation-agent` with the task description to understand the system context. This ensures you have authoritative documentation about the components you'll be modifying.
+   ```
+   result = invoke investigation-agent({
+     system: "",
+     question: "<taskDescription>"
+   })
+   
+   if result.error:
+     log("Investigation failed, proceeding with available knowledge")
+   else:
+     # Use result.content as reference documentation
+     systemDocumentation = result.content
+   ```
 
 1. **Understand** — Read the relevant files. Identify the minimal set of files that need to change to satisfy `taskDescription`. Do not refactor or expand scope beyond what is asked.
 


### PR DESCRIPTION
## Summary

Wires debugger-agent and repair-agent to invoke investigation-agent before proceeding with their main work. Both agents now delegate system understanding to investigation-agent, ensuring they have authoritative documentation about the components involved before debugging or making repairs.

## Changes

- **debugger-agent.md**: Added Step 0 to invoke investigation-agent with bug description before systematic debugging
- **repair-agent.md**: Added Step 0 to invoke investigation-agent with task description before applying repairs
- Both agents now have Agent and Skill tools in their frontmatter to support investigation-agent invocation
- Both agents register the invoke-investigation-agent skill

## Rationale

This closes the gap where the investigate command and manufacture flow should re-use the same documentation infrastructure. Per CLAUDE.md, when agents need to understand systems before proceeding, they should delegate to investigation-agent rather than doing ad-hoc research inline. This ensures:

1. Knowledge is centralized - investigation-agent checks docs/docs/ first before investigating
2. Documentation is kept in sync - if docs don't exist, investigation-agent creates them
3. Agents have consistent understanding - all agents use the same authoritative sources
4. Debugging is more efficient - agents start with system context rather than blind exploration

## Testing

Manual testing of debugger-agent and repair-agent invocations with various task descriptions will confirm they successfully invoke investigation-agent and proceed with their work.

Generated with Claude Code
