### PR TITLE
fix(hooks): use pointer file fallback in commit-on-subagent-stop

### DIFF
--- a/agents/dark-factory/scripts/commit-on-subagent-stop.sh
+++ b/agents/dark-factory/scripts/commit-on-subagent-stop.sh
@@ -24,7 +24,7 @@ case "$agent_type" in
     ;;
 esac
 
-work_dir="${DARK_FACTORY_WORK_DIR:-}"
+work_dir="${DARK_FACTORY_WORK_DIR:-$(cat /tmp/dark-factory-work-dir 2>/dev/null)}"
 if [ -z "$work_dir" ]; then
   echo "DARK_FACTORY_WORK_DIR not set, skipping commit" >&2
   exit 0

--- a/docs/docs/hooks.md
+++ b/docs/docs/hooks.md
@@ -6,7 +6,7 @@
 
 ## System Intent
 
-- What this is: Two Claude Code hooks — `pre-tool-use-hook.sh` and `post-tool-use-hook.sh` — intercept every Agent and Skill tool call during a manufacture run. The pre-hook injects brain.json context into the agent prompt and records a start timestamp for metrics. The post-hook merges any `brain-patch.json` written by the sub-agent back into `brain.json`, accumulates elapsed time and token counts, and marks the current phase complete.
+- What this is: Three Claude Code hooks — `pre-tool-use-hook.sh`, `post-tool-use-hook.sh`, and `commit-on-subagent-stop.sh` — manage brain state and produce ordered git commits during a manufacture run. The pre-hook injects brain.json context into the agent prompt and records a start timestamp for metrics. The post-hook merges any `brain-patch.json` written by the sub-agent back into `brain.json`, accumulates elapsed time and token counts, and marks the current phase complete. The SubagentStop hook commits staged changes to the feature worktree when skeleton-agent, testing-agent, or implementation-agent finishes, producing an ordered proof-of-execution commit sequence.
 
 ## Mermaid Diagram
 
@@ -22,6 +22,7 @@ flowchart TD
 
   CC -->|fires before tool runs| PreHook
   CC -->|fires after tool returns| PostHook
+  CC -->|fires on SubagentStop| StopHook["commit-on-subagent-stop.sh"]
 
   PreHook -->|"1. resolve WORK_DIR\n(env var → pointer file)"| PF
   PreHook -->|"2. record start_ms"| Brain
@@ -32,6 +33,10 @@ flowchart TD
   Patch -->|jq merge| Brain
   PostHook -->|"3. accumulate elapsed_ms,\ntokens, runs"| Brain
   PostHook -->|"4. mark phase complete"| Brain
+
+  StopHook -->|"1. resolve WORK_DIR\n(env var → pointer file)"| PF
+  StopHook -->|"2. read agent_type from stdin"| AgentType["agent_type\n(skeleton|testing|implementation)"]
+  StopHook -->|"3. git add --all\ngit commit -m <msg>"| GitCommit["Feature worktree commit"]
 ```
 
 ## Flows
@@ -124,6 +129,39 @@ Fires after every Agent or Skill tool call returns. Steps (all skipped on `no-br
 | `hooks.post-tool-use.metrics-accumulate` | Agent or Skill tool call | `brain.json` `.metrics[key]` updated with elapsed_ms, tokens, runs | side-effect | `start_ms` removed after accumulation |
 | `hooks.post-tool-use.set-phase-complete` | phase agent tool call | `brain.json` running phase set to complete | side-effect | |
 
