### PR TITLE
feat: add artifacts registry to brain.json for cross-agent file tracking

### DIFF
--- a/agents/dark-factory/scripts/post-tool-use-hook.sh
+++ b/agents/dark-factory/scripts/post-tool-use-hook.sh
@@ -34,25 +34,28 @@ HOOK_INPUT=$(cat)
 if [ -f "$PATCH_PATH" ]; then
   PATCH_CONTENTS=$(jq -c '.' "$PATCH_PATH")
   echo "post-tool-use-hook | merge-patch | patch=${PATCH_CONTENTS}" >&2
-  if jq -e '.notes' "$PATCH_PATH" > /dev/null 2>&1; then
-    (
-      flock -x 200
-      NOTES_TMP=$(mktemp /tmp/brain-notes-XXXXXX.json)
+  (
+    flock -x 200
+    POST_TMP=$(mktemp /tmp/brain-post-XXXXXX.json)
+    # Check if the patch contains notes or artifacts fields that require array-concat merge
+    HAS_ARRAY_FIELDS=$(jq 'has("notes") or has("artifacts")' "$PATCH_PATH")
+    if [ "$HAS_ARRAY_FIELDS" = "true" ]; then
       jq -s '
-        (.[0].notes // []) + (.[1].notes // []) as $merged_notes |
-        .[0] * .[1] | .notes = $merged_notes
-      ' "$BRAIN_PATH" "$PATCH_PATH" > "$NOTES_TMP" && mv "$NOTES_TMP" "$BRAIN_PATH"
-      rm -f "$PATCH_PATH"
-    ) 200>"$BRAIN_LOCK"
-  else
-    (
-      flock -x 200
-      POST_TMP=$(mktemp /tmp/brain-post-XXXXXX.json)
+        (.[0].notes // []) + (.[1].notes // []) as $notes |
+        ((.[0].artifacts.created // []) + (.[1].artifacts.created // [])) as $art_created |
+        ((.[0].artifacts.modified // []) + (.[1].artifacts.modified // [])) as $art_modified |
+        .[0] * .[1] |
+        .notes = $notes |
+        .artifacts.created = $art_created |
+        .artifacts.modified = $art_modified
+      ' "$BRAIN_PATH" "$PATCH_PATH" > "$POST_TMP" \
+        && mv "$POST_TMP" "$BRAIN_PATH"
+    else
       jq -s '.[0] * .[1]' "$BRAIN_PATH" "$PATCH_PATH" > "$POST_TMP" \
         && mv "$POST_TMP" "$BRAIN_PATH"
-      rm -f "$PATCH_PATH"
-    ) 200>"$BRAIN_LOCK"
-  fi
+    fi
+    rm -f "$PATCH_PATH"
+  ) 200>"$BRAIN_LOCK"
 else
   echo "post-tool-use-hook | no-patch | brain-patch.json not found, skipping merge" >&2
 fi

--- a/agents/documentation/agents/update-documentation-agent.md
+++ b/agents/documentation/agents/update-documentation-agent.md
@@ -94,10 +94,15 @@ else: Write `$WORK_DIR/brain-patch.json`:
   ```json
   { 
     "docsWritten": ["<absolute path 1>", "<absolute path 2>"],
-    "summary": "<one-liner>"
+    "summary": "<one-liner>",
+    "artifacts": {
+      "modified": ["<absolute path 1>", "<absolute path 2>"]
+    }
   }
   ```
 ```
+
+The `artifacts.modified` list must contain the same paths as `docsWritten`.
 
 Return the final output structure to the caller as your only message:
 ```json

--- a/agents/featurework/execution/agents/execution-agent.md
+++ b/agents/featurework/execution/agents/execution-agent.md
@@ -73,3 +73,23 @@ Rules:
 - Never spawn the next agent until the current one returns successfully.
 - Do not write code. Your job is sequencing and gate-checking.
 - Never invoke the built-in `Explore` subagent_type directly. Always route codebase research through `investigation-agent` — it checks existing docs first (cheap) before scanning the codebase.
+
+## brain-patch.json
+
+After all agents complete successfully, resolve WORK_DIR:
+```
+WORK_DIR = $DARK_FACTORY_WORK_DIR
+if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+if WORK_DIR is still empty: skip writing the patch silently
+else: Write `$WORK_DIR/brain-patch.json`:
+  ```json
+  {
+    "artifacts": {
+      "created": ["<absolute path to each new file created>"],
+      "modified": ["<absolute path to each existing file modified>"]
+    }
+  }
+  ```
+```
+
+Collect the list of created files from `skeleton-agent`'s `filesCreated` return value, and the list of modified files from any files edited by `implementation-agent`.

--- a/agents/featurework/execution/agents/skeleton-agent.md
+++ b/agents/featurework/execution/agents/skeleton-agent.md
@@ -39,3 +39,22 @@ You will be invoked with a `planPath` — a path to a `docs/plans/*.md` file.
 - If the plan file is unreadable or missing, stop immediately and return an error to the caller.
 - Do not implement any logic. Stubs only.
 - Do not proceed to the next file until the current one is written and checked off.
+
+## brain-patch.json
+
+After all skeleton files are created, resolve WORK_DIR:
+```
+WORK_DIR = $DARK_FACTORY_WORK_DIR
+if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+if WORK_DIR is still empty: skip writing the patch silently
+else: Write `$WORK_DIR/brain-patch.json`:
+  ```json
+  {
+    "artifacts": {
+      "created": ["<absolute path to each skeleton file created>"]
+    }
+  }
+  ```
+```
+
+The `created` list must contain the absolute path of every file written during this run.

--- a/skills/brain-state-manager/SKILL.md
+++ b/skills/brain-state-manager/SKILL.md
@@ -48,6 +48,10 @@ Creates a new brain.json in the work directory and sets up environment integrati
   "prUrl": null,
   "docsWritten": null,
   "skillsWritten": null,
+  "artifacts": {
+    "created": [],
+    "modified": []
+  },
   "phases": {
     "prep-running": false,
     "prep-complete": true,


### PR DESCRIPTION
## Summary
- Adds `artifacts: { "created": [], "modified": [] }` to brain.json schema so agents can register files they create/modify
- Updates `post-tool-use-hook.sh` to array-concatenate `artifacts.created` and `artifacts.modified` (not overwrite) when merging brain-patch.json
- Updates `execution-agent`, `skeleton-agent`, and `update-documentation-agent` to write artifacts to brain-patch.json
- Downstream agents (docs, skill-update, code review) can now read the pre-built artifact list instead of re-discovering via git diff

## Test plan
- [ ] Run a manufacture flow and verify artifacts accumulate across skeleton → execution → docs phases
- [ ] Verify multiple agents' artifacts are concatenated (not overwritten) in brain.json
- [ ] Verify empty artifacts arrays produce no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)