### PR TITLE
fix: commit metrics.csv to feature branch as part of manufacture PR

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -5,7 +5,7 @@ description: Top-level dark-factory orchestrator. Classifies tasks via task-clas
 tools: Read, Bash, Agent, PushNotification, AskUserQuestion, Skill
 model: haiku
 scripts: ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh, ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh
-allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh *), Bash(python3 ${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py *), Bash(git -C * log *), Bash(git rev-parse *)
+allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh *), Bash(python3 ${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py *), Bash(git -C * log *), Bash(git -C * add *), Bash(git -C * diff *), Bash(git -C * commit *), Bash(git -C * push *), Bash(cp *), Bash(git rev-parse *)
 skills: task-classifier, brain-state-manager
 ---
 
@@ -144,7 +144,12 @@ dark-factory-agent(taskDescription, taskName):
   projectDir = brain.projectDir
 
   # Step 12 — flush metrics then cleanup
-  bash("python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py\" --csv \"$projectDir/metrics.csv\" --brain \"$WORK_DIR/brain.json\" || true")
+  # Write metrics into the worktree so they land on the feature branch in the PR
+  bash("python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py\" --csv \"$WORK_DIR/metrics.csv\" --brain \"$WORK_DIR/brain.json\" || true")
+  # Commit and push metrics.csv to the feature branch so it lands in the PR
+  bash("git -C \"$WORK_DIR\" add metrics.csv && git -C \"$WORK_DIR\" diff --cached --quiet || git -C \"$WORK_DIR\" commit -m 'chore: update metrics.csv' && git -C \"$WORK_DIR\" push || true")
+  # Copy metrics back to the project root so the local file stays current
+  bash("cp \"$WORK_DIR/metrics.csv\" \"$projectDir/metrics.csv\" || true")
   invoke brain-state-manager({ operation: "delete", workDir: WORK_DIR })
   bash("rm -f /tmp/dark-factory-work-dir")
   bash("${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh \"$WORK_DIR\" \"$taskName\"")

--- a/docs/docs/dark-factory-agent.md
+++ b/docs/docs/dark-factory-agent.md
@@ -100,7 +100,9 @@ If non-feature worker returns error or hard-stop: runs cleanup, reports error, S
 - Extracts `prUrl` and `projectDir` from brain.json for final report
 
 ### Step 12: Metrics & Cleanup
-- Flushes metrics: `python3 update-metrics.py --csv metrics.csv --brain brain.json`
+- Flushes metrics into `$WORK_DIR/metrics.csv` (the feature branch worktree): `python3 update-metrics.py --csv $WORK_DIR/metrics.csv --brain brain.json`
+- Commits and pushes metrics.csv to the feature branch so it lands in the PR: `git -C $WORK_DIR add metrics.csv && git -C $WORK_DIR commit -m 'chore: update metrics.csv' && git -C $WORK_DIR push`
+- Copies metrics.csv back to `$projectDir/metrics.csv` so the local main copy stays current before the PR is merged
 - Deletes brain.json via brain-state-manager
 - Removes worktree via: `cleanup-worktree.sh WORK_DIR taskName`
 - Reports final success with PR URL

--- a/skills/flush-brain-data-before-cleanup/SKILL.md
+++ b/skills/flush-brain-data-before-cleanup/SKILL.md
@@ -18,7 +18,24 @@ If brain.json contains data that must outlive the session (metrics, report field
    - `projectDir` — path to the permanent repo root (needed to write persistent files)
    - Any artifact paths that should be registered outside the worktree
 
-2. In the cleanup script, read and flush that data **before** the `rm -f brain.json` call:
+2. In the cleanup script, read and flush that data **before** the `rm -f brain.json` call.
+
+   **In dark-factory-agent (manufacture flow)**: flush to `$WORK_DIR/metrics.csv` first so the file lands on the feature branch in the PR, then commit+push it, then copy to `$PROJECT_DIR/metrics.csv`:
+   ```bash
+   # Write to worktree so metrics land in the PR
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py" \
+     --csv "$WORK_DIR/metrics.csv" \
+     --brain "$WORK_DIR/brain.json" || true
+   # Commit metrics to the feature branch
+   git -C "$WORK_DIR" add metrics.csv && \
+     git -C "$WORK_DIR" diff --cached --quiet || \
+     git -C "$WORK_DIR" commit -m 'chore: update metrics.csv' && \
+     git -C "$WORK_DIR" push || true
+   # Copy back to project root so local copy stays current
+   cp "$WORK_DIR/metrics.csv" "$PROJECT_DIR/metrics.csv" || true
+   ```
+
+   **In cleanup-session-files.sh (Stop hook)**: flush directly to `$PROJECT_DIR/metrics.csv` (no worktree commit — the session is ending):
    ```bash
    BRAIN_PATH="$WORK_DIR/brain.json"
 
@@ -46,4 +63,4 @@ If brain.json contains data that must outlive the session (metrics, report field
 - The Stop hook (`cleanup-session-files.sh`) fires on both normal session end and on interruption (user presses Ctrl+C, Claude Code crashes). If the flush only happens in the normal-path cleanup of `dark-factory-agent`, metrics are silently lost on interruption. Both paths need the flush.
 - `CLAUDE_PLUGIN_ROOT` may be unset in some hook execution contexts. Always guard with `[ -n "$CLAUDE_PLUGIN_ROOT" ]` before referencing it, and provide a fallback or skip gracefully.
 - This pattern complements `capture-project-dir-before-worktree`: that skill explains how to store `projectDir` in brain.json so the cleanup step can locate the permanent repo. This skill explains what to do with that path at deletion time.
-- Do not attempt to write to `$WORK_DIR` after flushing, since the worktree may be deleted immediately after. Write only to `$PROJECT_DIR` paths derived from brain.json fields.
+- In the manufacture flow (dark-factory-agent), write metrics to `$WORK_DIR` first so they land in the PR commit, then copy to `$PROJECT_DIR`. In the Stop hook (cleanup-session-files.sh), write directly to `$PROJECT_DIR` since there is no PR commit to make.

--- a/tests/test_metrics_committed_to_pr.py
+++ b/tests/test_metrics_committed_to_pr.py
@@ -1,0 +1,110 @@
+"""
+Test that dark-factory-agent commits metrics.csv to the feature branch.
+
+Asserts that Step 12 in dark-factory-agent.md:
+1. Writes metrics to $WORK_DIR/metrics.csv (not $projectDir/metrics.csv)
+2. Stages and commits metrics.csv to the feature branch
+3. Copies metrics.csv back to $projectDir/metrics.csv
+"""
+
+import os
+import re
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DARK_FACTORY_AGENT_PATH = os.path.join(
+    REPO_ROOT, "agents", "dark-factory", "agents", "dark-factory-agent.md"
+)
+
+
+def _full(path):
+    with open(path) as f:
+        return f.read()
+
+
+class TestMetricsCommittedToPR:
+    """metricsCommittedToPR: metrics.csv is committed to the feature branch as part of the PR."""
+
+    def test_metrics_written_to_work_dir(self):
+        """
+        metricsCommittedToPR.write-to-workdir: update-metrics.py must target $WORK_DIR/metrics.csv
+        so the file ends up on the feature branch, not only in the main project directory.
+        """
+        content = _full(DARK_FACTORY_AGENT_PATH)
+        # Must reference WORK_DIR for the csv path, not just projectDir
+        assert '"$WORK_DIR/metrics.csv"' in content or "$WORK_DIR/metrics.csv" in content, (
+            "dark-factory-agent Step 12 must write metrics.csv to $WORK_DIR so it lands "
+            "on the feature branch. Found --csv pointing to projectDir only."
+        )
+
+    def test_metrics_csv_committed_to_branch(self):
+        """
+        metricsCommittedToPR.commit-to-branch: after flushing metrics, dark-factory-agent
+        must stage and commit metrics.csv so it lands in the PR.
+        """
+        content = _full(DARK_FACTORY_AGENT_PATH)
+        # Look for git add metrics.csv followed by git commit
+        assert "git -C" in content and "add metrics.csv" in content, (
+            "dark-factory-agent Step 12 must run 'git -C \"$WORK_DIR\" add metrics.csv' "
+            "to stage the updated metrics file for the PR commit."
+        )
+        assert "git -C" in content and "commit" in content and "metrics.csv" in content, (
+            "dark-factory-agent Step 12 must commit metrics.csv to the feature branch "
+            "so it appears in the PR diff."
+        )
+
+    def test_metrics_csv_pushed_to_remote(self):
+        """
+        metricsCommittedToPR.push-to-remote: dark-factory-agent must push the metrics
+        commit so the PR branch on the remote includes metrics.csv.
+        """
+        content = _full(DARK_FACTORY_AGENT_PATH)
+        # Look for push in the metrics section (Step 12)
+        step12_match = re.search(
+            r"# Step 12.*?(?=# Step 13|## cleanup|## Rules)",
+            content,
+            re.DOTALL,
+        )
+        assert step12_match is not None, "Could not find Step 12 section in dark-factory-agent.md"
+        step12 = step12_match.group(0)
+        assert "push" in step12, (
+            "dark-factory-agent Step 12 must push after committing metrics.csv so the "
+            "remote PR branch includes the metrics update."
+        )
+
+    def test_metrics_csv_copied_back_to_project_dir(self):
+        """
+        metricsCommittedToPR.copy-back: dark-factory-agent must copy metrics.csv from
+        $WORK_DIR back to $projectDir after committing, so the local main project dir
+        stays current even before the PR is merged.
+        """
+        content = _full(DARK_FACTORY_AGENT_PATH)
+        step12_match = re.search(
+            r"# Step 12.*?(?=# Step 13|## cleanup|## Rules)",
+            content,
+            re.DOTALL,
+        )
+        assert step12_match is not None, "Could not find Step 12 section in dark-factory-agent.md"
+        step12 = step12_match.group(0)
+        assert "$projectDir/metrics.csv" in step12, (
+            "dark-factory-agent Step 12 must copy metrics.csv back to $projectDir/metrics.csv "
+            "so the local working copy stays current after cleanup."
+        )
+
+    def test_metrics_allowed_tools_include_git_ops(self):
+        """
+        metricsCommittedToPR.allowed-tools: dark-factory-agent frontmatter must allow
+        git add, git diff, git commit, and git push so the metrics commit is not blocked.
+        """
+        content = _full(DARK_FACTORY_AGENT_PATH)
+        frontmatter_match = re.search(r"^---\n(.*?)\n---", content, re.DOTALL)
+        assert frontmatter_match is not None, "Could not find YAML frontmatter"
+        frontmatter = frontmatter_match.group(1)
+        assert "git -C * add *" in frontmatter, (
+            "allowed-tools must include 'Bash(git -C * add *)' for metrics staging"
+        )
+        assert "git -C * commit *" in frontmatter, (
+            "allowed-tools must include 'Bash(git -C * commit *)' for metrics commit"
+        )
+        assert "git -C * push *" in frontmatter, (
+            "allowed-tools must include 'Bash(git -C * push *)' for metrics push"
+        )


### PR DESCRIPTION
## Summary

- metrics.csv is now written to `$WORK_DIR/metrics.csv` (the feature branch worktree) instead of `$projectDir/metrics.csv`, so the file lands on the feature branch
- After flushing metrics, dark-factory-agent stages, commits, and pushes metrics.csv to the feature branch so every manufacture PR includes the updated metrics
- metrics.csv is then copied back to `$projectDir/metrics.csv` so the local main copy stays current before the PR is merged
- Added `git -C * add *`, `git -C * diff *`, `git -C * commit *`, `git -C * push *`, and `cp *` to `allowed-tools` in dark-factory-agent frontmatter
- Updated `flush-brain-data-before-cleanup` skill to document the two-phase flush pattern (worktree commit vs Stop hook direct write)
- Added `test_metrics_committed_to_pr.py` with 5 tests asserting all four behavioral requirements

## Test plan

- [x] `tests/test_metrics_committed_to_pr.py` — 5 new tests covering write-to-workdir, commit-to-branch, push-to-remote, copy-back, and allowed-tools assertions (all pass)
- [x] Full test suite run: 0 new failures introduced (16 pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)