+---
+
+### Flow: `hooks.subagent-stop`
+
+- Core files: `agents/dark-factory/scripts/commit-on-subagent-stop.sh`
+- Test files: `tests/test_commit_on_subagent_stop.py`
+
+Fires on every `SubagentStop` event. Reads `agent_type` from stdin (first line), maps it to a commit message, and commits all staged changes in the feature worktree. Always exits 0 — failures are non-blocking.
+
+Work-dir resolution uses the same two-step fallback as the other hooks: `DARK_FACTORY_WORK_DIR` env var first, then `/tmp/dark-factory-work-dir` pointer file. The env var is not reliably propagated to SubagentStop hook processes (they run as children of the Claude Code process after a subagent finishes, outside the bash subprocess where `export` was called), so the pointer file is the normal resolution path in production.
+
+#### Types
+
+```txt
+CommitMessage {
+  skeleton-agent:        "skeleton"
+  testing-agent:         "tests"
+  implementation-agent:  "implementation"
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `hooks.subagent-stop.skeleton-agent` | agent_type="skeleton-agent", staged changes exist | git commit "skeleton" in WORK_DIR | happy path | |
+| `hooks.subagent-stop.testing-agent` | agent_type="testing-agent", staged changes exist | git commit "tests" in WORK_DIR | happy path | |
+| `hooks.subagent-stop.implementation-agent` | agent_type="implementation-agent", staged changes exist | git commit "implementation" in WORK_DIR | happy path | |
+| `hooks.subagent-stop.no-staged-changes` | recognized agent_type, no staged changes | exits 0, logs to stderr | edge case | git diff --cached shows nothing |
+| `hooks.subagent-stop.unknown-agent-type` | agent_type not in recognized set | exits 0, logs to stderr | no-op | script handles gracefully even if matcher allows it |
+| `hooks.subagent-stop.no-work-dir` | DARK_FACTORY_WORK_DIR unset and pointer file absent | exits 0, logs "DARK_FACTORY_WORK_DIR not set, skipping commit" | no-op | not a dark-factory session or cleanup already ran |
+| `hooks.subagent-stop.git-failure` | git add or git commit fails | exits 0, logs error to stderr | error | non-blocking |
+
 ## Logs
 
 | Source | Location |
@@ -139,4 +177,4 @@ Fires after every Agent or Skill tool call returns. Steps (all skipped on `no-br
   ```bash
   /dark-factory:install
   ```
-- Notes: Hooks are registered in `.claude/settings.json` as `PreToolUse` and `PostToolUse` entries for the Agent tool. They run as children of the Claude Code process and inherit Claude Code's environment. The pointer file at `/tmp/dark-factory-work-dir` is the mechanism that makes the work directory visible to hooks across the subprocess isolation boundary.
+- Notes: Hooks are registered in `.claude/settings.json` as `PreToolUse`, `PostToolUse`, and `SubagentStop` entries. `PreToolUse` and `PostToolUse` match the Agent tool; `SubagentStop` fires whenever any subagent stops. All three hooks resolve the work directory using the same two-step fallback: `DARK_FACTORY_WORK_DIR` env var first, then the `/tmp/dark-factory-work-dir` pointer file. The pointer file is necessary because env vars exported inside a Bash tool call do not propagate to the Claude Code parent process or to hook subprocesses.

--- a/skills/claude-code-hook-env-isolation/SKILL.md
+++ b/skills/claude-code-hook-env-isolation/SKILL.md
@@ -40,7 +40,15 @@ file is the authoritative fallback for the common in-process case.
 
 ### Hook script side
 
-Add this block near the top of every hook that needs `DARK_FACTORY_WORK_DIR`, before any reference to `$BRAIN_PATH` or similar:
+When assigning `DARK_FACTORY_WORK_DIR` in any hook script, always use the inline pointer-file fallback form:
+
+```bash
+work_dir="${DARK_FACTORY_WORK_DIR:-$(cat /tmp/dark-factory-work-dir 2>/dev/null)}"
+```
+
+Never use `${DARK_FACTORY_WORK_DIR:-}` (bare empty fallback) — this silently produces an empty string when the env var is not propagated to the hook process, which is the common case.
+
+For hooks that set the variable once at the top and reference it throughout, use the multi-line form before any reference to `$work_dir` or `$BRAIN_PATH`:
 
 ```bash
 DARK_FACTORY_POINTER_FILE="/tmp/dark-factory-work-dir"
@@ -50,7 +58,7 @@ if [ -z "${DARK_FACTORY_WORK_DIR:-}" ] && [ -f "$DARK_FACTORY_POINTER_FILE" ]; t
 fi
 ```
 
-This must appear in both `pre-tool-use-hook.sh` and `post-tool-use-hook.sh`.
+This must appear in both `pre-tool-use-hook.sh`, `post-tool-use-hook.sh`, and any stop/subagent-stop hook scripts (e.g. `commit-on-subagent-stop.sh`).
 
 ## Why `/tmp/`
 

--- a/tests/test_commit_on_subagent_stop.py
+++ b/tests/test_commit_on_subagent_stop.py
@@ -193,17 +193,69 @@ class TestHookFiredWorkDirNotSet:
 
     def test_hook_fired_work_dir_not_set(self):
         # Plan path: hook-fired.dark-factory-work-dir-not-set
