### PR TITLE
perf(agents): switch repair-agent and pr-agent to haiku model

### DIFF
--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -6,7 +6,7 @@ tools: Read, Bash, Write, Edit, Command
 skills: create-pr
 commands: ci-watch-runner, comment-resolution-runner
 allowed-tools: Bash(gh pr create *), Bash(gh pr view *), Bash(gh api graphql *), Bash(git -C * push *), Bash(git -C * add *), Bash(git -C * commit *), Bash(git -C * status *), Bash(git -C * log *), Bash(cat > /tmp/pr-body.md *)
-model: sonnet
+model: haiku
 SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/pr-agent-cleanup-hook.sh"
 ---
 

--- a/agents/repair/agents/repair-agent.md
+++ b/agents/repair/agents/repair-agent.md
@@ -3,7 +3,7 @@ name: repair-agent
 user-invocable: false
 description: Lightweight repair agent. Applies a targeted change from a plain task description (no plan file), runs the test suite, and iteratively fixes failures up to 5 times.
 tools: Read, Write, Edit, Bash, Glob, Agent, Skill
-model: sonnet
+model: haiku
 skills: invoke-investigation-agent
 allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(npm run test *), Bash(go test *), Bash(bash *), Bash(mkdir -p *), Bash(find *), Bash(grep -r *)
 ---

--- a/docs/docs/pr-agent.md
+++ b/docs/docs/pr-agent.md
@@ -2,7 +2,7 @@
 
 **Role**: PR lifecycle manager for completed work.
 
-**Model**: Sonnet (heavy reasoning for PR body composition and comment resolution).
+**Model**: Haiku (lightweight model for PR body composition and comment resolution).
 
 **User-Invocable**: No (invoked by dark-factory-agent after all work is complete).
 

--- a/docs/docs/repair-agent.md
+++ b/docs/docs/repair-agent.md
@@ -2,7 +2,7 @@
 
 **Role**: Lightweight, targeted change agent for simple fixes and updates.
 
-**Model**: Sonnet (heavy reasoning for targeted problem-solving).
+**Model**: Haiku (lightweight model; sufficient for targeted, minimal changes).
 
 **User-Invocable**: No (invoked by dark-factory-agent).
 

--- a/skills/haiku-orchestrator-worker-split/SKILL.md
+++ b/skills/haiku-orchestrator-worker-split/SKILL.md
@@ -88,6 +88,7 @@ When adding new agents or doing a cost-reduction pass, audit all agents in the s
 3. Build a classification table in the plan with columns: Agent | File | Current Model | Classification | Justification | Action.
 4. For agents where Current Model does not match Classification, change only the `model:` field in YAML front-matter.
 5. No logic, instruction, or tooling changes are needed — model is purely a front-matter field.
+6. After changing an agent's `model:` field, also update any companion documentation files (e.g. `docs/docs/<agent-name>.md`) that mention the model by name. These narrative docs get out of sync and mislead future agents about actual behavior.
 
 ## Notes
 


### PR DESCRIPTION
## Description

Switch `repair-agent` and `pr-agent` from `model: sonnet` to `model: haiku` to reduce token costs for high-frequency orchestration agents.

These agents run frequently as part of the dark-factory automation loop. They perform orchestration work (routing, dispatching, watching CI) rather than complex reasoning, which makes them good candidates for haiku — a cheaper, faster model that handles structured orchestration tasks well.

### Changes

- `agents/repair/agents/repair-agent.md` — changed `model: sonnet` to `model: haiku`
- `agents/pr/agents/pr-agent.md` — changed `model: sonnet` to `model: haiku`
- `docs/docs/repair-agent.md` — updated model reference to haiku
- `docs/docs/pr-agent.md` — updated model reference to haiku
- `skills/haiku-orchestrator-worker-split/SKILL.md` — added step 6 to remind future agents to keep companion docs in sync when changing model fields

## Test Plan

- [ ] Verify repair-agent runs successfully on a haiku model after the change
- [ ] Verify pr-agent runs successfully on a haiku model after the change
- [ ] Confirm no regressions in the manufacture flow by running existing CI checks
