### PR TITLE
feat(skill-update-agent): add learned-skill marker to harvested skill frontmatter

### DIFF
--- a/agents/skill-update/agents/skill-update-agent.md
+++ b/agents/skill-update/agents/skill-update-agent.md
@@ -83,6 +83,7 @@ When creating a new skill file, use this format:
 name: <slug>
 description: "<one sentence: what this skill does and when to use it>"
 user-invocable: false
+learned-skill: true
 ---
 ## When to use
 <condition that triggers this skill>

--- a/docs/docs/skill-update-agent.md
+++ b/docs/docs/skill-update-agent.md
@@ -104,6 +104,7 @@ When creating a new skill file, use this format:
 name: <kebab-case-slug>
 description: "<one sentence: what this skill does and when to use it>"
 user-invocable: false
+learned-skill: true
 ---
 
 ## When to use

--- a/metrics.csv
+++ b/metrics.csv
@@ -1,13 +1,13 @@
 agent,skill,avg_runtime,avg_tokens,runs,sum_runtime,sum_tokens
 dark-factory:featurework:planning:agents:planning-agent,,31902.666666666668,1155.0,3,95708.0,3465.0
-dark-factory:featurework:execution:agents:execution-agent,,98042.5,587.5,4,392170.0,2350.0
+dark-factory:featurework:execution:agents:execution-agent,,78434.0,603.4,5,392170.0,3017.0
 dark-factory:code-review:agents:code-review-orchestrator-agent,,158897.16666666666,636.25,12,1906766.0,7635.0
 dark-factory:documentation:agents:update-documentation-agent,,77188.0,314.875,8,617504.0,2519.0
 dark-factory:skill-update:agents:skill-update-agent,,65516.0,357.57142857142856,7,458612.0,2503.0
 dark-factory:pr:agents:pr-agent,,58958.92857142857,140.07142857142858,14,825425.0,1961.0
-dark-factory:repair:agents:repair-agent,,15639.5625,213.625,16,250233.0,3418.0
+dark-factory:repair:agents:repair-agent,,13170.157894736842,179.89473684210526,19,250233.0,3418.0
 testing-agent,,0.0,0.0,13,0.0,0.0
-planning-agent,,0.0,0.0,14,0.0,0.0
+planning-agent,,0.0,0.0,19,0.0,0.0
 dark-factory:featurework:agents:feature-agent,,101365.9,605.4,20,2027318.0,12108.0
 Explore,,68061.0,1786.0,3,204183.0,5358.0
 dark-factory:featurework:planning:agents:sub-planning-agent,,0.0,355.0,1,0.0,355.0
@@ -17,6 +17,6 @@ code-review-orchestrator-agent,,148107.5,446.5,2,296215.0,893.0
 update-documentation-agent,,172217.0,525.0,2,344434.0,1050.0
 skill-update-agent,,75275.0,308.5,2,150550.0,617.0
 pr-agent,,66241.0,113.0,2,132482.0,226.0
-dark-factory:debugger:agents:debugger-agent,,0.0,0.0,2,0.0,0.0
+dark-factory:debugger:agents:debugger-agent,,0.0,0.0,3,0.0,0.0
 dark-factory:featurework:execution:agents:skeleton-agent,,0.0,0.0,1,0.0,0.0
 debugger-agent,,418539.0,728.0,1,418539.0,728.0


### PR DESCRIPTION
## Description

Add `learned-skill: true` to the skill-update-agent frontmatter template so that skills autonomously harvested by the agent are distinguishable from human-directed ones.

**Problem:** When the skill-update-agent creates new skill files, there was no way to tell whether a skill was created autonomously (by the agent during a run) or was manually authored by a human developer. This makes it hard to audit, filter, or treat the two categories differently.

**Solution:** Add `learned-skill: true` to the frontmatter template that skill-update-agent uses when scaffolding new skill files. Any skill created by the agent will carry this marker, while human-authored skills (which are written from scratch) will not include it by default.

**Changes:**
- `agents/skill-update/agents/skill-update-agent.md` — added `learned-skill: true` to the skill file template in the agent's instructions
- `docs/docs/skill-update-agent.md` — mirrored the same change in the authoritative documentation so the docs stay in sync

---
Generated with [dark factory](https://github.com/lewibs/dark-factory)