-        # Arrange: run hook without setting DARK_FACTORY_WORK_DIR
-        result = run_hook("skeleton-agent", work_dir=None)
+        # Arrange: run hook without setting DARK_FACTORY_WORK_DIR and without pointer file
+        # Remove the pointer file temporarily to test the true "not set" case
+        pointer_file = "/tmp/dark-factory-work-dir"
+        pointer_backup = None
+        if os.path.exists(pointer_file):
+            with open(pointer_file, "r") as f:
+                pointer_backup = f.read()
+            os.remove(pointer_file)
 
-        # Assert: exits 0 (non-blocking) and logs that env var is not set
-        assert result.returncode == 0, (
-            f"Expected exit 0 when DARK_FACTORY_WORK_DIR not set, got {result.returncode}. stderr: {result.stderr}"
-        )
-        # stderr should contain a message about the env var not being set
-        assert "DARK_FACTORY_WORK_DIR" in result.stderr, (
-            "Expected mention of DARK_FACTORY_WORK_DIR in stderr"
-        )
+        try:
+            result = run_hook("skeleton-agent", work_dir=None)
+
+            # Assert: exits 0 (non-blocking) and logs that env var is not set
+            assert result.returncode == 0, (
+                f"Expected exit 0 when DARK_FACTORY_WORK_DIR not set, got {result.returncode}. stderr: {result.stderr}"
+            )
+            # stderr should contain a message about the env var not being set or work_dir being empty
+            assert ("DARK_FACTORY_WORK_DIR" in result.stderr or "skipping commit" in result.stderr), (
+                "Expected skip message in stderr when work_dir is not available"
+            )
+        finally:
+            # Restore the pointer file
+            if pointer_backup is not None:
+                with open(pointer_file, "w") as f:
+                    f.write(pointer_backup)
+
+
+class TestHookFiredWorkDirFromPointerFile:
+    """Flow: hook-fired — path: hook-fired.dark-factory-work-dir-from-pointer-file"""
+
+    def test_hook_fired_work_dir_from_pointer_file(self):
+        # Plan path: hook-fired.dark-factory-work-dir-from-pointer-file
+        # Arrange: create a temp git repo and set up the pointer file, then run hook without DARK_FACTORY_WORK_DIR env var
+        repo = init_temp_git_repo()
+        stage_file(repo)
+
+        pointer_file = "/tmp/dark-factory-work-dir"
+        pointer_backup = None
+        if os.path.exists(pointer_file):
+            with open(pointer_file, "r") as f:
+                pointer_backup = f.read()
+
+        try:
+            # Write the repo path to the pointer file
+            with open(pointer_file, "w") as f:
+                f.write(repo)
+
+            # Act: run the hook without setting DARK_FACTORY_WORK_DIR (it should read from pointer file)
+            result = run_hook("skeleton-agent", work_dir=None)
+
+            # Assert: exits 0 and a commit was created using the pointer file path
+            assert result.returncode == 0, f"Expected exit 0, got {result.returncode}. stderr: {result.stderr}"
+            assert get_commit_count(repo) == 1, "Expected exactly one commit to be created from pointer file fallback"
+            assert get_last_commit_message(repo) == "skeleton", (
+                f"Expected commit message 'skeleton', got '{get_last_commit_message(repo)}'"
+            )
+        finally:
+            # Restore the pointer file
+            if pointer_backup is not None:
+                with open(pointer_file, "w") as f:
+                    f.write(pointer_backup)
+            elif os.path.exists(pointer_file):
+                os.remove(pointer_file)
 
 
 class TestHookFiredGitCommandFailure:


### PR DESCRIPTION
## Summary

Fixes the `commit-on-subagent-stop.sh` hook to use pointer file fallback when `DARK_FACTORY_WORK_DIR` environment variable is not propagated to the hook process. This ensures the hook can reliably locate the feature worktree even in subprocess isolation scenarios.

- Implements pointer file fallback in the hook script: `DARK_FACTORY_WORK_DIR="${DARK_FACTORY_WORK_DIR:-$(cat /tmp/dark-factory-work-dir 2>/dev/null)}"`
- Updated tests to verify both env var resolution and pointer file fallback paths
- Updated hook documentation to reflect the subagent-stop hook flow and work-dir resolution mechanism

## Test plan

- Verified existing test suite passes with new pointer file fallback mechanism
- Tests cover happy path (both env var and pointer file resolution), no-op cases (missing work dir, no staged changes, unknown agent type), and git failure handling

🤖 Generated with Claude Code
