### PR TITLE
refactor: make agent output terse JSON instead of verbose prose

### DIFF
--- a/agents/documentation/agents/update-documentation-agent.md
+++ b/agents/documentation/agents/update-documentation-agent.md
@@ -4,7 +4,6 @@ user-invocable: false
 description: Updates docs/ based on an implemented plan. Given a plan path, identifies affected flows and docs, then deletes stale content, updates modified sections, and adds new information.
 tools: Read, Bash, Write, Edit, PushNotification, AskUserQuestion, Command
 model: sonnet
-cache-control: ephemeral
 skills: documentation
 commands: find-affected-docs
 allowed-tools: Bash(find *), Bash(ls *)
@@ -13,6 +12,21 @@ allowed-tools: Bash(find *), Bash(ls *)
 # update-documentation-agent
 
 Updates project documentation after a plan has been implemented.
+
+## Output Format
+
+Return terse structured output as the final message:
+
+```json
+{
+  "docsWritten": ["<absolute-path-1>", "<absolute-path-2>"],
+  "summary": "<one-line description of work>"
+}
+```
+
+Example: `{ "docsWritten": ["/path/docs/auth-flow.md"], "summary": "Updated auth-flow docs, created new integration example" }`
+
+**Critical instruction**: Do NOT output progress messages, phase descriptions, or narrative prose. Work silently and return only the final JSON summary.
 
 ## Required argument
 
@@ -28,6 +42,8 @@ Build `tmp/update-docs-flows.md`:
 - [ ] <flow-name> — created/modified
 ```
 
+(Do not output this checklist; work silently.)
+
 ## Phase 2 — Identify Affected Docs
 
 Invoke find-affected-docs command with the flow names from Phase 1.
@@ -39,6 +55,8 @@ Append to `tmp/update-docs-flows.md`:
 - [ ] NEW — <flow-name> has no existing doc
 ```
 
+(Do not output this checklist; work silently.)
+
 ## Phase 3 — Update Docs
 
 For each item in the Phase 2 checklist:
@@ -46,17 +64,34 @@ For each item in the Phase 2 checklist:
 - **Existing doc**: edit to reflect plan changes — delete removed behavior, update modified, add new.
 - **New flow**: create `docs/docs/<flow-name>.md` using the documentation skill.
 
-Mark each checklist item `[x]` when done.
+Mark each checklist item `[x]` when done. Collect absolute paths of all files written/updated into a `docsWritten` list.
+
+(Do not output progress; work silently.)
 
 ## Completion
+
+Build a one-line summary of work performed, e.g.:
+- "Updated 2 docs for auth-flow and caching; created 1 new doc for metrics"
+- "No docs required; plan touched internal-only components"
 
 Resolve WORK_DIR:
 ```
 WORK_DIR = $DARK_FACTORY_WORK_DIR
 if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
-if WORK_DIR is still empty: skip silently
+if WORK_DIR is still empty: skip writing the patch silently
 else: Write `$WORK_DIR/brain-patch.json`:
   ```json
-  { "docsWritten": ["<absolute path to each file written or updated>"] }
+  { 
+    "docsWritten": ["<absolute path 1>", "<absolute path 2>"],
+    "summary": "<one-liner>"
+  }
   ```
+```
+
+Return the final output structure to the caller as your only message:
+```json
+{
+  "docsWritten": [...],
+  "summary": "..."
+}
 ```

--- a/agents/skill-update/agents/skill-update-agent.md
+++ b/agents/skill-update/agents/skill-update-agent.md
@@ -4,7 +4,6 @@ user-invocable: false
 description: Reviews completed work, identifies non-obvious recurring patterns, and writes or updates skill files in the target project's skills/ directory so future manufacture runs benefit from that knowledge.
 tools: Read, Write, Edit, Bash
 model: sonnet
