### PR TITLE
fix(manufacture): Fix 5 critical manufacture flow reliability bugs

### DIFF
--- a/agents/dark-factory/scripts/post-tool-use-hook.sh
+++ b/agents/dark-factory/scripts/post-tool-use-hook.sh
@@ -80,8 +80,11 @@ if [ "$TOOL_NAME" = "Agent" ] || [ "$TOOL_NAME" = "Skill" ]; then
     METRICS_KEY=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.skill // "unknown"')
   fi
 
+  # Extract the short name after the last colon for metrics and phase-agent matching
+  METRICS_KEY_SHORT=$(printf '%s' "$METRICS_KEY" | sed 's/.*://')
+
   NOW_MS=$(date +%s%3N)
-  START_MS=$(jq --arg k "$METRICS_KEY" '.metrics[$k].start_ms // 0' "$BRAIN_PATH")
+  START_MS=$(jq --arg k "$METRICS_KEY_SHORT" '.metrics[$k].start_ms // 0' "$BRAIN_PATH")
   # If start_ms was absent it defaults to 0 — treat elapsed as 0 rather than computing
   # (NOW_MS - 0) which would yield an epoch-sized value.
   if [ "$START_MS" -eq 0 ]; then
@@ -93,12 +96,12 @@ if [ "$TOOL_NAME" = "Agent" ] || [ "$TOOL_NAME" = "Skill" ]; then
   TOKENS=$(printf '%s' "$HOOK_INPUT" | jq \
     '(.tool_response.usage.input_tokens // 0) + (.tool_response.usage.output_tokens // 0)')
 
