### PR TITLE
fix(metrics): use tail instead of head for agent name extraction

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.32",
+  "version": "1.2.33",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/agents/dark-factory/scripts/post-tool-use-hook.sh
+++ b/agents/dark-factory/scripts/post-tool-use-hook.sh
@@ -58,7 +58,7 @@ if [ "$TOOL_NAME" = "Agent" ] || [ "$TOOL_NAME" = "Skill" ]; then
     METRICS_KEY=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.subagent_type // "unknown"')
     if [ "$METRICS_KEY" = "null" ] || [ "$METRICS_KEY" = "unknown" ]; then
       METRICS_KEY=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.prompt // ""' \
-        | grep -oP '(?<=agents/)[^/]+(?=\.md)' | head -1 || true)
+        | grep -oP '(?<=agents/)[^/]+(?=\.md)' | tail -1 || true)
       METRICS_KEY="${METRICS_KEY:-unknown}"
     fi
   else

--- a/agents/dark-factory/scripts/pre-tool-use-hook.sh
+++ b/agents/dark-factory/scripts/pre-tool-use-hook.sh
@@ -43,7 +43,7 @@ if [ "$TOOL_NAME" = "Agent" ] || [ "$TOOL_NAME" = "Skill" ]; then
     if [ "$METRICS_KEY" = "null" ] || [ "$METRICS_KEY" = "unknown" ]; then
       # Fallback: try to extract agent name from prompt path reference (agents/<name>.md)
       METRICS_KEY=$(printf '%s' "$TOOL_INPUT" | jq -r '.tool_input.prompt // ""' \
-        | grep -oP '(?<=agents/)[^/]+(?=\.md)' | head -1 || true)
+        | grep -oP '(?<=agents/)[^/]+(?=\.md)' | tail -1 || true)
       METRICS_KEY="${METRICS_KEY:-unknown}"
     fi
   else


### PR DESCRIPTION
## Summary

Fixed a bug where metrics.csv was showing 0.0 runtime for several agents (testing-agent, planning-agent, debugger-agent, skeleton-agent) despite having non-zero run counts.

## Root Cause

The post-tool-use-hook uses `head -1` to extract the first agent reference from the modified prompt. However, after the pre-hook injects brain context, the prompt contains multiple agent references:

1. Brain context (first) - containing old/stale agent paths
2. Current agent (last) - the one being invoked

This causes:
- Pre-hook records metrics under actual agent name (e.g., skeleton-agent)
- Post-hook looks for start_ms under wrong agent name (e.g., planning-agent from brain context)
- Doesn't find it, defaults to start_ms=0, sets elapsed_ms=0 as safety check

## Fix

Changed `head -1` to `tail -1` in both hooks to pick the LAST (correct) agent reference:
- agents/dark-factory/scripts/pre-tool-use-hook.sh line 46
- agents/dark-factory/scripts/post-tool-use-hook.sh line 61

## Test Plan

- All existing unit tests in test_update_metrics.py pass
- Fix verified by grammar test: tail -1 correctly picks last agent when multiple exist in prompt
- Next manufacture run will properly record runtime for previously-broken agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)