### PR TITLE
fix(hooks): move append-footer-hook from settings.json to hooks.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,17 +60,6 @@
           }
         ]
       }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/agents/pr/hooks/append-footer-hook.sh"
-          }
-        ]
-      }
     ]
   }
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -32,6 +32,15 @@
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/post-tool-use-hook.sh\""
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/agents/pr/hooks/append-footer-hook.sh\""
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

Moves the `append-footer-hook.sh` registration from `.claude/settings.json` to `hooks/hooks.json` so the hook ships with the plugin and fires for all users, not just locally.

## Changes

- Removed the PostToolUse hook entry from `.claude/settings.json`
- Added the PostToolUse hook entry to `hooks/hooks.json`

This ensures the footer hook is part of the plugin's distributed configuration and will execute for all installations.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>