### PR TITLE
fix(dark-factory-agent): add post-docs validation for leaked docs

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -141,6 +141,11 @@ dark-factory-agent(taskDescription, taskName):
   # Step 8 — update docs (must complete before PR)
   invoke update-documentation-agent({ planFilePath, workDir: WORK_DIR })
 
+  # Step 8 post-check: ensure docs were not written to main repo working tree
+  leakedDocs = bash("git -C \"$PROJECT_DIR\" status --porcelain docs/ 2>/dev/null | head -5")
+  if leakedDocs is not empty:
+    warn "WARNING: update-documentation-agent may have written docs to the main repo working tree instead of the worktree. Leaked files: " + leakedDocs + ". These will NOT appear in the PR. Run 'git -C \"$PROJECT_DIR\" checkout docs/' to discard them."
+
   # Step 9 — skill update (non-fatal)
   try:
     invoke skill-update-agent({ planFilePath, workDir: WORK_DIR, taskSummary: taskDescription })


### PR DESCRIPTION
## Summary

Add post-check validation in Step 8 of dark-factory-agent to detect when update-documentation-agent writes to the main repo working tree instead of the isolated worktree.

## Problem

Currently, if update-documentation-agent ignores the `workDir` parameter and writes to the main repo instead, the doc files appear as uncommitted changes in the main working tree but don't make it into the PR. There's no detection of this leak, so the issue goes unnoticed.

## Solution

After Step 8 (update-documentation-agent invocation), add a bash check that:
1. Runs `git status` on the main repo's `docs/` directory
2. Detects uncommitted doc changes that shouldn't be there
3. Displays a clear warning with remediation instructions

This surfaces the issue immediately so the developer can:
- Recognize the docs leaked to the main repo
- Discard them with `git checkout docs/`
- Investigate why update-documentation-agent behaved incorrectly

## Test Plan

- Review the new validation code added in Step 8
- Verify the bash command syntax is correct
- Confirm the warning message is helpful and actionable

Generated with Claude Code