### PR TITLE
fix(manufacture): spawn orchestrator as sub-agent

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.51",
+  "version": "1.2.52",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/commands/manufacture.md
+++ b/commands/manufacture.md
@@ -1,5 +1,33 @@
 ---
 description: "Top-level dark-factory orchestrator. Preps an isolated work dir, routes to the right worker agent (feature/debug/fix-flow), runs code review and doc housekeeping, opens a PR, then removes the work dir."
+tools: Agent
 ---
 
-Follow the instructions in `${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/agents/dark-factory-agent.md` exactly.
+You are the manufacture command dispatcher. Your sole responsibility is to invoke the dark-factory-agent as a sub-agent and return its result.
+
+## Input
+
+You will receive:
+- `taskDescription` — verbatim user request (what to build, fix, or investigate)
+- `taskName` — (optional) short slug for the work dir (e.g. `add-oauth`, `fix-login-bug`)
+
+If `taskName` is not provided, you may omit it and let dark-factory-agent derive it from taskDescription.
+
+## Orchestration
+
+Invoke dark-factory-agent with the provided inputs:
+
+```
+result = invoke Agent({
+  agent: "dark-factory-agent",
+  prompt: "taskDescription: <taskDescription>\ntaskName: <taskName if provided, otherwise omit this line>"
+})
+
+return result
+```
+
+## Rules
+
+- Never implement orchestration logic yourself. All logic (classification, prep, routing, review, docs, PR, cleanup) is owned by dark-factory-agent.
+- Invoke dark-factory-agent exactly once and return its result immediately.
+- Do not modify, parse, or filter dark-factory-agent's output — pass it through unchanged.

--- a/docs/docs/manufacture-command.md
+++ b/docs/docs/manufacture-command.md
@@ -1,0 +1,61 @@
+# manufacture-command
+
+## Metadata
+
+- System type: `command`
+
+## System Intent
+
+- What this is: `commands/manufacture.md` is the Claude Code slash command entry point for `/dark-factory:manufacture`. It is a thin dispatcher — its sole responsibility is to invoke `dark-factory-agent` as a sub-agent via the Agent tool and return its result unchanged. It contains no orchestration logic.
+
+## Dispatch Mechanism
+
+`commands/manufacture.md` invokes `dark-factory-agent` via the Agent tool:
+
+```
+result = invoke Agent({
+  agent: "dark-factory-agent",
+  prompt: "taskDescription: <taskDescription>\ntaskName: <taskName if provided>"
+})
+
+return result
+```
+
+`commands/manufacture.md` declares `tools: Agent` in its frontmatter, which grants it the ability to spawn sub-agents. All orchestration logic (task classification, worktree prep, routing to worker agents, code review, documentation, PR, cleanup) is owned by `dark-factory-agent`. The manufacture command never inspects, modifies, or filters the result — it passes it through to the caller as-is.
+
+### Why sub-agent invocation
+
+Previous versions of `commands/manufacture.md` contained inline instructions (e.g., a relative path to `dark-factory-agent.md` or a direct `Follow the instructions in ...` directive). This caused Claude to attempt orchestration inline rather than delegating to the dedicated agent, leading to flow deviation. The Agent tool invocation enforces hard isolation: `dark-factory-agent` runs in its own sub-agent context with its own instruction set, preventing the manufacture command layer from interfering.
+
+## Flows
+
+### Flow: `manufacture-command.dispatch`
+
+- Core files: `commands/manufacture.md`, `agents/dark-factory/agents/dark-factory-agent.md`
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `manufacture-command.dispatch.success` | `taskDescription`, optional `taskName` | `dark-factory-agent` result (PR URL) | happy path | sub-agent runs to completion and returns |
+| `manufacture-command.dispatch.error` | `taskDescription` | error from sub-agent | error | `dark-factory-agent` returns an error or hard-stop; manufacture-command passes it through |
+
+#### Pseudocode
+
+```
+invoke Agent(agent="dark-factory-agent", prompt=<taskDescription + taskName>)
+return result as-is
+```
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| agent execution | Claude Code session transcript |
+| brain state | `$WORK_DIR/brain.json` (managed by dark-factory-agent) |
+
+## Deployment
+
+- Mechanism: `Claude Code slash command`
+- Invocation: `/dark-factory:manufacture`
+- Notes: Requires dark-factory plugin installed. The `tools: Agent` frontmatter directive must be present for Claude Code to allow sub-agent invocation from this command.

