### PR TITLE
feat: add handoff notes to brain.json for cross-agent context sharing

### DIFF
--- a/agents/dark-factory/scripts/post-tool-use-hook.sh
+++ b/agents/dark-factory/scripts/post-tool-use-hook.sh
@@ -34,13 +34,25 @@ HOOK_INPUT=$(cat)
 if [ -f "$PATCH_PATH" ]; then
   PATCH_CONTENTS=$(jq -c '.' "$PATCH_PATH")
   echo "post-tool-use-hook | merge-patch | patch=${PATCH_CONTENTS}" >&2
-  (
-    flock -x 200
-    POST_TMP=$(mktemp /tmp/brain-post-XXXXXX.json)
-    jq -s '.[0] * .[1]' "$BRAIN_PATH" "$PATCH_PATH" > "$POST_TMP" \
-      && mv "$POST_TMP" "$BRAIN_PATH"
-    rm -f "$PATCH_PATH"
-  ) 200>"$BRAIN_LOCK"
+  if jq -e '.notes' "$PATCH_PATH" > /dev/null 2>&1; then
+    (
+      flock -x 200
+      NOTES_TMP=$(mktemp /tmp/brain-notes-XXXXXX.json)
+      jq -s '
+        (.[0].notes // []) + (.[1].notes // []) as $merged_notes |
+        .[0] * .[1] | .notes = $merged_notes
+      ' "$BRAIN_PATH" "$PATCH_PATH" > "$NOTES_TMP" && mv "$NOTES_TMP" "$BRAIN_PATH"
+      rm -f "$PATCH_PATH"
+    ) 200>"$BRAIN_LOCK"
+  else
+    (
+      flock -x 200
+      POST_TMP=$(mktemp /tmp/brain-post-XXXXXX.json)
+      jq -s '.[0] * .[1]' "$BRAIN_PATH" "$PATCH_PATH" > "$POST_TMP" \
+        && mv "$POST_TMP" "$BRAIN_PATH"
+      rm -f "$PATCH_PATH"
+    ) 200>"$BRAIN_LOCK"
+  fi
 else
   echo "post-tool-use-hook | no-patch | brain-patch.json not found, skipping merge" >&2
 fi

--- a/agents/dark-factory/scripts/pre-tool-use-hook.sh
+++ b/agents/dark-factory/scripts/pre-tool-use-hook.sh
@@ -97,7 +97,17 @@ fi
 # pre-hook.inject: inject brain context into the agent prompt
 BRAIN_CONTEXT=$(jq -c '.' "$BRAIN_PATH")
 CURRENT_PROMPT=$(printf '%s' "$TOOL_INPUT" | jq -r '.tool_input.prompt // .prompt // ""')
-NEW_PROMPT="BRAIN STATE (read-only context — do not modify brain.json directly):
+
+NOTES_JSON=$(jq -c '.notes // []' "$BRAIN_PATH")
+NOTES_COUNT=$(printf '%s' "$NOTES_JSON" | jq 'length')
+if [ "$NOTES_COUNT" -gt 0 ]; then
+  NOTES_BLOCK=$(printf '%s' "$NOTES_JSON" | jq -r '.[] | "- " + .')
+  NOTES_HEADER="HANDOFF NOTES FROM PRIOR AGENTS:\n${NOTES_BLOCK}\n\n"
+else
+  NOTES_HEADER=""
+fi
+
+NEW_PROMPT="${NOTES_HEADER}BRAIN STATE (read-only context — do not modify brain.json directly):
 ${BRAIN_CONTEXT}
 
 ${CURRENT_PROMPT}"

--- a/agents/debugger/agents/debugger-agent.md
+++ b/agents/debugger/agents/debugger-agent.md
@@ -51,7 +51,8 @@ if WORK_DIR is still empty: skip writing the patch silently
 else: Write `$WORK_DIR/brain-patch.json` with:
   ```json
   {
-    "bugFiles": ["<absolute path to each bug audit log file written>"]
+    "bugFiles": ["<absolute path to each bug audit log file written>"],
+    "notes": ["debugger-agent: root cause was <summary>, fixed in <key files>"]
   }
   ```
 ```

--- a/agents/featurework/execution/agents/execution-agent.md
+++ b/agents/featurework/execution/agents/execution-agent.md
@@ -44,6 +44,30 @@ When a hard-stop is returned from `implementation-agent`:
 - If "Resume": re-read the plan, confirm its status is `approved`, and resume from step 5 (re-spawn `implementation-agent`).
 - Do not spawn any agents until a resume response is received.
 
+## Brain Patch
+
+After step 5 succeeds (all flows green), before deleting checklists:
+
+Resolve WORK_DIR:
+```
+WORK_DIR = $DARK_FACTORY_WORK_DIR
+if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+if WORK_DIR is still empty: skip writing the patch silently
+else: Write `$WORK_DIR/brain-patch.json` with:
+  ```json
+  {
+    "notes": ["execution-agent: implemented <N> flows, modified files: <list key files>"]
+  }
+  ```
+```
+
+Replace `<N>` with the count of flows implemented and `<list key files>` with a comma-separated list of the key files modified by implementation-agent.
+
+Rules:
+- Do NOT read `brain.json` directly — your context is already injected by the pre-hook.
+- Do NOT write `brain.json` directly — only write `brain-patch.json`.
+- Use pointer file fallback (`/tmp/dark-factory-work-dir`) if DARK_FACTORY_WORK_DIR is unset.
+
 ## Rules
 
 - Never spawn the next agent until the current one returns successfully.

--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -43,7 +43,12 @@ pr-agent(planFilePath or description):
   WORK_DIR = $DARK_FACTORY_WORK_DIR
   if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
   if WORK_DIR is still empty: skip silently
-  else: write $WORK_DIR/brain-patch.json: { "prUrl": pr_url }
+  else: write $WORK_DIR/brain-patch.json:
+    {
+      "prUrl": pr_url,
+      "notes": ["pr-agent: opened PR at <prUrl>, CI <passed/failed>"]
+    }
+  Replace <prUrl> with the actual PR URL and <passed/failed> with the CI result from step 3.
 
   # Step 3 — Watch CI (delegate to ci-watch-runner command)
   ciResult = invoke ci-watch-runner({ prUrl: pr_url, maxIterations: 5 })

--- a/skills/brain-state-manager/SKILL.md
+++ b/skills/brain-state-manager/SKILL.md
@@ -63,7 +63,8 @@ Creates a new brain.json in the work directory and sets up environment integrati
     "pr-complete": false,
     "cleanup-running": false,
     "cleanup-complete": false
-  }
+  },
+  "notes": []
 }
 ```
 


### PR DESCRIPTION
## Summary
- Adds `notes: []` field to brain.json schema so agents can leave short observations for downstream agents
- Updates `pre-tool-use-hook.sh` to inject notes prominently as a `HANDOFF NOTES FROM PRIOR AGENTS:` block above the brain state
- Updates `post-tool-use-hook.sh` to array-concatenate the `notes` field instead of overwriting it on each patch merge
- Updates `execution-agent`, `debugger-agent`, and `pr-agent` to write a 1-2 sentence handoff note to `brain-patch.json`

## Test plan
- [ ] Run a manufacture flow and verify notes appear in downstream agent prompts
- [ ] Verify multiple agent notes accumulate correctly (not overwritten)
- [ ] Verify empty notes array produces no header injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)