### PR TITLE
refactor: rename invoke-investigation-agent skill to investigation-delegate

### DIFF
--- a/agents/debugger/agents/debugger-agent.md
+++ b/agents/debugger/agents/debugger-agent.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Runs systematic debugging on a non-obvious bug by following the debug skill checklist step by step.
 tools: Read, Write, Edit, Bash, Glob, Agent, Skill
 model: sonnet
-skills: systematic-debugging, invoke-investigation-agent
+skills: systematic-debugging, investigation-delegate
 allowed-tools: Bash(bash *), Bash(pytest *), Bash(python *), Bash(npm test *), Bash(grep -r *), Bash(find *), Bash(aws *), Bash(gh *), Bash(docker *), Bash(curl *)
 SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
 ---

--- a/agents/repair/agents/repair-agent.md
+++ b/agents/repair/agents/repair-agent.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Lightweight repair agent. Applies a targeted change from a plain task description (no plan file), runs the test suite, and iteratively fixes failures up to 5 times.
 tools: Read, Write, Edit, Bash, Glob, Agent, Skill
 model: haiku
-skills: invoke-investigation-agent
+skills: investigation-delegate
 allowed-tools: Bash(pytest *), Bash(python *), Bash(npm test *), Bash(npm run test *), Bash(go test *), Bash(bash *), Bash(mkdir -p *), Bash(find *), Bash(grep -r *), Bash(aws *), Bash(gh *), Bash(git *)
 SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
 ---

--- a/docs/plans/2026-04-27-investigation-agent-integration.md
+++ b/docs/plans/2026-04-27-investigation-agent-integration.md
@@ -142,7 +142,7 @@ Rather than editing all agent files individually, the plan uses the CLAUDE.md ap
 
 3. **Optional: Create an investigation-agent-call skill** (if agents cannot directly invoke sub-agents):
    - Wraps the investigation-agent invocation with standard error handling
-   - Provides a convenient interface: `@invoke-investigation-agent(system="...", question="...")`
+   - Provides a convenient interface: `@investigation-delegate(system="...", question="...")`
    - Agents reference this skill in their CLAUDE.md guidance
 
 ## Logs

--- a/skills/investigation-delegate/SKILL.md
+++ b/skills/investigation-delegate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: invoke-investigation-agent
+name: investigation-delegate
 description: "Use this skill when an agent needs to understand how a system or component works before proceeding — delegate that research to investigation-agent rather than doing it inline."
 user-invocable: false
 ---


### PR DESCRIPTION
## Summary

Renames the `invoke-investigation-agent` skill to `investigation-delegate` to fix naming confusion with the `investigation-agent` agent.

**Problem**: Haiku agents reading their own instructions see:
- A loaded skill named `invoke-investigation-agent`
- An instruction saying `invoke investigation-agent(...)`

These nearly identical names cause confusion — Haiku might use the Skill tool instead of spawning the sub-agent.

**Solution**: Rename skill to `investigation-delegate`, making it clearly different from the agent name.

## Changes

- Renamed `skills/invoke-investigation-agent/` → `skills/investigation-delegate/`
- Updated `name:` field in SKILL.md
- Updated skill declarations in repair-agent.md and debugger-agent.md
- Updated reference in investigation-agent-integration plan

## Testing

- All 256 existing passing tests still pass
- No new test failures introduced
- Verified all references updated (0 remaining references to old name)