--- a/docs/docs/manufacture.md
+++ b/docs/docs/manufacture.md
@@ -59,7 +59,7 @@ flowchart TD
 
 - Core files: `commands/manufacture.md`, `agents/dark-factory/agents/dark-factory-agent.md`, `agents/featurework/agents/feature-agent.md`
 
-The `commands/manufacture.md` command uses `${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/agents/dark-factory-agent.md` (an absolute plugin-root-relative path) to locate the orchestrator instructions. This ensures the correct agent file is found when dark-factory is invoked from a nested Claude session where the working directory may not be the plugin root.
+`commands/manufacture.md` is a thin dispatcher. It invokes `dark-factory-agent` exactly once as a sub-agent via the Agent tool, passing `taskDescription` and optional `taskName`, then returns the result unchanged. All orchestration logic (classification, worktree prep, routing, code review, docs, PR, cleanup) lives entirely in `dark-factory-agent` — `commands/manufacture.md` contains none of it.
 
 The feature route is a single-invocation human-in-the-loop planning flow. `dark-factory-agent` invokes `feature-agent` exactly once and waits for a terminal status. `feature-agent` runs at depth 2 and calls `AskUserQuestion` directly for all user interaction — it handles all approval loops internally (draft → mermaid diagram → individual flows → final execution) before calling `execution-agent` to write the code. `dark-factory-agent` does not implement a multi-turn loop for the feature route; it receives one of three terminal statuses: `done`, `hard-stop`, or `aborted`.
 

--- a/metrics.csv
+++ b/metrics.csv
@@ -5,7 +5,7 @@ dark-factory:code-review:agents:code-review-orchestrator-agent,,119138.235294117
 dark-factory:documentation:agents:update-documentation-agent,,59854.333333333336,250.58333333333334,12,718252.0,3007.0
 dark-factory:skill-update:agents:skill-update-agent,,48341.90909090909,265.8181818181818,11,531761.0,2924.0
 dark-factory:pr:agents:pr-agent,,56624.125,165.75,16,905986.0,2652.0
-dark-factory:repair:agents:repair-agent,,12952.346153846154,175.53846153846155,26,336761.0,4564.0
+dark-factory:repair:agents:repair-agent,,12472.62962962963,169.03703703703704,27,336761.0,4564.0
 testing-agent,,0.0,0.0,13,0.0,0.0
 planning-agent,,0.0,0.0,20,0.0,0.0
 dark-factory:featurework:agents:feature-agent,,88144.26086956522,526.4347826086956,23,2027318.0,12108.0