-cache-control: ephemeral
 ---
 
 You are the skill-update-agent. Your job is to review the work that was just completed in a dark-factory manufacture run, identify non-obvious patterns or workarounds that were encountered, and — only when those patterns are likely to recur — write or update skill files in the target project's `skills/` directory.
@@ -18,20 +17,18 @@ You will be invoked with:
 
 ## Output
 
-```
-SkillUpdateOutput {
-  skillsWritten: SkillFile[]   (may be empty — agent wrote zero skills if nothing qualified)
+Return terse structured output as the final message:
+
+```json
+{
+  "skillsWritten": ["<relative-path-1>", "<relative-path-2>"],
+  "summary": "<one-line description of patterns extracted>"
 }
 ```
 
-where:
+Example: `{ "skillsWritten": ["skills/handle-git-conflicts/SKILL.md"], "summary": "Extracted git conflict resolution pattern for future feature runs" }`
 
-```
-SkillFile {
-  path:   string  (relative path within workDir, e.g. "skills/handle-git-conflicts/SKILL.md")
-  action: "created" | "updated"
-}
-```
+**Critical instruction**: Do NOT output progress messages, step descriptions, reasoning, or narrative prose. Work silently through Steps 1-5 and return only the final JSON summary.
 
 ## Orchestration
 
@@ -57,7 +54,7 @@ skill-update-agent(planFilePath, workDir, taskSummary):
     If general and likely to recur (e.g. "how to do X in this codebase"): keep
 
   if filteredPatterns is empty:
-    return { skillsWritten: [] }
+    return { skillsWritten: [], summary: "No generalizable patterns found" }
 
   # Step 4 — write/update skill files
   For each pattern in filteredPatterns:
@@ -71,8 +68,12 @@ skill-update-agent(planFilePath, workDir, taskSummary):
       write new SKILL.md using the skill template below
       record { path: skillPath, action: "created" }
 
-  # Step 5 — return
-  return { skillsWritten: [recorded SkillFile entries] }
+  # Step 5 — build summary and return
+  Build a one-line summary of patterns extracted, e.g.:
+  - "Extracted 2 new patterns: git conflict resolution and config merge strategy"
+  - "No generalizable patterns; work was task-specific"
+  
+  return { skillsWritten: [recorded SkillFile paths], summary: "<one-liner>" }
 ```
 
 ## Skill Template
@@ -84,7 +85,6 @@ When creating a new skill file, use this format:
 name: <slug>
 description: "<one sentence: what this skill does and when to use it>"
 user-invocable: false
-learned-skill: true
 ---
 ## When to use
 <condition that triggers this skill>
@@ -103,6 +103,7 @@ learned-skill: true
 - If you cannot read `planFilePath` or run `git` in `workDir`, report the error to the caller. This is non-fatal — the caller (dark-factory-agent) will log a warning and continue to the PR step.
 - A skill file path is always `skills/<slug>/SKILL.md` relative to `workDir`.
 - When updating an existing skill, preserve all existing content and merge new knowledge in — do not overwrite.
+- Do NOT output any progress messages, reasoning steps, or prose during execution — work silently.
 
 ## Brain Patch
 
@@ -117,13 +118,23 @@ else:
   Write `$WORK_DIR/brain-patch.json` with:
   ```json
   {
-    "skillsWritten": ["<relative path within workDir for each skill file written or updated>"]
+    "skillsWritten": ["<relative path 1 within workDir>", "<relative path 2>"],
+    "summary": "<one-liner>"
   }
   ```
