### PR TITLE
fix(dark-factory-agent): add F7 and F8 guards for feature-agent

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -81,6 +81,12 @@ dark-factory-agent(taskDescription, taskName):
   # Invoke feature-agent once and wait for status: done/hard-stop/aborted.
   Route based on classification:
     - "feature" → result = invoke feature-agent({ taskDescription })
+        # Validate result is JSON with status field before inspecting status
+        if result is not a JSON object or result.status is undefined:
+          run cleanup(WORK_DIR, taskName)
+          report "feature-agent returned unstructured output — expected JSON with status field."
+          STOP
+
         if result.status == "done":
           # feature-agent finished all phases including execution — continue to Step 5
         if result.status == "hard-stop":
@@ -190,4 +196,5 @@ bash("\"$PLUGIN_ROOT/agents/dark-factory/scripts/cleanup-worktree.sh\" \"$WORK_D
 - FORBIDDEN: Never write brain.json directly using cat, echo, Bash, or any tool. Always use brain-state-manager skill. Direct writes corrupt state and will break downstream agents.
 - FORBIDDEN: Never invoke sub-planning-agent directly. Always route through feature-agent. Feature-agent calls AskUserQuestion directly for all user interaction — dark-factory-agent must NOT implement a multi-turn loop for feature-agent responses. Invoke feature-agent once and wait for status: done/hard-stop/aborted.
 - FORBIDDEN: Never use `${CLAUDE_PLUGIN_ROOT}` inside Bash tool call pseudocode — it is empty in Bash tool call subprocesses. Always resolve plugin root via `installed_plugins.json` using explicit plugin name lookup (e.g., `d['plugins'].get('dark-factory@dark-factory')`) to handle multiple installed plugins correctly.
+- FORBIDDEN: Never re-invoke feature-agent after it has been called once. If the user responds to an AskUserQuestion during the feature-agent session, that response is handled internally by feature-agent — do NOT spawn a new feature-agent or re-invoke the manufacture command in response to user answers during an active feature-agent session.
 - FORBIDDEN: Never merge a PR manually or instruct any sub-agent to merge. pr-agent returns status:ready but does not merge. Merging is the developer's responsibility after review.

--- a/metrics.csv
+++ b/metrics.csv
@@ -1,10 +1,10 @@
 agent,skill,avg_runtime,avg_tokens,runs,sum_runtime,sum_tokens
 dark-factory:featurework:planning:agents:planning-agent,,31902.666666666668,1155.0,3,95708.0,3465.0
 dark-factory:featurework:execution:agents:execution-agent,,78434.0,603.4,5,392170.0,3017.0
-dark-factory:code-review:agents:code-review-orchestrator-agent,,109013.78947368421,588.0526315789474,19,2071262.0,11173.0
-dark-factory:documentation:agents:update-documentation-agent,,56605.21428571428,234.78571428571428,14,792473.0,3287.0
-dark-factory:skill-update:agents:skill-update-agent,,41090.92307692308,243.07692307692307,13,534182.0,3160.0
-dark-factory:pr:agents:pr-agent,,53293.294117647056,156.0,17,905986.0,2652.0
+dark-factory:code-review:agents:code-review-orchestrator-agent,,100817.80952380953,583.6190476190476,21,2117174.0,12256.0
+dark-factory:documentation:agents:update-documentation-agent,,54168.375,222.9375,16,866694.0,3567.0
+dark-factory:skill-update:agents:skill-update-agent,,35773.53333333333,226.4,15,536603.0,3396.0
+dark-factory:pr:agents:pr-agent,,50332.555555555555,147.33333333333334,18,905986.0,2652.0
 dark-factory:repair:agents:repair-agent,,12472.62962962963,169.03703703703704,27,336761.0,4564.0
 testing-agent,,0.0,0.0,13,0.0,0.0
 planning-agent,,0.0,0.0,20,0.0,0.0


### PR DESCRIPTION
## Summary

Adds two critical guards to the dark-factory-agent orchestration spec to prevent recurring issues:

- **F7**: Adds FORBIDDEN rule preventing re-invocation of feature-agent after initial call
- **F8**: Adds explicit JSON validation of feature-agent result before status inspection

## Changes

- Added F7 rule: "Never re-invoke feature-agent after it has been called once" to Rules section
- Added F8 validation: Check that result is JSON object with status field before handling status codes

## Test plan

- [x] File syntax verified (YAML frontmatter + pseudocode intact)
- [x] Both rules added to correct sections (Rules and Step 4)
- [x] Changes guard against known orchestration failures

---

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
