### PR TITLE
chore(agents): expand allowed-tools for cloud-native projects

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.40",
+  "version": "1.2.41",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/agents/debugger/agents/debugger-agent.md
+++ b/agents/debugger/agents/debugger-agent.md
@@ -5,7 +5,7 @@ description: Runs systematic debugging on a non-obvious bug by following the deb
 tools: Read, Write, Edit, Bash, Glob, Agent, Skill
 model: sonnet
 skills: systematic-debugging, invoke-investigation-agent
-allowed-tools: Bash(bash *), Bash(pytest *), Bash(python *), Bash(npm test *), Bash(grep -r *), Bash(find *)
+allowed-tools: Bash(bash *), Bash(pytest *), Bash(python *), Bash(npm test *), Bash(grep -r *), Bash(find *), Bash(aws *), Bash(gh *), Bash(docker *), Bash(curl *)
 ---
 
 You are a systematic debugger. Your only job is to follow the steps in `flows/debugger/skills/debug/SKILL.md` in order, without skipping.

--- a/agents/featurework/execution/agents/implementation-agent.md
+++ b/agents/featurework/execution/agents/implementation-agent.md
@@ -5,7 +5,7 @@ description: Phase 3 of plan execution. Implements each flow from the flows chec
 tools: Read, Write, Edit, Bash, Glob, Agent, PushNotification, AskUserQuestion
 skills: deviation-protocol, logging
 model: sonnet
-allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(bash *), Bash(mkdir -p *), Bash(find *), Bash(grep -r *)
+allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(bash *), Bash(mkdir -p *), Bash(find *), Bash(grep -r *), Bash(aws *), Bash(gh *), Bash(git *), Bash(docker *)
 SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
 ---
 

--- a/agents/featurework/execution/agents/testing-agent.md
+++ b/agents/featurework/execution/agents/testing-agent.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Phase 2 of plan execution. Reads a plan file, builds a flows checklist, and writes one failing test per flow path. Confirms all new tests fail before returning.
 tools: Read, Write, Edit, Bash, Glob
 model: sonnet
-allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(bash *), Bash(find *)
+allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(bash *), Bash(find *), Bash(aws *), Bash(git *)
 SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
 ---
 

--- a/agents/fix-flow/agents/debug-flow-agent.md
+++ b/agents/fix-flow/agents/debug-flow-agent.md
@@ -5,7 +5,7 @@ description: Runs an integration flow, waits for it to finish, fetches logs, and
 tools: Read, Write, Edit, Bash, Grep, Glob, Agent
 model: sonnet
 scripts: trigger.sh, wait-for-completion.sh, fetch-logs.sh
-allowed-tools: Bash(bash trigger.sh), Bash(bash wait-for-completion.sh), Bash(bash fetch-logs.sh)
+allowed-tools: Bash(bash trigger.sh), Bash(bash wait-for-completion.sh), Bash(bash fetch-logs.sh), Bash(bash *), Bash(aws *), Bash(gh *), Bash(git *), Bash(docker *), Bash(curl *)
 ---
 
 You are the debug-flow-agent. Your job is to run the flow, wait for it to finish, and fetch the logs. You do not debug, create PRs, or deploy. Once you have the logs, you hand off to debugger-agent to do the actual debugging.

--- a/agents/fix-flow/agents/ralph-fix-and-push.md
+++ b/agents/fix-flow/agents/ralph-fix-and-push.md
@@ -4,7 +4,7 @@ description: Owns the bug-fixing loop for fix-flow-orchestrator. Spawns debugger
 tools: Read, Bash, Agent, PushNotification, AskUserQuestion
 model: haiku
 user-invocable: false
-allowed-tools: Bash(bash *), Bash(find *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *)
+allowed-tools: Bash(bash *), Bash(find *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *), Bash(aws *), Bash(gh *)
 ---
 
 You are ralph-fix-and-push. You own the fix loop. Your job is to keep iterating — trigger the flow, debug failures, commit fixes locally — until the flow passes green, then create a single PR with all accumulated commits.

--- a/agents/repair/agents/repair-agent.md
+++ b/agents/repair/agents/repair-agent.md
@@ -5,7 +5,7 @@ description: Lightweight repair agent. Applies a targeted change from a plain ta
 tools: Read, Write, Edit, Bash, Glob, Agent, Skill
 model: haiku
 skills: invoke-investigation-agent
-allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(npm run test *), Bash(go test *), Bash(bash *), Bash(mkdir -p *), Bash(find *), Bash(grep -r *)
+allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(npm run test *), Bash(go test *), Bash(bash *), Bash(mkdir -p *), Bash(find *), Bash(grep -r *), Bash(aws *), Bash(gh *), Bash(git *)
 ---
 
 You are the repair-agent. Your job is to apply a targeted change described in plain language, run the existing test suite, fix any breakage iteratively, and report back to the caller.

--- a/docs/docs/debugger-agent.md
+++ b/docs/docs/debugger-agent.md
@@ -130,6 +130,12 @@ Resolves WORK_DIR (see rule 7) and writes `$WORK_DIR/brain-patch.json`:
 
 - Read, Write, Edit, Bash, Glob, Agent
 