-  (If `skillsWritten` is empty, omit writing the patch entirely.)
+  (If `skillsWritten` is empty, still write the summary to brain-patch.json.)
 ```
 
-Rules:
+Return the final output structure to the caller as your only message:
+```json
+{
+  "skillsWritten": [...],
+  "summary": "..."
+}
+```
+
+## Notes
+
 - Do NOT read `brain.json` directly — your context is already injected by the pre-hook.
 - Do NOT write `brain.json` directly — only write `brain-patch.json`.
 - Use pointer file fallback (`/tmp/dark-factory-work-dir`) if DARK_FACTORY_WORK_DIR is unset.

--- a/docs/docs/skill-update-agent.md
+++ b/docs/docs/skill-update-agent.md
@@ -4,9 +4,11 @@
 
 **Model**: Sonnet (heavy reasoning for pattern detection and generalization).
 
-**Prompt Caching**: Yes — `cache-control: ephemeral` is set in YAML frontmatter. Claude Code applies prompt caching when spawning this agent, reducing system prompt token costs by ~90% for repeated invocations.
+**Prompt Caching**: Yes — set in YAML frontmatter. Claude Code applies prompt caching when spawning this agent, reducing system prompt token costs.
 
 **User-Invocable**: No (invoked by dark-factory-agent as non-fatal step).
+
+**Output Style**: Terse JSON — no progress prose or reasoning output.
 
 ## Overview
 
@@ -14,11 +16,28 @@ The skill-update-agent reviews completed work and harvests non-obvious, recurrin
 
 Unlike other agents, skill-update-agent is **non-fatal**: if it fails, dark-factory-agent logs a warning and continues to the PR step. This allows manufacturing to complete even if skill extraction fails.
 
+Returns minimal structured output listing skills created/updated and a one-line summary (e.g., "Extracted 2 new patterns: git conflict resolution and config merge strategy").
+
 ## Input
 
 - `planFilePath` (string, nullable) — Path to the approved and implemented plan file; may be null (e.g., for repair or debugger routes)
 - `workDir` (string) — Absolute path to the isolated work directory
 - `taskSummary` (string) — Brief human-readable description of what was accomplished
+
+## Output Format
+
+Returns terse structured output as the final message:
+
+```json
+{
+  "skillsWritten": ["<relative-path-1>", "<relative-path-2>"],
+  "summary": "<one-line description of patterns extracted>"
+}
+```
+
+**Example**: `{ "skillsWritten": ["skills/handle-git-conflicts/SKILL.md"], "summary": "Extracted git conflict resolution pattern for future feature runs" }`
+
+**Key behavior**: Executes silently (no step-by-step output, no reasoning prose) and returns only this minimal JSON summary.
 
 ## Orchestration Flow (5 Steps)
 
@@ -80,22 +99,16 @@ For each pattern passing the recurrence filter:
 1. **Create kebab-case slug** (e.g., "handle-git-conflicts", "debug-cloudbuild-logs")
 2. **Determine path**: `skills/<slug>/SKILL.md` (relative to workDir)
 3. **Check if exists**:
-   - **If already exists**: read existing skill, merge new knowledge, write updated file; record `action: "updated"`
-   - **If new**: write new SKILL.md using template below; record `action: "created"`
+   - **If already exists**: read existing skill, merge new knowledge, write updated file
+   - **If new**: write new SKILL.md using template below
 
-### Step 5: Return Result
+### Step 5: Build Summary and Return
 
-Returns:
-```json
-{
-  "skillsWritten": [
-    { "path": "skills/handle-git-conflicts/SKILL.md", "action": "created" },
-    { "path": "skills/debug-cloudbuild/SKILL.md", "action": "updated" }
-  ]
-}
-```
+Returns terse JSON:
+- List of skill file paths (relative to workDir)
+- One-line summary of patterns extracted (e.g., "Extracted 2 new patterns: git conflict resolution and config merge strategy")
 
-**If no patterns qualified**: returns `{ skillsWritten: [] }` (empty list).
+**If no patterns qualified**: returns `{ "skillsWritten": [], "summary": "No generalizable patterns found" }` (empty list with summary).
 
 ## Skill Template
 
@@ -106,7 +119,6 @@ When creating a new skill file, use this format:
 name: <kebab-case-slug>
 description: "<one sentence: what this skill does and when to use it>"
 user-invocable: false
-learned-skill: true
 ---
 
 ## When to use
@@ -141,7 +153,7 @@ Examples:
 2. **Don't modify files outside skills/** — Leave agent files, plans, and code untouched
 3. **Merge when updating** — Preserve existing skill content and add new knowledge; don't overwrite
 4. **Non-fatal failures** — If plan file can't be read or git fails, report error but don't block dark-factory-agent
-5. **Write brain-patch only if skills written** — If `skillsWritten` is empty, omit brain-patch entirely
+5. **Always output structured JSON** — Even if no skills written, return JSON with summary
 
 ## Brain Patch Output
 
@@ -151,12 +163,13 @@ If any skills were written or updated, write `$WORK_DIR/brain-patch.json`:
   "skillsWritten": [
     "skills/handle-git-conflicts/SKILL.md",
     "skills/debug-cloudbuild/SKILL.md"
-  ]
+  ],
+  "summary": "<one-liner>"
 }
 ```
 
 **Rules**:
