### PR TITLE
fix(dark-factory-agent): add post-worker brain-patch validation

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -125,6 +125,9 @@ dark-factory-agent(taskDescription, taskName):
   brain = invoke brain-state-manager({ operation: "read", workDir: WORK_DIR })
   planFilePath = brain.planFilePath
 
+  if planFilePath is null AND classification == "feature":
+    warn "WARNING: feature-agent returned status:done but planFilePath is missing from brain.json. brain-patch.json may not have been written. Downstream agents will use taskDescription as fallback — PR body and code review context may be lower quality."
+
   # Step 7 — code review
   invoke code-review-orchestrator-agent({
     planFilePath: planFilePath ?? "Task: " + taskDescription,

--- a/docs/docs/dark-factory-agent.md
+++ b/docs/docs/dark-factory-agent.md
@@ -70,9 +70,12 @@ If non-feature worker returns error or hard-stop: runs cleanup, reports error, S
 - Bash: `git -C "$WORK_DIR" log main..feature/<taskName> --oneline`
 - Halts with error if no new commits found (cleanup runs first)
 
-### Step 6: Read Plan File Path
+### Step 6: Read Plan File Path and Validate Brain State
 - Delegates to `brain-state-manager` with `operation: "read"`
 - Extracts `planFilePath` from brain.json (may be null for debugger/repair routes)
+- **Validation**: If `planFilePath` is null AND classification is "feature", logs warning:
+  - feature-agent always writes planFilePath on success, so null indicates brain-patch.json write failure
+  - Warning alerts developer before proceeding to downstream agents with degraded context
 
 ### Step 7: Code Review
 - Invokes `code-review-orchestrator-agent` with:

--- a/metrics.csv
+++ b/metrics.csv
@@ -1,10 +1,10 @@
 agent,skill,avg_runtime,avg_tokens,runs,sum_runtime,sum_tokens
 dark-factory:featurework:planning:agents:planning-agent,,31902.666666666668,1155.0,3,95708.0,3465.0
 dark-factory:featurework:execution:agents:execution-agent,,78434.0,603.4,5,392170.0,3017.0
-dark-factory:code-review:agents:code-review-orchestrator-agent,,94047.21739130435,579.9565217391304,23,2163086.0,13339.0
-dark-factory:documentation:agents:update-documentation-agent,,52273.055555555555,213.72222222222223,18,940915.0,3847.0
-dark-factory:skill-update:agents:skill-update-agent,,31707.29411764706,213.64705882352942,17,539024.0,3632.0
-dark-factory:pr:agents:pr-agent,,47683.47368421053,139.57894736842104,19,905986.0,2652.0
+dark-factory:code-review:agents:code-review-orchestrator-agent,,88359.92,576.88,25,2208998.0,14422.0
+dark-factory:documentation:agents:update-documentation-agent,,50756.8,206.35,20,1015136.0,4127.0
+dark-factory:skill-update:agents:skill-update-agent,,28497.105263157893,203.57894736842104,19,541445.0,3868.0
+dark-factory:pr:agents:pr-agent,,45299.3,132.6,20,905986.0,2652.0
 dark-factory:repair:agents:repair-agent,,12472.62962962963,169.03703703703704,27,336761.0,4564.0
 testing-agent,,0.0,0.0,13,0.0,0.0
 planning-agent,,0.0,0.0,20,0.0,0.0


### PR DESCRIPTION
## Summary

Adds explicit validation in Step 6 of dark-factory-agent to detect when feature-agent completes successfully but fails to write brain-patch.json to brain.json.

**Problem**: After feature-agent returns status:done, dark-factory-agent reads planFilePath from brain.json. If the worker exited early and never wrote brain-patch.json, planFilePath will be null. The agent silently falls back to using taskDescription as the plan reference, with no warning that something went wrong.

**Fix**: Add a validation warning that logs when planFilePath is null AND classification == "feature". Since feature-agent always writes planFilePath on success, null indicates a brain-patch write failure. This makes the silent fallback visible so developers know the brain-patch write failed rather than wondering why downstream agents have lower-quality context.

## Changes

1. **agents/dark-factory/agents/dark-factory-agent.md** (Step 6)
   - Added validation check after reading planFilePath
   - Warns explicitly when feature-agent returns success but brain-patch.json write failed
   
2. **docs/docs/dark-factory-agent.md** (Step 6 documentation)
   - Updated documentation to explain the validation behavior
   - Notes that null planFilePath for feature classification indicates brain-patch failure

## Test Plan

- Run dark-factory-agent on a feature task where feature-agent might exit early
- Verify warning appears in logs when planFilePath is null AND classification == "feature"
- Verify downstream agents (code-review, docs, PR) still function with taskDescription fallback
- Verify warning does NOT appear for fix-flow/debugger/repair routes (they can have null planFilePath)

🤖 Generated with Claude Code