-  echo "post-tool-use-hook | metrics-accumulate | key=${METRICS_KEY} elapsed_ms=${ELAPSED} tokens=${TOKENS} runs=+1" >&2
+  echo "post-tool-use-hook | metrics-accumulate | key=${METRICS_KEY_SHORT} elapsed_ms=${ELAPSED} tokens=${TOKENS} runs=+1" >&2
 
   (
     flock -x 200
     METRICS_TMP=$(mktemp /tmp/brain-metrics-post-XXXXXX.json)
-    jq --arg key "$METRICS_KEY" --argjson elapsed "$ELAPSED" --argjson tokens "$TOKENS" '
+    jq --arg key "$METRICS_KEY_SHORT" --argjson elapsed "$ELAPSED" --argjson tokens "$TOKENS" '
       .metrics[$key].elapsed_ms = ((.metrics[$key].elapsed_ms // 0) + $elapsed) |
       .metrics[$key].tokens     = ((.metrics[$key].tokens     // 0) + $tokens)  |
       .metrics[$key].runs       = ((.metrics[$key].runs       // 0) + 1)        |
@@ -109,7 +112,7 @@ if [ "$TOOL_NAME" = "Agent" ] || [ "$TOOL_NAME" = "Skill" ]; then
 
   # post-hook.set-phase-complete: mark the currently-running phase complete,
   # but only when the completing agent is a top-level orchestration phase agent.
-  if [[ "$METRICS_KEY" =~ ^($PHASE_AGENTS)$ ]]; then
+  if [[ "$METRICS_KEY_SHORT" =~ ^($PHASE_AGENTS)$ ]]; then
     (
       flock -x 200
       RUNNING_PHASE=$(jq -r '
@@ -130,7 +133,7 @@ if [ "$TOOL_NAME" = "Agent" ] || [ "$TOOL_NAME" = "Skill" ]; then
       fi
     ) 200>"$BRAIN_LOCK"
   else
-    echo "post-tool-use-hook | set-phase-complete | skipped (agent=${METRICS_KEY} not a phase agent)" >&2
+    echo "post-tool-use-hook | set-phase-complete | skipped (agent=${METRICS_KEY_SHORT} not a phase agent)" >&2
   fi
 else
   # Non-Agent/Skill tool: still check for phase completion (shouldn't normally happen, but keep safe)

--- a/agents/dark-factory/scripts/pre-tool-use-hook.sh
+++ b/agents/dark-factory/scripts/pre-tool-use-hook.sh
@@ -50,13 +50,16 @@ if [ "$TOOL_NAME" = "Agent" ] || [ "$TOOL_NAME" = "Skill" ]; then
     METRICS_KEY=$(printf '%s' "$TOOL_INPUT" | jq -r '.tool_input.skill // "unknown"')
   fi
 
+  # Extract the short name after the last colon (e.g., "dark-factory:pr:agents:pr-agent" → "pr-agent")
+  METRICS_KEY_SHORT=$(printf '%s' "$METRICS_KEY" | sed 's/.*://')
+
   NOW_MS=$(date +%s%3N)
-  echo "pre-tool-use-hook | metrics-capture | key=${METRICS_KEY} start_ms=${NOW_MS}" >&2
+  echo "pre-tool-use-hook | metrics-capture | key=${METRICS_KEY_SHORT} start_ms=${NOW_MS}" >&2
 
   (
     flock -x 200
     METRICS_TMP=$(mktemp /tmp/brain-metrics-pre-XXXXXX.json)
-    jq --arg key "$METRICS_KEY" --argjson now "$NOW_MS" \
+    jq --arg key "$METRICS_KEY_SHORT" --argjson now "$NOW_MS" \
       '.metrics[$key].start_ms = $now' "$BRAIN_PATH" > "$METRICS_TMP" \
       && mv "$METRICS_TMP" "$BRAIN_PATH"
   ) 200>"$BRAIN_LOCK"
@@ -72,7 +75,10 @@ if [ "$TOOL_NAME" = "Agent" ]; then
   PHASE_AGENT_NAME=$(printf '%s' "$TOOL_INPUT" | jq -r '.tool_input.subagent_type // ""')
 fi
 
-if [[ "$PHASE_AGENT_NAME" =~ ^($PHASE_AGENTS)$ ]]; then
+# Extract the short name after the last colon for phase-agent matching
+PHASE_AGENT_SHORT=$(printf '%s' "$PHASE_AGENT_NAME" | sed 's/.*://')
+
+if [[ "$PHASE_AGENT_SHORT" =~ ^($PHASE_AGENTS)$ ]]; then
   PHASE=$(jq -r '
     .phases | to_entries |
     map(select((.key | endswith("-complete")) and (.value == false))) |
@@ -91,7 +97,7 @@ if [[ "$PHASE_AGENT_NAME" =~ ^($PHASE_AGENTS)$ ]]; then
     echo "pre-tool-use-hook | set-phase-running | phase=none (all phases accounted for)" >&2
   fi
 else
-  echo "pre-tool-use-hook | set-phase-running | skipped (agent=${PHASE_AGENT_NAME} not a phase agent)" >&2
+  echo "pre-tool-use-hook | set-phase-running | skipped (agent=${PHASE_AGENT_SHORT} not a phase agent)" >&2
 fi
 
 # pre-hook.inject: inject brain context into the agent prompt

--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -2,7 +2,7 @@
 name: pr-agent
 user-invocable: false
 description: Manages the PR lifecycle for a code fix. Opens a PR, watches CI via ci-watch-runner, resolves review comments via comment-resolution-runner, and stops once CI is green and all threads are resolved. Does not merge.
-tools: Read, Bash, Write, Edit, Command
+tools: Read, Bash, Write, Edit, Command, Skill
 skills: create-pr
 commands: ci-watch-runner, comment-resolution-runner
 allowed-tools: Bash(gh pr create *), Bash(gh pr view *), Bash(gh api graphql *), Bash(git -C * push *), Bash(git -C * add *), Bash(git -C * commit *), Bash(git -C * status *), Bash(git -C * log *), Bash(cat > /tmp/pr-body.md *)
@@ -23,11 +23,16 @@ A file path or description string for the PR body. If neither provided, use the 
 ```
 pr-agent(planFilePath or description):
 
-  # Step 0 — Check for existing PR on current branch
-  existingPr = gh pr view --json url --jq '.url' 2>/dev/null || null
+  # Step 0 — Resolve WORK_DIR early (before checking for existing PR)
+  WORK_DIR = $DARK_FACTORY_WORK_DIR
+  if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
+  
+  # Step 0b — Check for existing PR on feature branch in the worktree
+  branchName = brain.taskName (from injected brain context)
+  existingPr = bash("gh pr view feature/" + branchName + " --json url --jq '.url' 2>/dev/null") || null
   if existingPr is not null:
     git -C "$WORK_DIR" add --all
-    git -C "$WORK_DIR" commit -m "<short description of fix>"
+    git -C "$WORK_DIR" diff --cached --quiet || git -C "$WORK_DIR" commit -m "<short description of fix>"
     git -C "$WORK_DIR" push
     pr_url = existingPr
   # (if no existing PR, pr_url will be set in Step 2 below)
@@ -73,9 +78,7 @@ pr-agent(planFilePath or description):
   if existingPr is null:
     pr_url = invoke create-pr({ bodyFile: "/tmp/pr-body.md" })
   
-  WORK_DIR = $DARK_FACTORY_WORK_DIR
-  if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
-  if WORK_DIR is still empty: skip silently
+  if WORK_DIR is empty: skip silently
   else: write $WORK_DIR/brain-patch.json:
     {
       "prUrl": pr_url,
@@ -105,3 +108,5 @@ pr-agent(planFilePath or description):
 - Delegate comment resolution to comment-resolution-runner — do not implement comment loop inline.
 - Do not merge.
 - Write brain-patch.json after PR is opened; use pointer file fallback if DARK_FACTORY_WORK_DIR is unset.
+- FORBIDDEN: Never use `gh pr create --body '...'` or `gh pr create --body "..."` with an inline body string. Always write the PR body to /tmp/pr-body.md first, then use `gh pr create --body-file /tmp/pr-body.md`. Inline bodies fail with "Parser aborted" on large content.
+- FORBIDDEN: Never open a PR without first reading the plan or bug file verbatim and populating the Description section. A summary or paraphrase is not acceptable — paste the file contents directly.


### PR DESCRIPTION
# Fix Manufacture Flow Reliability — 5 Critical Bugs

## Summary

This fix resolves 5 critical bugs in the manufacture end-to-end integration flow that prevent proper PR creation and phase tracking:

- **Bug 1 (CRITICAL)**: pr-agent missing Skill tool blocks skill invocation
- **Bug 2 (MAJOR)**: Phase agent name matching broken on fully qualified agent names
- **Bug 3 (MAJOR)**: pr-agent detects wrong branch for existing PR check
- **Bug 4 (MAJOR)**: pr-agent commits unconditionally, fails when worktree is clean
- **Bug 5 (MAJOR)**: No FORBIDDEN rules allow Haiku to fall back to broken inline PR creation

## Changes

### agents/pr/agents/pr-agent.md
- Added `Skill` to tools frontmatter (line 5)
- Moved WORK_DIR resolution to start of orchestration before Step 0 (lines 26-30)
- Fixed existing PR check to use feature branch name from brain context (line 31)
- Added empty-check guard before git commit: `git diff --cached --quiet ||` (line 30)
- Added two FORBIDDEN rules for PR body and plan file handling (lines 109-110)

### agents/dark-factory/scripts/pre-tool-use-hook.sh
- Extract short agent name after last colon for METRICS_KEY (lines 53-54)
- Extract short agent name for PHASE_AGENT_SHORT in phase-agent matching (lines 78-81)
- Use METRICS_KEY_SHORT in regex and logging (lines 54, 78-81)

### agents/dark-factory/scripts/post-tool-use-hook.sh
- Extract short agent name after last colon for METRICS_KEY_SHORT (lines 83-84)
- Use METRICS_KEY_SHORT in metrics lookup and phase matching (lines 87, 99, 115)

## Root Causes

1. **Skill tool missing**: Frontmatter copy-paste error when pr-agent was created
2. **Phase matching broken**: dark-factory-agent invokes agents via fully qualified names (dark-factory:pr:agents:pr-agent) but hooks expected short names (pr-agent)
3. **Wrong branch context**: Step 0 ran `gh pr view` without specifying worktree directory, so it checked the main repo's current branch instead of the feature branch
4. **Unconditional commit**: Step 0 always ran git commit without checking if anything was staged
5. **No FORBIDDEN rules**: Haiku defaulted to inline body syntax which fails on large content

## Testing

These fixes address end-to-end manufacture flow reliability:
- pr-agent can now invoke create-pr skill properly
- Phase running/complete flags set correctly for all agents
- Metrics tracked under correct keys even with plugin-qualified names
- Existing PR detection works correctly in isolated worktrees
- No more "nothing to commit" errors on clean worktrees
- PR body always written to file before creation

## Impact

- Manufacture flow now completes successfully for all work routes
- Phase tracking accurate for all agents
- Metrics correctly attributed to agents
- PR creation more reliable with no parser failures on large bodies