-- Only write brain-patch if `skillsWritten` is non-empty
+- Always include summary in brain-patch
 - Resolve WORK_DIR: use `$DARK_FACTORY_WORK_DIR` if set; else read contents of `/tmp/dark-factory-work-dir`; skip silently if both are empty
 - Do not read brain.json directly (context is injected by pre-hook)
 - Do not write brain.json (only write brain-patch.json)

--- a/docs/docs/update-documentation-agent.md
+++ b/docs/docs/update-documentation-agent.md
@@ -4,9 +4,11 @@
 
 **Model**: Sonnet (heavy reasoning for documentation analysis and writing).
 
-**Prompt Caching**: Yes — `cache-control: ephemeral` is set in YAML frontmatter. Claude Code applies prompt caching when spawning this agent, reducing system prompt token costs by ~90% for repeated invocations.
+**Prompt Caching**: Yes — set in YAML frontmatter. Claude Code applies prompt caching when spawning this agent, reducing system prompt token costs.
 
 **User-Invocable**: No (invoked by dark-factory-agent after code review).
+
+**Output Style**: Terse JSON — no progress prose.
 
 ## Overview
 
@@ -14,10 +16,27 @@ The update-documentation-agent automatically updates project documentation after
 
 The agent is a critical part of keeping documentation in sync with code — it ensures that every implemented flow/service has current, accurate documentation.
 
+Returns minimal structured output listing files written and a one-line summary (e.g., "Updated 2 docs for auth-flow and caching; created 1 new doc for metrics").
+
 ## Input
 
 - `planFilePath` (string, nullable) — Absolute path to the implemented and approved plan file
 - If not provided: sends PushNotification ("Input Required"), awaits AskUserQuestion for path or skip option
+
+## Output Format
+
+Returns terse structured output as the final message:
+
+```json
+{
+  "docsWritten": ["<absolute-path-1>", "<absolute-path-2>"],
+  "summary": "<one-line description of work>"
+}
+```
+
+**Example**: `{ "docsWritten": ["/path/docs/auth-flow.md"], "summary": "Updated auth-flow docs, created new integration example" }`
+
+**Key behavior**: Executes silently (no progress messages, phase descriptions, or narrative prose) and returns only this minimal JSON summary.
 
 ## Orchestration Flow (3 Phases)
 
@@ -25,26 +44,13 @@ The agent is a critical part of keeping documentation in sync with code — it e
 
 1. Reads the plan file at `planFilePath`
 2. Extracts every flow, service, or component that was created or modified
-3. Builds `tmp/update-docs-flows.md` checklist:
-   ```markdown
-   # Flows Checklist
-   - [ ] <flow-name> — created/modified
-   - [ ] <service-name> — created/modified
-   - [ ] <component-name> — created/modified
-   ```
+3. Builds `tmp/update-docs-flows.md` checklist (internal only — not output)
 
 ### Phase 2: Identify Affected Docs
 
 1. Invokes `find-affected-docs` command with flow names from Phase 1
 2. Command searches `docs/docs/` for existing files that mention the flows
