### PR TITLE
fix(code-review): detect unresolvable issues early

### DIFF
--- a/agents/code-review/agents/code-review-orchestrator-agent.md
+++ b/agents/code-review/agents/code-review-orchestrator-agent.md
@@ -41,12 +41,19 @@ StandardError {
    - `agents/code-review/agents/low-level-review-agent.md` with input `codePath`
 3. Wait for both to complete.
    - If either returns an error: surface the error and halt. Do not start the resolver.
-4. Enter the resolver loop:
-   - Spawn `agents/code-review/agents/resolver-agent.md` with `issuesFilePath` set to the absolute path of `<codePath>/issues.md`.
-   - Wait for it to return.
-   - If it returns an error: surface the error and halt.
-   - If `anyRemaining` is false: exit the loop.
-   - If `anyRemaining` is true: re-enter the loop (re-spawn the resolver).
+4. Enter the resolver loop (up to 10 iterations):
+   - Initialize `noProgressCount = 0`.
+   - For each iteration:
+     - Read the current issues.md file and count the number of unresolved issues. Store this as `issueCountBefore`.
+     - Spawn `agents/code-review/agents/resolver-agent.md` with `issuesFilePath` set to the absolute path of `<codePath>/issues.md`.
+     - Wait for it to return.
+     - If it returns an error: surface the error and halt.
+     - Read the updated issues.md file and count the number of unresolved issues. Store this as `issueCountAfter`.
+     - If `issueCountAfter < issueCountBefore`: reset `noProgressCount = 0` (progress was made).
+     - If `issueCountAfter >= issueCountBefore`: increment `noProgressCount += 1` (no progress).
+     - If `noProgressCount >= 2`: exit the loop early and return a `StandardError` with message: "Code review resolver is stuck — issue count unchanged for 2 consecutive iterations. Unresolvable issues likely require human review: [list the remaining unresolved issues here]."
+     - If `anyRemaining` is false: exit the loop (all issues resolved).
+     - If `anyRemaining` is true and `noProgressCount < 2`: continue to next iteration.
 5. Use `manage-issues-file` command with `operation: "delete"` to remove the issues file.
 6. Return `{ status: "complete" }`.
 


### PR DESCRIPTION
## Summary

Added early detection for unresolvable issues in the code review resolver loop.

## Problem

The resolver loop runs up to 10 iterations, burning all of them even when issues are genuinely unresolvable (requiring human judgment or architectural changes). This wastes iterations and provides no actionable feedback to the developer.

## Solution

Implemented consecutive-no-progress detection mechanism:
1. Track issue count at the start of each iteration
2. After resolver runs, compare counts
3. If no progress (count unchanged), increment noProgressCount
4. If noProgressCount >= 2, exit early with actionable error listing stuck issues

## Changed File

- `agents/code-review/agents/code-review-orchestrator-agent.md` — Updated resolver loop task specification to include progress tracking and early exit logic

## Testing

No new tests needed — this is a task specification update for an orchestrator agent (no executable code changes). Existing tests continue to pass.

🤖 Generated with Claude Code
