### PR TITLE
fix: replace agent file path refs with subagent_type

### DIFF
--- a/agents/code-review/agents/code-review-orchestrator-agent.md
+++ b/agents/code-review/agents/code-review-orchestrator-agent.md
@@ -36,16 +36,16 @@ StandardError {
 ## Your task
 
 1. Use `manage-issues-file` command with `operation: "create"` to initialize the issues file with an empty review points array.
-2. Spawn in parallel:
-   - `agents/code-review/agents/high-level-review-agent.md` with inputs `planFilePath` and `codePath`
-   - `agents/code-review/agents/low-level-review-agent.md` with input `codePath`
+2. Spawn in parallel using the Agent tool with subagent_type:
+   - Invoke Agent tool with subagent_type `dark-factory:code-review:agents:high-level-review-agent` with inputs `planFilePath` and `codePath`
+   - Invoke Agent tool with subagent_type `dark-factory:code-review:agents:low-level-review-agent` with input `codePath`
 3. Wait for both to complete.
    - If either returns an error: surface the error and halt. Do not start the resolver.
 4. Enter the resolver loop (up to 10 iterations):
    - Initialize `noProgressCount = 0`.
    - For each iteration:
      - Read the current issues.md file and count the number of unresolved issues. Store this as `issueCountBefore`.
-     - Spawn `agents/code-review/agents/resolver-agent.md` with `issuesFilePath` set to the absolute path of `<codePath>/issues.md`.
+     - Invoke Agent tool with subagent_type `dark-factory:code-review:agents:resolver-agent` with `issuesFilePath` set to the absolute path of `<codePath>/issues.md`.
      - Wait for it to return.
      - If it returns an error: surface the error and halt.
      - Read the updated issues.md file and count the number of unresolved issues. Store this as `issueCountAfter`.

--- a/metrics.csv
+++ b/metrics.csv
@@ -1,10 +1,10 @@
 agent,skill,avg_runtime,avg_tokens,runs,sum_runtime,sum_tokens
 dark-factory:featurework:planning:agents:planning-agent,,31902.666666666668,1155.0,3,95708.0,3465.0
 dark-factory:featurework:execution:agents:execution-agent,,78434.0,603.4,5,392170.0,3017.0
-dark-factory:code-review:agents:code-review-orchestrator-agent,,79338.68965517242,572.0,29,2300822.0,16588.0
-dark-factory:documentation:agents:update-documentation-agent,,48482.416666666664,195.29166666666666,24,1163578.0,4687.0
-dark-factory:skill-update:agents:skill-update-agent,,23751.608695652172,188.69565217391303,23,546287.0,4340.0
-dark-factory:pr:agents:pr-agent,,41181.181818181816,120.54545454545455,22,905986.0,2652.0
+dark-factory:code-review:agents:code-review-orchestrator-agent,,75701.09677419355,570.0322580645161,31,2346734.0,17671.0
+dark-factory:documentation:agents:update-documentation-agent,,47607.653846153844,191.03846153846155,26,1237799.0,4967.0
+dark-factory:skill-update:agents:skill-update-agent,,21948.32,183.04,25,548708.0,4576.0
+dark-factory:pr:agents:pr-agent,,39390.69565217391,115.30434782608695,23,905986.0,2652.0
 dark-factory:repair:agents:repair-agent,,12472.62962962963,169.03703703703704,27,336761.0,4564.0
 testing-agent,,0.0,0.0,13,0.0,0.0
 planning-agent,,0.0,0.0,20,0.0,0.0
@@ -21,3 +21,4 @@ dark-factory:debugger:agents:debugger-agent,,39633.333333333336,111.0,6,237800.0
 dark-factory:featurework:execution:agents:skeleton-agent,,0.0,0.0,1,0.0,0.0
 debugger-agent,,418539.0,728.0,1,418539.0,728.0
 dark-factory:dark-factory:agents:dark-factory-agent,,0.0,267.0,1,0.0,267.0
+dark-factory-agent,,0.0,362.0,1,0.0,362.0


### PR DESCRIPTION
## Problem

The `code-review-orchestrator-agent` was referencing its sub-agents using relative file paths like `agents/code-review/agents/high-level-review-agent.md`. When the orchestrator runs as a sub-agent of `dark-factory-agent`, the working directory is the project worktree (not the plugin root), so these file path references fail silently.

As a result, despite `code-review-orchestrator-agent` having 29+ recorded runs in metrics.csv, the three sub-agents (`high-level-review-agent`, `low-level-review-agent`, `resolver-agent`) have **zero runs** — they are never actually being invoked.

## Solution

Updated `code-review-orchestrator-agent` to specify proper `subagent_type` strings in Agent tool invocations:

- `agents/code-review/agents/high-level-review-agent.md` → `dark-factory:code-review:agents:high-level-review-agent`
- `agents/code-review/agents/low-level-review-agent.md` → `dark-factory:code-review:agents:low-level-review-agent`
- `agents/code-review/agents/resolver-agent.md` → `dark-factory:code-review:agents:resolver-agent`

The Agent tool can now resolve sub-agents correctly regardless of the current working directory.

## Files Changed

- `agents/code-review/agents/code-review-orchestrator-agent.md` — Updated task instructions to use subagent_type format and clarified Agent tool usage (4 line changes).

## Scope

This is a targeted fix following the documented pattern in `dark-factory:command-must-invoke-agent-by-name` skill — always use subagent_type with the Agent tool, never file path references.

## Test Plan

No new tests required — this is a documentation/specification fix. Existing integration tests (feature-agent → code-review-orchestrator-agent → sub-agents) will now execute the sub-agents correctly, whereas they were previously skipped.