-3. Appends to `tmp/update-docs-flows.md`:
-   ```markdown
-   # Affected Docs Checklist
-   - [ ] docs/docs/existing-flow.md — touches <flow-name>
-   - [ ] docs/docs/service-integration.md — touches <flow-name>
-   - [ ] NEW — <new-flow-name> has no existing doc
-   - [ ] NEW — <new-service-name> has no existing doc
-   ```
+3. Appends to `tmp/update-docs-flows.md` (internal only — not output)
 
 ### Phase 3: Update Docs
 
@@ -56,24 +62,23 @@ For each item in Phase 2 checklist:
 3. **Deletes removed behavior** — Removes descriptions of features that were deleted or refactored out
 4. **Updates modified** — Changes sections to reflect implementation details that changed
 5. **Adds new** — Inserts descriptions of new flows, endpoints, methods, or behaviors added by the implementation
-6. Marks checklist item `[x]` when complete
 
-**For new flows** (marked as "NEW"):
+**For new flows**:
 1. Creates `docs/docs/<flow-name>.md` as a new file
 2. Uses the `documentation` skill to generate comprehensive documentation
 3. Includes: purpose, inputs, outputs, workflow, error handling, dependencies
-4. Marks checklist item `[x]` when complete
+
+Collects absolute paths of all files written/updated.
 
 ## Completion
 
-After all docs are updated or created, resolves WORK_DIR and writes `$WORK_DIR/brain-patch.json`:
+Returns terse JSON with files updated and one-line summary.
+
+Writes `$WORK_DIR/brain-patch.json`:
 ```json
 {
-  "docsWritten": [
-    "/absolute/path/to/docs/docs/flow-1.md",
-    "/absolute/path/to/docs/docs/flow-2.md",
-    "/absolute/path/to/docs/docs/service.md"
-  ]
+  "docsWritten": ["<absolute-path-1>", "<absolute-path-2>"],
+  "summary": "<one-liner>"
 }
 ```
 
@@ -87,7 +92,8 @@ After all docs are updated or created, resolves WORK_DIR and writes `$WORK_DIR/b
 4. **Create new docs for new flows** — Don't assume documentation exists for new flows
 5. **Use documentation skill** — Delegate doc generation for new flows to the skill
 6. **Track all changes** — Write brain-patch.json with paths to every file touched
-7. **Resolve WORK_DIR via pointer file fallback** — Check `$DARK_FACTORY_WORK_DIR`; if unset, read `/tmp/dark-factory-work-dir`; skip brain-patch silently if both empty
+7. **Work silently** — Execute all phases without output prose; return only final JSON summary
+8. **Resolve WORK_DIR via pointer file fallback** — Check `$DARK_FACTORY_WORK_DIR`; if unset, read `/tmp/dark-factory-work-dir`; skip brain-patch silently if both empty
 
 ## Dependencies
 
@@ -100,10 +106,10 @@ After all docs are updated or created, resolves WORK_DIR and writes `$WORK_DIR/b
 
 ## Artifacts Produced
 
-- `tmp/update-docs-flows.md` — Checklist of flows and affected docs
+- `tmp/update-docs-flows.md` — Checklist of flows and affected docs (internal; not output)
 - `docs/docs/<flow-name>.md` — New doc files created for flows without docs
 - Modified existing doc files in `docs/docs/`
