### PR TITLE
fix: improve branch-drift guard diagnostics

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -114,8 +114,11 @@ dark-factory-agent(taskDescription, taskName):
   # Step 5 — branch-drift guard
   driftCheck = bash("git -C \"$WORK_DIR\" log main..feature/" + taskName + " --oneline")
   if driftCheck is empty:
+    # Collect diagnostic information before cleanup
+    worktreeLog = bash("git -C \"$WORK_DIR\" log --oneline -5")
+    worktreeStatus = bash("git -C \"$WORK_DIR\" status")
     run cleanup(WORK_DIR, taskName)
-    report error: "Branch-drift guard failed: feature/" + taskName + " has no commits ahead of main."
+    report error: "Branch-drift guard failed: feature/" + taskName + " has no commits ahead of main.\nWorktree log (last 5):\n" + worktreeLog + "\nWorktree status:\n" + worktreeStatus
     STOP
 
   # Step 6 — read planFilePath from brain.json

--- a/metrics.csv
+++ b/metrics.csv
@@ -1,10 +1,10 @@
 agent,skill,avg_runtime,avg_tokens,runs,sum_runtime,sum_tokens
 dark-factory:featurework:planning:agents:planning-agent,,31902.666666666668,1155.0,3,95708.0,3465.0
 dark-factory:featurework:execution:agents:execution-agent,,78434.0,603.4,5,392170.0,3017.0
-dark-factory:code-review:agents:code-review-orchestrator-agent,,100817.80952380953,583.6190476190476,21,2117174.0,12256.0
-dark-factory:documentation:agents:update-documentation-agent,,54168.375,222.9375,16,866694.0,3567.0
-dark-factory:skill-update:agents:skill-update-agent,,35773.53333333333,226.4,15,536603.0,3396.0
-dark-factory:pr:agents:pr-agent,,50332.555555555555,147.33333333333334,18,905986.0,2652.0
+dark-factory:code-review:agents:code-review-orchestrator-agent,,94047.21739130435,579.9565217391304,23,2163086.0,13339.0
+dark-factory:documentation:agents:update-documentation-agent,,52273.055555555555,213.72222222222223,18,940915.0,3847.0
+dark-factory:skill-update:agents:skill-update-agent,,31707.29411764706,213.64705882352942,17,539024.0,3632.0
+dark-factory:pr:agents:pr-agent,,47683.47368421053,139.57894736842104,19,905986.0,2652.0
 dark-factory:repair:agents:repair-agent,,12472.62962962963,169.03703703703704,27,336761.0,4564.0
 testing-agent,,0.0,0.0,13,0.0,0.0
 planning-agent,,0.0,0.0,20,0.0,0.0


### PR DESCRIPTION
## Summary

Improves diagnostics in the branch-drift guard step (Step 5 of dark-factory-agent) when it detects that a feature branch has no commits ahead of main.

Previously, the error message was generic and provided no actionable information about why commits were missing. Now the error includes:

1. Last 5 commits in the worktree (`git log --oneline -5`) — detects if commits landed somewhere else
2. Current worktree status (`git status`) — shows if uncommitted changes were left behind

This makes it immediately clear whether: (a) the worker never committed anything, (b) there are uncommitted changes left behind, or (c) commits landed on the wrong branch.

## Changes

- **agents/dark-factory/agents/dark-factory-agent.md** — Step 5: Added two diagnostic bash commands before the cleanup and error report. Updated error message to include the diagnostic output.

## Testing

This fix improves error reporting when branch-drift guard fails. The improvement is self-documenting in the agent instruction file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)