### PR TITLE
feat: add /dark-factory:metrics command for performance ranking

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.33",
+  "version": "1.2.34",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,49 @@
+# Plan: Add /metrics Command
+
+## System Intent
+
+Create a new `/dark-factory:metrics` plugin command that displays a ranked list of agents and skills by slowest average runtime and highest token usage.
+
+The command reads from `metrics.csv` in the project root and displays two ranked tables:
+1. Slowest agents/skills by avg_runtime (descending)
+2. Most token-intensive agents/skills by avg_tokens (descending)
+
+Each ranking shows the top 15 entries with columns for:
+- Agent/Skill name
+- Average runtime (ms)
+- Average tokens
+- Number of runs
+- Total runtime
+- Total tokens
+
+## Implementation
+
+### Files Created
+
+- `commands/metrics.md` — Plugin command definition and documentation
+- `commands/metrics/metrics.py` — Python script implementing the ranking and display logic
+
+### Key Features
+
+- Reads metrics.csv using Python's csv module
+- Filters out entries where both avg_runtime and avg_tokens are 0.0
+- Sorts by runtime and tokens separately
+- Formats output as readable ASCII tables
+- Handles missing files gracefully with error messages
+- Searches multiple common locations for metrics.csv
+
+### Testing
+
+The implementation has been tested against the actual metrics.csv file and displays:
+- Top slowest agents: debugger-agent (418.5s), update-documentation-agent (172.2s), code-review-orchestrator-agent (158.9s)
+- Top token users: Explore (1786.0 avg), planning-agent (1155.0 avg), investigation-agent (1081.0 avg)
+
+## Approval Gates
+
+- [x] Draft plan complete
+- [x] Implementation complete and tested
+- [x] All files committed to feature branch
+
+## Completion Status
+
+Ready for code review and PR.

--- a/commands/metrics.md
+++ b/commands/metrics.md
@@ -1,0 +1,38 @@
+---
+name: metrics
+description: "Display ranked list of slowest and most token-intensive agents and skills from metrics.csv"
+---
+
+# metrics
+
+Display a ranked list of agents and skills by execution time and token usage.
+
+## Output
+
+Displays two ranked tables:
+1. **Slowest Agents/Skills** — sorted by avg_runtime (milliseconds) in descending order
+2. **Highest Token Usage** — sorted by avg_tokens in descending order
+
+Each table shows:
+- Agent/Skill name
+- Average runtime (ms)
+- Average tokens
+- Number of runs
+- Total runtime (ms)
+- Total tokens
+
+## Algorithm
+
+1. Read metrics.csv from the project root
+2. Parse CSV rows (skip header and rows with 0.0 values for both metrics)
+3. Sort by avg_runtime descending → display top slowest
+4. Sort by avg_tokens descending → display top token-heaviest
+5. Format as human-readable tables
+
+## Implementation
+
+The command is implemented as a simple Python script that:
+- Reads the CSV file
+- Filters out entries with zero metrics
+- Generates two sorted rankings
+- Formats output as readable tables