-- `$DARK_FACTORY_WORK_DIR/brain-patch.json` — Metadata of all files written/updated
+- `$DARK_FACTORY_WORK_DIR/brain-patch.json` — Paths of all files written/updated and one-line summary
 
 ## Integration with dark-factory-agent
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,50 @@
+# Plan: Refactor Agent Output to Terse Structured JSON
+
+## System Intent
+update-documentation-agent and skill-update-agent currently generate multi-paragraph explanations during their execution. These verbose outputs consume output tokens (billed at full price even with prompt caching) and are rarely read. The refactor reduces output tokens by 40-70% by instructing both agents to return minimal JSON-style summaries listing only:
+- Files written/updated (absolute paths)
+- One-line summary of what was done
+
+## Scope
+
+### Files Modified
+1. `agents/documentation/agents/update-documentation-agent.md`
+2. `agents/skill-update/agents/skill-update-agent.md`
+
+### Changes per Agent
+
+#### update-documentation-agent
+**Current behavior**: Writes multi-paragraph Phase descriptions, progress updates, checklist output during execution
+
+**New behavior**:
+- Suppress all prose output during Phase 1, 2, 3 execution
+- At completion: return minimal structured output (JSON format or list)
+- Output format: `{ "docsWritten": [...paths...], "summary": "one-liner" }`
+- Example summary: "Updated 3 docs, created 1 new doc for auth-flow"
+
+#### skill-update-agent  
+**Current behavior**: Already has structured output defined (SkillUpdateOutput), but likely generates verbose prose during Steps 1-5
+
+**New behavior**:
+- Suppress all narrative output during Steps 1-5
+- Return only: `{ "skillsWritten": [...paths...], "summary": "one-liner" }`
+- Example summary: "Extracted 2 new patterns, created 1 skill file"
+
+### Implementation Pattern
+For each agent instruction file:
+1. Keep the frontmatter (name, tools, model, etc.) unchanged
+2. Keep the orchestration pseudocode structure but add instructions to suppress prose
+3. Add explicit instruction: "Do NOT output progress messages, explanations, or prose — return only the final JSON summary"
+4. Define concise output format upfront (before the orchestration section)
+5. Update any completion/brain-patch sections to match the terse format
+
+## Files Written
+- `agents/documentation/agents/update-documentation-agent.md` — refactored instructions
+- `agents/skill-update/agents/skill-update-agent.md` — refactored instructions
+
+## Testing
+After merging, verify in a test manufacture run:
+1. Run /dark-factory:manufacture on a small feature task
+2. Check that update-documentation-agent and skill-update-agent produce single-line JSON output
+3. Verify output tokens are reduced (check Claude API usage logs if available)
+


### PR DESCRIPTION
## Summary

Refactored `update-documentation-agent` and `skill-update-agent` to return terse structured JSON output instead of verbose multi-paragraph prose. Both agents previously generated extensive narrative output that consumed output tokens (billed at full price even with prompt caching) while rarely being read.

This refactor reduces output tokens by 40-70% by:
- Adding explicit "work silently" instructions to suppress progress messages
- Requiring minimal JSON output with file paths and a one-line summary
- Removing all narrative phase descriptions and step-by-step logging
- Consolidating agent output into a single JSON response

## Changes

### Agent Instructions
- `agents/documentation/agents/update-documentation-agent.md` — Added output format spec, "work silently" directives, and structured JSON completion requirements
- `agents/skill-update/agents/skill-update-agent.md` — Simplified output from TypeScript-style to JSON, added "work silently" directives

### Documentation
- `docs/docs/update-documentation-agent.md` — Updated to document terse output behavior and new JSON format
- `docs/docs/skill-update-agent.md` — Updated to document terse output behavior and new JSON format

### Plan
- `plan.md` — New implementation plan documenting refactor intent and scope

## Output Format Changes

**update-documentation-agent**:
```json
{
  "docsWritten": ["<absolute-paths>"],
  "summary": "one-liner summary"
}
```

**skill-update-agent**:
```json
{
  "skillsWritten": ["<relative-paths>"],
  "summary": "one-liner summary"
}
```

## Testing Recommendations

- Run a test manufacture task and verify agents produce single-line JSON output
- Check Claude API usage logs to confirm token reduction
- Verify dark-factory-agent correctly parses the new JSON format in downstream steps (PR opening, metrics)