--- a/skills/command-must-invoke-agent-by-name/SKILL.md
+++ b/skills/command-must-invoke-agent-by-name/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: command-must-invoke-agent-by-name
+description: "Plugin command files (commands/*.md) must invoke agents via the Agent tool by name, not by referencing an agent .md file path inline, because path-based references fail in nested Claude sessions where CWD is not the plugin root."
+user-invocable: false
+---
+## When to use
+
+Any time you create or modify a file in `commands/` that is meant to delegate to
+an agent. Also use when debugging a command that works when invoked directly but
+silently falls through or executes inline logic in a nested session.
+
+## Steps
+
+1. Open the command file (e.g., `commands/manufacture.md`).
+
+2. In the YAML frontmatter, declare `tools: Agent`:
+   ```markdown
+   ---
+   description: "Short description."
+   tools: Agent
+   ---
+   ```
+
+3. In the command body, invoke the target agent by its registered name using the
+   `Agent` tool:
+   ```
+   result = invoke Agent({
+     agent: "dark-factory-agent",
+     prompt: "<pass through user input verbatim>"
+   })
+   return result
+   ```
+
+4. Do NOT reference the agent's `.md` file path inline (e.g., `Follow the
+   instructions in agents/dark-factory/agents/dark-factory-agent.md exactly.`).
+   This style worked when the command was called from the plugin root as CWD, but
+   fails in nested sessions where CWD is different — Claude Code cannot resolve the
+   relative path and falls back to running orchestration logic inline, bypassing
+   the intended agent flow entirely.
+
+5. The command body should contain no orchestration logic itself. Its sole
+   responsibility is to pass inputs through to the named agent.
+
+## Notes
+
+- The failure mode for path-based references is silent: in a nested session the
+  agent is not invoked, but the command doesn't error. Instead, the current Claude
+  instance attempts to execute the instructions from memory or improvise, producing
+  unpredictable results.
+- Invoking by name (`agent: "dark-factory-agent"`) is CWD-independent — Claude
+  Code resolves the agent by its registered slug, not by filesystem path.
+- If the agent needs access to specific tools (e.g., `Bash`, `Read`), those must
+  be declared in the agent's own frontmatter `tools:` field, not in the command
+  file's frontmatter. The command file only needs `tools: Agent`.
+- This pattern is enforced by `tests/test_agent_flow_deviation_nested.py`, which
+  asserts that `commands/manufacture.md` uses `invoke Agent({ agent: "dark-factory-agent" ... })`.

--- a/tests/test_agent_flow_deviation_nested.py
+++ b/tests/test_agent_flow_deviation_nested.py
@@ -47,9 +47,9 @@ def _body(path: str) -> str:
 
 class TestManufactureCmdPath:
     """
-    agentFlowDeviationNestedSession — commands/manufacture.md must reference
-    dark-factory-agent.md via ${CLAUDE_PLUGIN_ROOT} so the path resolves correctly
-    regardless of the caller's CWD.
+    agentFlowDeviationNestedSession — commands/manufacture.md must invoke
+    dark-factory-agent as a sub-agent via the Agent tool, not via file path reference.
+    This prevents CWD-dependent resolution failures in nested sessions.
     """
 
     def test_manufacture_cmd_does_not_use_bare_relative_path(self):
@@ -63,10 +63,11 @@ class TestManufactureCmdPath:
         plugin install directory. A bare relative path then fails to resolve, and the caller
         falls back to invoking the subagent type directly, bypassing the normal dispatch flow.
 
-        The reference must use ${CLAUDE_PLUGIN_ROOT} to anchor the path to the plugin root.
+        The proper solution is to invoke dark-factory-agent as a sub-agent using the Agent
+        tool with agent: "dark-factory-agent", which doesn't depend on CWD-relative paths.
 
         If this test fails: commands/manufacture.md still uses a bare relative path for
-        dark-factory-agent.md — replace it with a ${CLAUDE_PLUGIN_ROOT}-anchored path.
+        dark-factory-agent.md — replace it with an Agent tool invocation.
         # Plan path: agentFlowDeviationNestedSession.manufacture-no-bare-relative-path
         """
         content = _full(MANUFACTURE_CMD_PATH)
@@ -79,30 +80,32 @@ class TestManufactureCmdPath:
             "commands/manufacture.md must NOT reference dark-factory-agent.md with a bare "
             "relative path ('agents/dark-factory/agents/dark-factory-agent.md'). "
             "When invoked from a nested Claude session, this path fails to resolve because "
-            "CWD is not the plugin root. Use ${CLAUDE_PLUGIN_ROOT} to anchor the path: "
-            "`${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/agents/dark-factory-agent.md`."
+            "CWD is not the plugin root. Use the Agent tool to invoke dark-factory-agent by name: "
+            "`invoke Agent({ agent: \"dark-factory-agent\", prompt: ... })`"
         )
 
-    def test_manufacture_cmd_uses_plugin_root_anchor(self):
+    def test_manufacture_cmd_uses_agent_tool(self):
         """
-        agentFlowDeviationNestedSession.manufacture-uses-plugin-root:
-        commands/manufacture.md must reference dark-factory-agent.md using
-        ${CLAUDE_PLUGIN_ROOT} so the path resolves regardless of CWD.
+        agentFlowDeviationNestedSession.manufacture-uses-agent-tool:
+        commands/manufacture.md must invoke dark-factory-agent as a sub-agent using the
+        Agent tool, rather than using a file path reference (which breaks in nested sessions).
 
-        If this test fails: commands/manufacture.md does not reference the plugin root,
-        meaning the path is vulnerable to CWD-dependent resolution failures.
-        # Plan path: agentFlowDeviationNestedSession.manufacture-uses-plugin-root
+        Using the Agent tool with agent: "dark-factory-agent" resolves the agent by name,
+        which is CWD-independent and works correctly in nested sessions.
+
+        If this test fails: commands/manufacture.md does not use the Agent tool to invoke
+        dark-factory-agent — update it to use invoke Agent({ agent: "dark-factory-agent" ... }).
+        # Plan path: agentFlowDeviationNestedSession.manufacture-uses-agent-tool
         """
         content = _full(MANUFACTURE_CMD_PATH)
-        uses_plugin_root = re.search(
-            r'\$\{CLAUDE_PLUGIN_ROOT\}.*dark-factory-agent\.md|'
-            r'dark-factory-agent\.md.*\$\{CLAUDE_PLUGIN_ROOT\}',
+        uses_agent_tool = re.search(
+            r'invoke\s+Agent\s*\(\s*\{\s*agent\s*:\s*["\']dark-factory-agent["\']',
             content,
         )
-        assert uses_plugin_root is not None, (
-            "commands/manufacture.md must reference dark-factory-agent.md using "
-            "${CLAUDE_PLUGIN_ROOT} to anchor the path to the plugin install root. "
-            "Example: `${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/agents/dark-factory-agent.md`."
+        assert uses_agent_tool is not None, (
+            "commands/manufacture.md must invoke dark-factory-agent as a sub-agent using "
+            "the Agent tool. This approach is CWD-independent and works in nested sessions. "
+            "Example: `invoke Agent({ agent: \"dark-factory-agent\", prompt: ... })`"
         )
 
 


### PR DESCRIPTION
## Summary

- Fix manufacture command to properly invoke dark-factory-agent as a sub-agent via the Agent tool, rather than attempting orchestration inline
- Document the dispatch mechanism in new manufacture-command system doc
- Add new skill pattern for command files that must invoke agents by name instead of by path (path-based references fail in nested Claude sessions)

## Changes

**commands/manufacture.md**: Converted from inline orchestration logic to a thin dispatcher that invokes `dark-factory-agent` as a sub-agent using the `Agent` tool. The command now:
- Declares `tools: Agent` in frontmatter
- Invokes dark-factory-agent by name (not by path)
- Passes taskDescription and optional taskName through
- Returns the sub-agent's result unchanged
- Contains zero orchestration logic

**docs/docs/manufacture.md**: Updated system documentation to reflect that manufacture.md is now a dispatcher, not an inline orchestrator

**docs/docs/manufacture-command.md** (new): Added comprehensive system documentation for the manufacture-command, including dispatch mechanism, flow paths, and deployment notes

**skills/command-must-invoke-agent-by-name/SKILL.md** (new): Documented the pattern of using the Agent tool to invoke agents by registered name instead of by file path. This prevents CWD-dependent failures in nested Claude sessions.

## Root Cause

Previous implementations used path-based references (e.g., `Follow the instructions in agents/dark-factory/agents/dark-factory-agent.md`) or absolute plugin-root-relative paths. These fail silently in nested sessions where the working directory is not the plugin root — Claude Code cannot resolve the relative path and falls back to executing orchestration logic inline, bypassing the intended agent delegation entirely.

## Solution

Using the `Agent` tool with agent-name-based invocation (`invoke Agent({ agent: "dark-factory-agent", prompt: ... })`) is CWD-independent. Claude Code resolves agents by their registered slug, not by filesystem path, making the dispatch mechanism robust across all invocation contexts.

## Test Plan

- Verify that `/dark-factory:manufacture` invokes dark-factory-agent as a sub-agent
- Verify that manufacture.md does not contain inline orchestration logic
- Verify that the test `tests/test_agent_flow_deviation_nested.py` passes (tests that manufacture.md uses the correct Agent invocation pattern)
- Verify that dark-factory operations (feature, debug, fix-flow routes) work correctly when invoked from the main dark-factory directory and from nested Claude sessions