--- a/commands/metrics/metrics.py
+++ b/commands/metrics/metrics.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Metrics command: Display ranked list of slowest and most token-intensive agents/skills
+"""
+
+import csv
+import os
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+def read_metrics_csv(csv_path: str) -> List[dict]:
+    """Read and parse metrics.csv file."""
+    rows = []
+    try:
+        with open(csv_path, 'r') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                # Skip rows with zero values for both metrics
+                avg_runtime = float(row.get('avg_runtime', 0))
+                avg_tokens = float(row.get('avg_tokens', 0))
+                
+                if avg_runtime == 0.0 and avg_tokens == 0.0:
+                    continue
+                
+                rows.append({
+                    'name': row.get('agent', row.get('skill', 'Unknown')).strip() or 'Unknown',
+                    'avg_runtime': avg_runtime,
+                    'avg_tokens': avg_tokens,
+                    'runs': int(row.get('runs', 0)),
+                    'sum_runtime': float(row.get('sum_runtime', 0)),
+                    'sum_tokens': float(row.get('sum_tokens', 0)),
+                })
+    except FileNotFoundError:
+        print(f"Error: metrics.csv not found at {csv_path}", file=sys.stderr)
+        return []
+    except Exception as e:
+        print(f"Error reading metrics.csv: {e}", file=sys.stderr)
+        return []
+    
+    return rows
+
+def format_table(headers: List[str], rows: List[Tuple], col_widths: List[int]) -> str:
+    """Format data as a simple ASCII table."""
+    lines = []
+    
+    # Header
+    header_line = " | ".join(h.ljust(w) for h, w in zip(headers, col_widths))
+    lines.append(header_line)
+    lines.append("-" * len(header_line))
+    
+    # Rows
+    for row in rows:
+        row_line = " | ".join(str(v).ljust(w) for v, w in zip(row, col_widths))
+        lines.append(row_line)
+    
+    return "\n".join(lines)
+
+def main():
+    """Main entry point."""
+    # Find project root (metrics.csv should be there)
+    # Start from current directory and work up
+    current = Path.cwd()
+    metrics_csv = None
+    
+    # Try common locations
+    for attempt in [current, current.parent, Path.home() / "github" / "dark_factory" / "dark_factory"]:
+        candidate = attempt / "metrics.csv"
+        if candidate.exists():
+            metrics_csv = candidate
+            break
+    
+    if not metrics_csv:
+        # Fallback to env var or current dir
+        metrics_csv = Path(os.environ.get('DARK_FACTORY_METRICS_CSV', 'metrics.csv'))
+    
+    # Read metrics
+    rows = read_metrics_csv(str(metrics_csv))
+    
+    if not rows:
+        print("No metrics data available.")
+        return
+    
+    # Sort by runtime (slowest first)
+    slowest = sorted(rows, key=lambda r: r['avg_runtime'], reverse=True)
+    
+    # Sort by tokens (highest first)
+    most_tokens = sorted(rows, key=lambda r: r['avg_tokens'], reverse=True)
+    
+    # Display slowest
+    print("\n=== SLOWEST AGENTS/SKILLS (by avg_runtime) ===\n")
+    headers = ["Agent/Skill", "Avg Runtime (ms)", "Avg Tokens", "Runs", "Total Runtime (ms)", "Total Tokens"]
+    col_widths = [40, 18, 12, 6, 18, 14]
+    
+    slowest_rows = [
+        (
+            row['name'][:39],
+            f"{row['avg_runtime']:.0f}",
+            f"{row['avg_tokens']:.1f}",
+            str(row['runs']),
+            f"{row['sum_runtime']:.0f}",
+            f"{row['sum_tokens']:.0f}",
+        )
+        for row in slowest[:15]  # Top 15
+    ]
+    
+    print(format_table(headers, slowest_rows, col_widths))
+    
+    # Display most tokens
+    print("\n\n=== HIGHEST TOKEN USAGE (by avg_tokens) ===\n")
+    most_tokens_rows = [
+        (
+            row['name'][:39],
+            f"{row['avg_runtime']:.0f}",
+            f"{row['avg_tokens']:.1f}",
+            str(row['runs']),
+            f"{row['sum_runtime']:.0f}",
+            f"{row['sum_tokens']:.0f}",
+        )
+        for row in most_tokens[:15]  # Top 15
+    ]
+    
+    print(format_table(headers, most_tokens_rows, col_widths))
+    print()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Implements a new `/dark-factory:metrics` plugin command that displays ranked lists of agents and skills by:
- Slowest average runtime (milliseconds)
- Highest average token usage

The command reads from `metrics.csv` in the project root and displays the top 15 entries in each category with comprehensive metrics.

## Changes

- `commands/metrics.md` — Plugin command documentation
- `commands/metrics/metrics.py` — Python implementation with CSV parsing and table formatting

## Key Features

- Filters out zero-valued entries (agents/skills with no recorded metrics)
- Displays both slowest (by runtime) and most token-intensive (by avg_tokens) rankings
- Formats output as readable ASCII tables
- Handles missing metrics.csv file gracefully
- Searches multiple common locations for metrics.csv file

## Test Output

```
=== SLOWEST AGENTS/SKILLS (by avg_runtime) ===

debugger-agent                           | 418539             | 728.0        | 1      | 418539             | 728           
update-documentation-agent               | 172217             | 525.0        | 2      | 344434             | 1050          
code-review-orchestrator-agent           | 158897             | 636.2        | 12     | 1906766            | 7635
```

Enables performance monitoring and optimization targeting for the dark-factory system.

Generated with Claude Code