+## Allowed Bash Commands
+
+`Bash(bash *)`, `Bash(pytest *)`, `Bash(python *)`, `Bash(npm test *)`, `Bash(grep -r *)`, `Bash(find *)`, `Bash(aws *)`, `Bash(gh *)`, `Bash(docker *)`, `Bash(curl *)`
+
+Includes cloud-native tooling (`aws`, `gh`, `docker`, `curl`) so the agent can fetch remote logs, query cloud resources, and inspect container state without silently failing on cloud-hosted projects.
+
 ## Error Handling
 
 - If bug is obviously simple (not non-obvious/state-dependent): report and STOP

--- a/docs/docs/repair-agent.md
+++ b/docs/docs/repair-agent.md
@@ -118,6 +118,12 @@ Sets `significantChange` flag based on whether any modified file is:
 
 - Read, Write, Edit, Bash, Glob
 
+## Allowed Bash Commands
+
+`Bash(pytest *)`, `Bash(python *)`, `Bash(npm test *)`, `Bash(npm run test *)`, `Bash(go test *)`, `Bash(bash *)`, `Bash(mkdir -p *)`, `Bash(find *)`, `Bash(grep -r *)`, `Bash(aws *)`, `Bash(gh *)`, `Bash(git *)`
+
+Includes `aws`, `gh`, and `git` so the agent can inspect cloud state, query GitHub, and run git operations when validating cloud-native repairs.
+
 ## Error Handling
 
 - If no test suite exists: skips test validation; repair still succeeds if code is syntactically valid

--- a/metrics.csv
+++ b/metrics.csv
@@ -5,7 +5,7 @@ dark-factory:code-review:agents:code-review-orchestrator-agent,,158897.166666666
 dark-factory:documentation:agents:update-documentation-agent,,77188.0,314.875,8,617504.0,2519.0
 dark-factory:skill-update:agents:skill-update-agent,,65516.0,357.57142857142856,7,458612.0,2503.0
 dark-factory:pr:agents:pr-agent,,58958.92857142857,140.07142857142858,14,825425.0,1961.0
-dark-factory:repair:agents:repair-agent,,11915.857142857143,162.76190476190476,21,250233.0,3418.0
+dark-factory:repair:agents:repair-agent,,11374.227272727272,155.36363636363637,22,250233.0,3418.0
 testing-agent,,0.0,0.0,13,0.0,0.0
 planning-agent,,0.0,0.0,20,0.0,0.0
 dark-factory:featurework:agents:feature-agent,,96538.95238095238,576.5714285714286,21,2027318.0,12108.0

--- a/skills/declare-tools-in-agent-frontmatter/SKILL.md
+++ b/skills/declare-tools-in-agent-frontmatter/SKILL.md
@@ -34,3 +34,8 @@ Use this whenever you create or modify an agent file (any `agents/**/*.md`) that
   Without these entries, the agent will be blocked from running those git commands at runtime.
 - A regression test (`tests/test_push_notification_declared.py`) exists in this repo that parses the YAML front-matter of all agent files and asserts `PushNotification` is present in `tools:` for every agent that references it in its body. Run this test after modifying agent files to catch omissions early.
 - When adding a new skill invocation to an existing agent (e.g., adding `skills/logging/SKILL.md` to `implementation-agent.md`), always update the `skills:` field in the same edit — do not treat it as optional cleanup.
+- **Doer agents should have broad CLI access by default.** Agents that execute work (implementation-agent, testing-agent, debugger-agent, debug-flow-agent, ralph-fix-and-push, repair-agent) must include `aws`, `gh`, `git`, and `docker` in their `allowed-tools`. Restricting `allowed-tools` to only specific test runners (e.g., `pytest`, `npm test`) assumes a pure local project and silently degrades on cloud-native or infrastructure projects — the agent will not error; it will simply do the best it can with read-only tools and return a plausible-looking but incomplete or incorrect result. The canonical baseline for doer agents is:
+  ```yaml
+  allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(bash *), Bash(mkdir -p *), Bash(find *), Bash(grep -r *), Bash(aws *), Bash(gh *), Bash(git *), Bash(docker *), Bash(curl *)
+  ```
+  Orchestrator agents (those that only plan and delegate) do not need this expansion.


### PR DESCRIPTION
## Summary

Expanded `allowed-tools` on six doer agents (debugger-agent, repair-agent, implementation-agent, testing-agent, debug-flow-agent, and ralph-fix-and-push) to include `aws`, `gh`, `git`, `docker`, and `curl` CLI commands. Previously blocked commands caused silent fallback to read-only behavior with no warning, breaking cloud-native and infrastructure projects.

## Why

Doer agents that execute work should have broad CLI access by default. Restricting `allowed-tools` to only specific test runners (e.g., `pytest`, `npm test`) assumes a pure local project and silently degrades on cloud-native or infrastructure projects — the agent will not error; it will simply do the best it can with read-only tools and return a plausible-looking but incomplete or incorrect result.

## Changes

- **debugger-agent.md** — Added allowed Bash commands including `aws`, `gh`, `docker`, `curl` for fetching remote logs and querying cloud resources
- **repair-agent.md** — Added allowed Bash commands including `aws`, `gh`, `git` for validating cloud-native repairs
- **declare-tools-in-agent-frontmatter/SKILL.md** — Added canonical guidance for doer agents to include broad CLI access by default

## Validation

These changes expand the agent capabilities to handle cloud-native projects without silently degrading to read-only behavior.
