### PR TITLE
fix(hooks): flush metrics to csv before session cleanup

### DIFF
--- a/agents/dark-factory/scripts/cleanup-session-files.sh
+++ b/agents/dark-factory/scripts/cleanup-session-files.sh
@@ -31,6 +31,23 @@ if [ -z "$WORK_DIR" ]; then
   exit 0
 fi
 
+BRAIN_PATH="$WORK_DIR/brain.json"
+
+# Before deleting brain.json, flush metrics to metrics.csv (if metrics exist)
+if [ -f "$BRAIN_PATH" ]; then
+  PROJECT_DIR=$(jq -r '.projectDir // empty' "$BRAIN_PATH" 2>/dev/null || true)
+  if [ -n "$PROJECT_DIR" ]; then
+    METRICS_CSV="$PROJECT_DIR/metrics.csv"
+    CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+    if [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py" ]; then
+      python3 "${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py" \
+        --csv "$METRICS_CSV" \
+        --brain "$BRAIN_PATH" || true
+      echo "cleanup-session-files | metrics-flushed | csv=$METRICS_CSV" >&2
+    fi
+  fi
+fi
+
 # Array of session files to clean up (relative to WORK_DIR or absolute paths)
 SESSION_FILES=(
   "$WORK_DIR/brain.json"

--- a/docs/docs/hooks.md
+++ b/docs/docs/hooks.md
@@ -6,7 +6,7 @@
 
 ## System Intent
 
-- What this is: Three Claude Code hooks — `pre-tool-use-hook.sh`, `post-tool-use-hook.sh`, and `commit-on-subagent-stop.sh` — manage brain state and produce ordered git commits during a manufacture run. The pre-hook injects brain.json context into the agent prompt and records a start timestamp for metrics. The post-hook merges any `brain-patch.json` written by the sub-agent back into `brain.json`, accumulates elapsed time and token counts, and marks the current phase complete. The SubagentStop hook commits staged changes to the feature worktree when skeleton-agent, testing-agent, or implementation-agent finishes, producing an ordered proof-of-execution commit sequence.
+- What this is: Four Claude Code hooks — `pre-tool-use-hook.sh`, `post-tool-use-hook.sh`, `commit-on-subagent-stop.sh`, and `cleanup-session-files.sh` — manage brain state, metrics persistence, and ordered git commits during a manufacture run. The pre-hook injects brain.json context into the agent prompt and records a start timestamp for metrics. The post-hook merges any `brain-patch.json` written by the sub-agent back into `brain.json`, accumulates elapsed time and token counts, and marks the current phase complete. The SubagentStop hook commits staged changes to the feature worktree when skeleton-agent, testing-agent, or implementation-agent finishes, producing an ordered proof-of-execution commit sequence. The Stop hook flushes accumulated metrics from brain.json to metrics.csv before deleting all transient session files.
 
 ## Mermaid Diagram
 
@@ -22,7 +22,8 @@ flowchart TD
 
   CC -->|fires before tool runs| PreHook
   CC -->|fires after tool returns| PostHook
-  CC -->|fires on SubagentStop| StopHook["commit-on-subagent-stop.sh"]
+  CC -->|fires on SubagentStop| SubStopHook["commit-on-subagent-stop.sh"]
+  CC -->|fires on Stop| SessionCleanupHook["cleanup-session-files.sh"]
 
   PreHook -->|"1. resolve WORK_DIR\n(env var → pointer file)"| PF
   PreHook -->|"2. record start_ms"| Brain
@@ -34,9 +35,14 @@ flowchart TD
   PostHook -->|"3. accumulate elapsed_ms,\ntokens, runs"| Brain
   PostHook -->|"4. mark phase complete"| Brain
 
-  StopHook -->|"1. resolve WORK_DIR\n(env var → pointer file)"| PF
-  StopHook -->|"2. read agent_type from stdin"| AgentType["agent_type\n(skeleton|testing|implementation)"]
-  StopHook -->|"3. git add --all\ngit commit -m <msg>"| GitCommit["Feature worktree commit"]
+  SubStopHook -->|"1. resolve WORK_DIR\n(env var → pointer file)"| PF
+  SubStopHook -->|"2. read agent_type from stdin"| AgentType["agent_type\n(skeleton|testing|implementation)"]
+  SubStopHook -->|"3. git add --all\ngit commit -m <msg>"| GitCommit["Feature worktree commit"]
+
+  SessionCleanupHook -->|"1. resolve WORK_DIR\n(env var → pointer file)"| PF
+  SessionCleanupHook -->|"2. flush metrics"| Brain
+  Brain -->|update-metrics.py| MetricsCSV["PROJECT_DIR/metrics.csv"]
+  SessionCleanupHook -->|"3. delete session files"| Brain
 ```
 
 ## Flows
@@ -162,6 +168,33 @@ CommitMessage {
 | `hooks.subagent-stop.no-work-dir` | DARK_FACTORY_WORK_DIR unset and pointer file absent | exits 0, logs "DARK_FACTORY_WORK_DIR not set, skipping commit" | no-op | not a dark-factory session or cleanup already ran |
 | `hooks.subagent-stop.git-failure` | git add or git commit fails | exits 0, logs error to stderr | error | non-blocking |
 
+---
+
+### Flow: `hooks.session-cleanup`
+
+- Core files: `agents/dark-factory/scripts/cleanup-session-files.sh`
+- Test files: `tests/test_cleanup_session_files.py`
+
+Fires on the Claude Code `Stop` event (registered in `hooks/hooks.json`). Runs after every session ends — whether or not a manufacture task was in progress. Always exits 0.
+
+Steps:
+
+1. Resolve `DARK_FACTORY_WORK_DIR` using the same two-step fallback as other hooks (env var → pointer file). If neither is set, exit immediately with no-op.
+2. If `brain.json` exists and contains a `projectDir` field, and `CLAUDE_PLUGIN_ROOT` is set and `scripts/update-metrics.py` exists: call `python3 update-metrics.py --csv <projectDir>/metrics.csv --brain brain.json` to flush accumulated session metrics to the CSV. Errors from this step are non-fatal (`|| true`).
+3. Delete all transient session files: `brain.json`, `brain.json.lock`, `brain-patch.json`, `flows-state.json`, and `/tmp/dark-factory-work-dir`.
+
+This step is the only place where metrics stored in `brain.json` during a session are written durably to `metrics.csv`. Without this flush, all per-agent elapsed time, token counts, and run counts accumulated by the post-hook would be lost when `brain.json` is deleted.
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `hooks.session-cleanup.no-work-dir` | env var unset, pointer file absent | exits 0, logs to stderr | no-op | not a dark-factory session |
+| `hooks.session-cleanup.metrics-flush` | brain.json present with projectDir, update-metrics.py accessible | metrics written to `<projectDir>/metrics.csv`, logs `metrics-flushed` to stderr | happy path | |
+| `hooks.session-cleanup.no-metrics-script` | CLAUDE_PLUGIN_ROOT unset or update-metrics.py missing | metrics flush skipped silently | degraded | session files still deleted |
+| `hooks.session-cleanup.no-project-dir` | brain.json present but projectDir empty or missing | metrics flush skipped silently | degraded | session files still deleted |
+| `hooks.session-cleanup.delete-files` | session files exist | each file deleted; per-file success/failure logged to stderr | happy path | failures are warnings; exit is always 0 |
+
 ## Logs
 
 | Source | Location |
@@ -177,4 +210,4 @@ CommitMessage {
   ```bash
   /dark-factory:install
   ```
-- Notes: Hooks are registered in `.claude/settings.json` as `PreToolUse`, `PostToolUse`, and `SubagentStop` entries. `PreToolUse` and `PostToolUse` match the Agent tool; `SubagentStop` fires whenever any subagent stops. All three hooks resolve the work directory using the same two-step fallback: `DARK_FACTORY_WORK_DIR` env var first, then the `/tmp/dark-factory-work-dir` pointer file. The pointer file is necessary because env vars exported inside a Bash tool call do not propagate to the Claude Code parent process or to hook subprocesses.
+- Notes: Hooks are registered in `hooks/hooks.json` (merged into `.claude/settings.json` at install time) as `PreToolUse`, `PostToolUse`, `SubagentStop`, and `Stop` entries. `PreToolUse` and `PostToolUse` match the Agent tool; `SubagentStop` fires whenever any subagent stops; `Stop` fires once when the Claude Code session ends. All four hooks resolve the work directory using the same two-step fallback: `DARK_FACTORY_WORK_DIR` env var first, then the `/tmp/dark-factory-work-dir` pointer file. The pointer file is necessary because env vars exported inside a Bash tool call do not propagate to the Claude Code parent process or to hook subprocesses. The `Stop` hook (`cleanup-session-files.sh`) is the authoritative flush point for metrics — it writes brain.json metrics to `metrics.csv` before deleting all session files.

--- a/skills/flush-brain-data-before-cleanup/SKILL.md
+++ b/skills/flush-brain-data-before-cleanup/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: flush-brain-data-before-cleanup
+description: "Any script that deletes brain.json (including the Stop hook cleanup-session-files.sh) must flush derived persistent data — metrics, artifacts, etc. — from brain.json before the deletion, because brain.json is the only in-session source of that data."
+user-invocable: false
+---
+## When to use
+
+Whenever modifying or adding logic to any script that deletes `brain.json`, including:
+- `cleanup-session-files.sh` (called by the Stop hook on session end or interruption)
+- `dark-factory-agent` cleanup steps that delete brain.json before calling `cleanup-worktree.sh`
+
+If brain.json contains data that must outlive the session (metrics, report fields, artifact paths), it must be flushed before deletion in every code path that removes brain.json.
+
+## Steps
+
+1. Identify all persistent data stored in brain.json that must survive session end. Common examples:
+   - `metrics.*` fields accumulated by hook scripts (token counts, durations, phase counts)
+   - `projectDir` — path to the permanent repo root (needed to write persistent files)
+   - Any artifact paths that should be registered outside the worktree
+
+2. In the cleanup script, read and flush that data **before** the `rm -f brain.json` call:
+   ```bash
+   BRAIN_PATH="$WORK_DIR/brain.json"
+
+   if [ -f "$BRAIN_PATH" ]; then
+     PROJECT_DIR=$(jq -r '.projectDir // empty' "$BRAIN_PATH" 2>/dev/null || true)
+     if [ -n "$PROJECT_DIR" ] && [ -n "$CLAUDE_PLUGIN_ROOT" ]; then
+       python3 "${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py" \
+         --csv "$PROJECT_DIR/metrics.csv" \
+         --brain "$BRAIN_PATH" || true
+     fi
+   fi
+
+   rm -f "$BRAIN_PATH"
+   ```
+
+3. Use `|| true` on flush calls so a failed flush never blocks the cleanup. Log the result to stderr for auditability:
+   ```bash
+   echo "cleanup-session-files | metrics-flushed | csv=$METRICS_CSV" >&2
+   ```
+
+4. Apply this same flush-before-delete pattern in every code path that removes brain.json: normal manufacture cleanup, error-path `cleanup()` trap functions, and the Stop hook script.
+
+## Notes
+
+- The Stop hook (`cleanup-session-files.sh`) fires on both normal session end and on interruption (user presses Ctrl+C, Claude Code crashes). If the flush only happens in the normal-path cleanup of `dark-factory-agent`, metrics are silently lost on interruption. Both paths need the flush.
+- `CLAUDE_PLUGIN_ROOT` may be unset in some hook execution contexts. Always guard with `[ -n "$CLAUDE_PLUGIN_ROOT" ]` before referencing it, and provide a fallback or skip gracefully.
+- This pattern complements `capture-project-dir-before-worktree`: that skill explains how to store `projectDir` in brain.json so the cleanup step can locate the permanent repo. This skill explains what to do with that path at deletion time.
+- Do not attempt to write to `$WORK_DIR` after flushing, since the worktree may be deleted immediately after. Write only to `$PROJECT_DIR` paths derived from brain.json fields.

--- a/tests/test_cleanup_session_files.py
+++ b/tests/test_cleanup_session_files.py
@@ -1,0 +1,273 @@
+"""
+Unit tests for cleanup-session-files.sh.
+
+Tests cover:
+- Metrics are flushed to CSV before brain.json is deleted
+- Session files are properly cleaned up
+- Script handles missing projectDir gracefully
+- Script handles missing update-metrics.py gracefully
+"""
+
+import csv
+import json
+import os
+import subprocess
+import tempfile
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CLEANUP_SCRIPT = os.path.join(
+    REPO_ROOT, "agents", "dark-factory", "scripts", "cleanup-session-files.sh"
+)
+UPDATE_METRICS_SCRIPT = os.path.join(REPO_ROOT, "scripts", "update-metrics.py")
+
+
+def make_brain(project_dir=None, metrics=None):
+    """Create a minimal brain.json dict."""
+    brain = {
+        "taskDescription": "test task",
+        "taskName": "test",
+        "workDir": "/tmp/test",
+        "projectDir": project_dir,
+        "classification": "feature",
+        "planFilePath": None,
+        "bugFiles": None,
+        "prUrl": None,
+        "docsWritten": None,
+        "skillsWritten": None,
+        "phases": {},
+    }
+    if metrics is not None:
+        brain["metrics"] = metrics
+    return brain
+
+
+def run_cleanup(work_dir, env_override=None):
+    """Run cleanup-session-files.sh and return CompletedProcess."""
+    env = dict(os.environ)
+    env["CLAUDE_PLUGIN_ROOT"] = REPO_ROOT
+    if env_override:
+        env.update(env_override)
+    return subprocess.run(
+        ["bash", CLEANUP_SCRIPT],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def read_csv_rows(csv_path):
+    """Return list of row dicts from csv_path; empty list if file absent."""
+    if not os.path.exists(csv_path):
+        return []
+    with open(csv_path, newline="") as f:
+        return list(csv.DictReader(f))
+
+
+class TestCleanupFlushesMetrics:
+    """Flow: cleanupFlushesMetrics"""
+
+    def test_success_flushes_metrics_before_delete(self):
+        """cleanupFlushesMetrics.success: metrics are flushed to CSV before brain.json is deleted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Setup: create a work dir with brain.json and a project dir with metrics.csv
+            brain = make_brain(
+                project_dir=tmpdir,
+                metrics={
+                    "feature-agent": {
+                        "elapsed_ms": 1000,
+                        "tokens": 200,
+                        "runs": 1,
+                    }
+                },
+            )
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            csv_path = os.path.join(tmpdir, "metrics.csv")
+
+            # Run cleanup
+            result = run_cleanup(tmpdir, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+
+            # Verify metrics were flushed to CSV
+            assert os.path.exists(csv_path), "metrics.csv should exist after cleanup"
+            rows = read_csv_rows(csv_path)
+            assert len(rows) == 1
+            assert rows[0]["agent"] == "feature-agent"
+            assert int(rows[0]["runs"]) == 1
+
+            # Verify brain.json was deleted
+            assert not os.path.exists(brain_path), "brain.json should be deleted after cleanup"
+
+    def test_flush_no_metrics(self):
+        """cleanupFlushesMetrics.no-metrics: cleanup succeeds even when brain.json has no metrics."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            brain = make_brain(project_dir=tmpdir, metrics={})
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            csv_path = os.path.join(tmpdir, "metrics.csv")
+
+            result = run_cleanup(tmpdir, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            # No metrics, so CSV should not be created
+            assert not os.path.exists(csv_path)
+            assert not os.path.exists(brain_path)
+
+    def test_flush_no_project_dir(self):
+        """cleanupFlushesMetrics.no-project-dir: cleanup succeeds when projectDir is null."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            brain = make_brain(
+                project_dir=None,
+                metrics={
+                    "feature-agent": {"elapsed_ms": 1000, "tokens": 200, "runs": 1}
+                },
+            )
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            result = run_cleanup(tmpdir, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            # brain.json should be deleted even if projectDir is null
+            assert not os.path.exists(brain_path)
+
+    def test_flush_missing_update_metrics_script(self):
+        """cleanupFlushesMetrics.missing-script: cleanup succeeds even if update-metrics.py is not found."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            brain = make_brain(
+                project_dir=tmpdir,
+                metrics={
+                    "feature-agent": {"elapsed_ms": 1000, "tokens": 200, "runs": 1}
+                },
+            )
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            # Clear CLAUDE_PLUGIN_ROOT so script can't find update-metrics.py
+            result = run_cleanup(
+                tmpdir,
+                env_override={
+                    "DARK_FACTORY_WORK_DIR": tmpdir,
+                    "CLAUDE_PLUGIN_ROOT": "",
+                },
+            )
+
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            # brain.json should still be deleted
+            assert not os.path.exists(brain_path)
+
+    def test_flush_accumulates_with_existing_csv(self):
+        """cleanupFlushesMetrics.accumulate: metrics accumulate with existing CSV rows."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "metrics.csv")
+
+            # Pre-populate CSV with one row
+            with open(csv_path, "w", newline="") as f:
+                writer = csv.DictWriter(
+                    f,
+                    fieldnames=[
+                        "agent",
+                        "skill",
+                        "avg_runtime",
+                        "avg_tokens",
+                        "runs",
+                        "sum_runtime",
+                        "sum_tokens",
+                    ],
+                )
+                writer.writeheader()
+                writer.writerow({
+                    "agent": "feature-agent",
+                    "skill": "",
+                    "avg_runtime": "1000.0",
+                    "avg_tokens": "200.0",
+                    "runs": "1",
+                    "sum_runtime": "1000.0",
+                    "sum_tokens": "200.0",
+                })
+
+            brain = make_brain(
+                project_dir=tmpdir,
+                metrics={
+                    "feature-agent": {"elapsed_ms": 2000, "tokens": 400, "runs": 1}
+                },
+            )
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            result = run_cleanup(tmpdir, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+
+            # Verify metrics accumulated
+            rows = read_csv_rows(csv_path)
+            assert len(rows) == 1
+            assert int(rows[0]["runs"]) == 2
+
+
+class TestCleanupDeletesSessionFiles:
+    """Flow: cleanupDeletesSessionFiles"""
+
+    def test_deletes_brain_json(self):
+        """cleanupDeletesSessionFiles.brain: brain.json is deleted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            brain = make_brain(project_dir=tmpdir)
+            brain_path = os.path.join(tmpdir, "brain.json")
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+
+            result = run_cleanup(tmpdir, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            assert not os.path.exists(brain_path)
+
+    def test_deletes_all_session_files(self):
+        """cleanupDeletesSessionFiles.all: all session files are deleted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            brain = make_brain(project_dir=tmpdir)
+            brain_path = os.path.join(tmpdir, "brain.json")
+            patch_path = os.path.join(tmpdir, "brain-patch.json")
+            flows_path = os.path.join(tmpdir, "flows-state.json")
+            lock_path = os.path.join(tmpdir, "brain.json.lock")
+
+            with open(brain_path, "w") as f:
+                json.dump(brain, f)
+            with open(patch_path, "w") as f:
+                json.dump({}, f)
+            with open(flows_path, "w") as f:
+                json.dump({}, f)
+            with open(lock_path, "w") as f:
+                f.write("")
+
+            result = run_cleanup(tmpdir, env_override={"DARK_FACTORY_WORK_DIR": tmpdir})
+
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            assert not os.path.exists(brain_path)
+            assert not os.path.exists(patch_path)
+            assert not os.path.exists(flows_path)
+            assert not os.path.exists(lock_path)
+
+    def test_no_work_dir(self):
+        """cleanupDeletesSessionFiles.no-work-dir: cleanup exits 0 when DARK_FACTORY_WORK_DIR is unset."""
+        env = dict(os.environ)
+        env.pop("DARK_FACTORY_WORK_DIR", None)
+
+        result = subprocess.run(
+            ["bash", CLEANUP_SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 0
+        assert "no-work-dir" in result.stderr


### PR DESCRIPTION
## Summary

Fix the metrics flush issue: metrics accumulated in brain.json during a session are now flushed to metrics.csv before deletion, preventing silent loss of all per-agent statistics at session end.

Previously, metrics (elapsed time, token counts, run counts) accumulated by hook scripts were stored only in brain.json and lost when the session ended. This fix adds a metrics flush step to cleanup-session-files.sh that calls update-metrics.py to durably write accumulated metrics to metrics.csv before brain.json is deleted.

## Changes

- **agents/dark-factory/scripts/cleanup-session-files.sh**: Added metrics flush logic (lines 36-49) that reads projectDir from brain.json and calls update-metrics.py before deleting session files.
- **tests/test_cleanup_session_files.py**: Added 8 new tests covering:
  - Successful metrics flush to CSV before brain.json deletion
  - Graceful handling when brain.json has no metrics
  - Graceful handling when projectDir is null
  - Graceful handling when update-metrics.py is not found
  - Proper accumulation of metrics with existing CSV rows
  - Verification that all session files are deleted
  - Verification of no-work-dir exit behavior
- **docs/docs/hooks.md**: Updated documentation to include the session cleanup hook flow, explaining when metrics are flushed and what happens to session files.
- **skills/flush-brain-data-before-cleanup/SKILL.md**: New skill documenting the pattern of flushing persistent data before brain.json deletion.

## Test Plan

- Run the full test suite with `pytest tests/test_cleanup_session_files.py` — all 8 tests should pass.
- Verify that metrics.csv is created/updated after a manufacture session completes.
- Verify that brain.json and other session files are cleaned up without error.
- Test interruption scenarios (Ctrl+C) to ensure metrics are flushed even during early termination.

🧠 Generated with Claude Code
