### PR TITLE
fix(dark-factory-agent): add brain.json verification in Step 3

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -77,6 +77,13 @@ dark-factory-agent(taskDescription, taskName):
 
   If brain-state-manager errors: report error and STOP
 
+  # Verify brain.json was actually written to disk
+  brainExists = bash("test -f \"$WORK_DIR/brain.json\" && echo 'ok' || echo 'missing'")
+  if brainExists != "ok":
+    bash("\"$PLUGIN_ROOT/agents/dark-factory/scripts/cleanup-worktree.sh\" \"$WORK_DIR\" \"$taskName\"")
+    report error: "brain.json not found at $WORK_DIR/brain.json after brain-state-manager completed. Check WORK_DIR permissions and disk space. Worktree cleaned up."
+    STOP
+
   # Write pointer file so hook processes can resolve WORK_DIR without the env var
   bash("printf '%s' \"$WORK_DIR\" > /tmp/dark-factory-work-dir")
 

--- a/metrics.csv
+++ b/metrics.csv
@@ -1,10 +1,10 @@
 agent,skill,avg_runtime,avg_tokens,runs,sum_runtime,sum_tokens
 dark-factory:featurework:planning:agents:planning-agent,,31902.666666666668,1155.0,3,95708.0,3465.0
 dark-factory:featurework:execution:agents:execution-agent,,78434.0,603.4,5,392170.0,3017.0
-dark-factory:code-review:agents:code-review-orchestrator-agent,,88359.92,576.88,25,2208998.0,14422.0
-dark-factory:documentation:agents:update-documentation-agent,,50756.8,206.35,20,1015136.0,4127.0
-dark-factory:skill-update:agents:skill-update-agent,,28497.105263157893,203.57894736842104,19,541445.0,3868.0
-dark-factory:pr:agents:pr-agent,,45299.3,132.6,20,905986.0,2652.0
+dark-factory:code-review:agents:code-review-orchestrator-agent,,83515.18518518518,574.2592592592592,27,2254910.0,15505.0
+dark-factory:documentation:agents:update-documentation-agent,,49516.22727272727,200.3181818181818,22,1089357.0,4407.0
+dark-factory:skill-update:agents:skill-update-agent,,25898.380952380954,195.42857142857142,21,543866.0,4104.0
+dark-factory:pr:agents:pr-agent,,43142.19047619047,126.28571428571429,21,905986.0,2652.0
 dark-factory:repair:agents:repair-agent,,12472.62962962963,169.03703703703704,27,336761.0,4564.0
 testing-agent,,0.0,0.0,13,0.0,0.0
 planning-agent,,0.0,0.0,20,0.0,0.0
@@ -20,3 +20,4 @@ pr-agent,,66241.0,113.0,2,132482.0,226.0
 dark-factory:debugger:agents:debugger-agent,,39633.333333333336,111.0,6,237800.0,666.0
 dark-factory:featurework:execution:agents:skeleton-agent,,0.0,0.0,1,0.0,0.0
 debugger-agent,,418539.0,728.0,1,418539.0,728.0
+dark-factory:dark-factory:agents:dark-factory-agent,,0.0,267.0,1,0.0,267.0


### PR DESCRIPTION
## Summary
Add brain.json existence verification immediately after brain-state-manager completes in Step 3. This catches silent failures where brain-state-manager returns without error but the file was never written due to permissions or disk space issues.

## Changes
- Inserted verification block (lines 80-85) that tests for file existence
- If missing, runs cleanup-worktree.sh and stops with a clear error message
- Positioned correctly between brain-state-manager invocation and pointer file write

## Risk
Low - this is a defensive guard that only activates on failure paths and follows the existing cleanup pattern.