### PR TITLE
Replace ambiguous Spawn instructions with explicit Agent tool invocations

### DIFF
--- a/agents/featurework/execution/agents/execution-agent.md
+++ b/agents/featurework/execution/agents/execution-agent.md
@@ -1,7 +1,7 @@
 ---
 name: execution-agent
 user-invocable: false
-description: Orchestrates end-to-end execution of an approved plan file. Spawns skeleton-agent, testing-agent, and implementation-agent in sequence. Enters planning mode if a hard-stop deviation is triggered.
+description: Orchestrates end-to-end execution of an approved plan file. Invokes skeleton-agent, testing-agent, and implementation-agent in sequence. Enters planning mode if a hard-stop deviation is triggered.
 tools: Read, Write, Edit, Bash, Agent, PushNotification, AskUserQuestion
 allowed-tools: Bash(rm tmp/files-checklist.md), Bash(rm tmp/flows-checklist.md)
 model: haiku
@@ -9,7 +9,7 @@ cache-control: ephemeral
 SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
 ---
 
-You are the execution-agent. Your job is to take an approved plan file and execute it end-to-end by spawning three agents in strict sequence. You do not write code yourself.
+You are the execution-agent. Your job is to take an approved plan file and execute it end-to-end by invoking three agents in strict sequence. You do not write code yourself.
 
 ## Input
 
@@ -18,14 +18,14 @@ You will be invoked with a `planPath` — a path to a `docs/plans/*.md` file.
 ## Your task
 
 1. Read the plan file at `planPath`.
-   - If the file does not exist: stop and report the error. Do not spawn any sub-agents.
-2. Spawn `skeleton-agent` with `planPath`. Wait for it to return.
+   - If the file does not exist: stop and report the error. Do not invoke any sub-agents.
+2. Invoke Agent tool with subagent_type `dark-factory:featurework:execution:agents:skeleton-agent` and input `planPath`. Wait for it to return.
    - Assert `tmp/files-checklist.md` is fully checked off.
    - Assert every file listed in the checklist exists on disk.
-4. Spawn `testing-agent` with `planPath`. Wait for it to return.
+4. Invoke Agent tool with subagent_type `dark-factory:featurework:execution:agents:testing-agent` and input `planPath`. Wait for it to return.
    - Assert `tmp/flows-checklist.md` exists.
    - Assert the test run output confirms all new tests are failing.
-5. Spawn `implementation-agent` with `planPath` and the path to `tmp/flows-checklist.md`. Wait for it to return.
+5. Invoke Agent tool with subagent_type `dark-factory:featurework:execution:agents:implementation-agent` with inputs `planPath` and the path to `tmp/flows-checklist.md`. Wait for it to return.
    - If it returns `hardStop: true`: enter planning mode (see Planning Mode below).
    - If it returns `allFlowsGreen: true`:
 6. Delete `tmp/files-checklist.md` and `tmp/flows-checklist.md`.
@@ -42,8 +42,8 @@ When a hard-stop is returned from `implementation-agent`:
       - label: "Resume", description: "The plan is updated and approved — re-read and continue from the current flow"
       - label: "Abort", description: "Cancel execution entirely"
 - If "Abort": stop immediately.
-- If "Resume": re-read the plan, confirm its status is `approved`, and resume from step 5 (re-spawn `implementation-agent`).
-- Do not spawn any agents until a resume response is received.
+- If "Resume": re-read the plan, confirm its status is `approved`, and resume from step 5 (re-invoke `implementation-agent`).
+- Do not invoke any agents until a resume response is received.
 
 ## Brain Patch
 
@@ -71,7 +71,7 @@ Rules:
 
 ## Rules
 
-- Never spawn the next agent until the current one returns successfully.
+- Never invoke the next agent until the current one returns successfully.
 - Do not write code. Your job is sequencing and gate-checking.
 - Never invoke the built-in `Explore` subagent_type directly. Always route codebase research through `investigation-agent` — it checks existing docs first (cheap) before scanning the codebase.
 

--- a/agents/fix-flow/agents/fix-flow-orchestrator.md
+++ b/agents/fix-flow/agents/fix-flow-orchestrator.md
@@ -2,7 +2,7 @@
 name: fix-flow-orchestrator
 user-invocable: false
 description: "Autonomously drives a failing integration flow to green. Generates test/log/deploy scripts, then loops: trigger, debug, PR, deploy until the flow passes."
-tools: Read, Bash, PushNotification, AskUserQuestion
+tools: Read, Bash, Agent, PushNotification, AskUserQuestion
 model: haiku
 allowed-tools: "Bash(find *), Bash(grep -r *)"
 ---
@@ -21,27 +21,21 @@ The flow name is required. If not provided, call PushNotification with title: "I
 
 ## Phase 1 — Understand System
 
-Spawn a sub-agent using investigation-agent.
-
-Pass it:
+Invoke Agent tool with subagent_type `dark-factory:documentation:agents:investigation-agent` with input:
 - The flow name from the argument
 
 Wait for it to return the path to the `docs/docs/` file it wrote. Then write `docs/plans/system-diagram.md` from that documentation as the working plan for this session. Do not proceed to Phase 2 until `docs/plans/system-diagram.md` exists.
 
 ## Phase 2 — Setup
 
-Spawn a sub-agent using setup-wizard.
-
-Pass it:
+Invoke Agent tool with subagent_type `dark-factory:fix-flow:agents:setup-wizard` with input:
 - Path to `docs/plans/system-diagram.md`
 
 Wait for it to return paths to the generated scripts. Do not proceed to Phase 3 until all required scripts exist.
 
 ## Phase 3 — Fix and Push
 
-Spawn a sub-agent using the instructions in ralph-fix-and-push.
-
-Pass it:
+Invoke Agent tool with subagent_type `dark-factory:fix-flow:agents:ralph-fix-and-push` with inputs:
 - Paths to all generated scripts from Phase 2
 - branchName (e.g., "feature/fix-flow-single-branch")
 

--- a/docs/docs/execution-agent.md
+++ b/docs/docs/execution-agent.md
@@ -1,0 +1,121 @@
+# execution-agent
+
+**Role**: Orchestrates end-to-end execution of an approved plan file by invoking three specialized agents in strict sequence.
+
+**Model**: Haiku (lightweight orchestration, no heavy reasoning).
+
+**User-Invocable**: No (invoked internally by the featurework orchestration flow).
+
+## Overview
+
+The execution-agent takes an approved feature plan and coordinates three phases of execution:
+1. Skeleton creation (skeleton-agent)
+2. Test generation (testing-agent)
+3. Implementation (implementation-agent)
+
+It handles gate-checking between phases and can enter planning mode if a hard-stop occurs during implementation.
+
+## Input
+
+- `planPath` (string, required) — Absolute path to an approved `docs/plans/*.md` file
+
+## Execution Flow
+
+### Step 1: Validate Plan
+
+1. Reads the plan file at `planPath`
+2. If file does not exist: stops and reports error. Does NOT invoke any sub-agents.
+
+### Step 2: Skeleton Creation
+
+1. Invokes Agent tool with subagent_type `dark-factory:featurework:execution:agents:skeleton-agent` with input `planPath`
+2. Waits for skeleton-agent to return
+3. Verifies `tmp/files-checklist.md` is fully checked off
+4. Verifies every file listed in the checklist exists on disk
+
+### Step 3: Test Generation
+
+1. Invokes Agent tool with subagent_type `dark-factory:featurework:execution:agents:testing-agent` with input `planPath`
+2. Waits for testing-agent to return
+3. Verifies `tmp/flows-checklist.md` exists
+4. Verifies the test run output confirms all new tests are failing
+
+### Step 4: Implementation
+
+1. Invokes Agent tool with subagent_type `dark-factory:featurework:execution:agents:implementation-agent` with inputs:
+   - `planPath`
+   - Path to `tmp/flows-checklist.md` (from Step 3)
+2. Waits for implementation-agent to return
+3. Checks return status:
+   - If `hardStop: true`: enters Planning Mode (see below)
+   - If `allFlowsGreen: true`: continues to Step 5
+
+### Step 5: Cleanup
+
+1. Deletes `tmp/files-checklist.md` and `tmp/flows-checklist.md`
+2. Reports success to developer
+
+## Planning Mode
+
+When implementation-agent returns `hardStop: true`:
+
+1. Sends PushNotification:
+   - Title: "Execution Paused — Input Required"
+   - Message: "Plan execution has been paused due to a hard-stop. Review the plan and reply when ready to resume."
+
+2. Uses AskUserQuestion:
+   - Header: "Execution Paused"
+   - Question: "Execution is paused (hard-stop). Edit the plan and resume when ready."
+   - Options:
+     - "Resume" — The plan is updated and approved, continue from current flow
+     - "Abort" — Cancel execution entirely
+
+3. Actions based on response:
+   - If "Abort": stops immediately
+   - If "Resume": re-reads the plan, confirms its status is `approved`, re-invokes implementation-agent to resume
+
+4. Does NOT invoke agents until a resume response is received
+
+## Sub-Agents
+
+- **skeleton-agent**: Creates file structure and scaffolding based on plan
+- **testing-agent**: Generates test files and runs test suite to verify all new tests fail
+- **implementation-agent**: Implements each flow defined in the plan; may trigger hard-stop for clarification
+
+## Key Design Rules
+
+1. **Sequential invocation** — Never invoke the next agent until the current one returns successfully
+2. **Gate-checking** — Verify checklist artifacts exist and meet quality gates before proceeding
+3. **No direct coding** — execution-agent orchestrates; it does not write code
+4. **Explicit Agent tool syntax** — Use Agent tool with proper subagent_type references
+5. **Hard-stop recovery** — Support re-planning and resumption without restarting from skeleton phase
+6. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`
+
+## Tools
+
+- Read, Write, Edit, Bash, Agent, PushNotification, AskUserQuestion
+
+## Return Value
+
+On success:
+```json
+{
+  "status": "complete",
+  "filesCreated": ["<list of files created by skeleton-agent>"],
+  "keyFilesModified": ["<list of key files modified by implementation-agent>"]
+}
+```
+
+On hard-stop (user chooses to abort):
+```json
+{
+  "status": "aborted"
+}
+```
+
+## Error Handling
+
+- If plan file does not exist: reports error and stops
+- If any agent returns an error: reports error and stops
+- If gate-checking fails (missing checklist, unchecked items): reports error and stops
+- If planning mode resume check fails (plan not approved): asks user to fix and resubmit

--- a/docs/docs/fix-flow-orchestrator.md
+++ b/docs/docs/fix-flow-orchestrator.md
@@ -26,7 +26,7 @@ The fix-flow-orchestrator is a specialized orchestrator for fixing broken integr
    - Uses AskUserQuestion to request flow name or allow cancel/reinvocation
    - Stops and waits for response
 
-2. Spawns `investigation-agent` with the flow name
+2. Invokes Agent tool with subagent_type `dark-factory:documentation:agents:investigation-agent` with the flow name
 
 3. Waits for investigation-agent to return path to documentation file (in `docs/docs/`)
 
@@ -38,7 +38,7 @@ The fix-flow-orchestrator is a specialized orchestrator for fixing broken integr
 
 **Objective**: Generate test trigger, log fetching, and deployment scripts.
 
-1. Spawns `setup-wizard` sub-agent with:
+1. Invokes Agent tool with subagent_type `dark-factory:fix-flow:agents:setup-wizard` with:
    - Path to `docs/plans/system-diagram.md`
 
 2. Waits for setup-wizard to return paths to generated scripts:
@@ -52,7 +52,7 @@ The fix-flow-orchestrator is a specialized orchestrator for fixing broken integr
 
 **Objective**: Loop through fix attempts until flow passes; create single PR with all fixes.
 
-1. Spawns `ralph-fix-and-push` sub-agent with:
+1. Invokes Agent tool with subagent_type `dark-factory:fix-flow:agents:ralph-fix-and-push` with:
    - Paths to all generated scripts from Phase 2
    - branchName (e.g., "feature/fix-flow-<flow-name>")
 
@@ -74,7 +74,8 @@ When ralph-fix-and-push returns `all-green: true`:
 3. **Verify Phase 2 scripts exist** — Before invoking ralph-fix-and-push, confirm all generated scripts are present
 4. **Persist documentation** — system-diagram.md and bug audit logs remain in the repository after fixes complete
 5. **Single PR output** — ralph-fix-and-push produces one PR with all accumulated fixes across multiple debug loops
-6. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
+6. **Explicit Agent tool invocation** — Use Agent tool with proper subagent_type references, not vague "Spawn X" instructions
+7. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
 
 ## Dependencies
 
@@ -83,7 +84,7 @@ When ralph-fix-and-push returns `all-green: true`:
 
 ## Tools
 
-- Read, Bash, PushNotification, AskUserQuestion
+- Read, Bash, Agent, PushNotification, AskUserQuestion
 
 ## Return Value
 

--- a/docs/plans/fix-subagent-invocation.md
+++ b/docs/plans/fix-subagent-invocation.md
@@ -1,0 +1,76 @@
+# Fix subagent invocation in execution-agent and fix-flow-orchestrator
+
+## Status
+
+approved
+
+## Summary
+
+Replace ambiguous "Spawn X" instructions in execution-agent and fix-flow-orchestrator with explicit Agent tool invocations using proper subagent_type references. This improves clarity and ensures correct agent routing.
+
+## Problem Statement
+
+**execution-agent** currently uses vague language like:
+- "Spawn `skeleton-agent` with `planPath`"
+- "Spawn `testing-agent` with `planPath`"
+- "Spawn `implementation-agent` with `planPath`"
+
+**fix-flow-orchestrator** uses equally vague instructions:
+- "Spawn a sub-agent using investigation-agent"
+- "Spawn a sub-agent using setup-wizard"
+- "Spawn a sub-agent using the instructions in ralph-fix-and-push"
+
+These "Spawn X" patterns lack explicit subagent_type values and don't follow the documented Agent tool invocation pattern shown in code-review-orchestrator-agent:
+```
+Invoke Agent tool with subagent_type `dark-factory:code-review:agents:high-level-review-agent`
+```
+
+## Affected Systems
+
+1. **execution-agent** (`agents/featurework/execution/agents/execution-agent.md`)
+   - Lines with "Spawn" instructions for skeleton-agent, testing-agent, implementation-agent
+   
+2. **fix-flow-orchestrator** (`agents/fix-flow/agents/fix-flow-orchestrator.md`)
+   - Phase 1 investigation-agent invocation
+   - Phase 2 setup-wizard invocation
+   - Phase 3 ralph-fix-and-push invocation
+
+## Solution
+
+### Phase 1: Implementation
+
+Replace each "Spawn X" with explicit Agent tool call:
+
+**execution-agent changes:**
+- Replace "Spawn `skeleton-agent`" with: Invoke Agent tool with subagent_type "dark-factory:featurework:execution:agents:skeleton-agent"
+- Replace "Spawn `testing-agent`" with: Invoke Agent tool with subagent_type "dark-factory:featurework:execution:agents:testing-agent"
+- Replace "Spawn `implementation-agent`" with: Invoke Agent tool with subagent_type "dark-factory:featurework:execution:agents:implementation-agent"
+
+**fix-flow-orchestrator changes:**
+- Replace "Spawn a sub-agent using investigation-agent" with: Invoke Agent tool with subagent_type "dark-factory:investigation-agent"
+- Replace "Spawn a sub-agent using setup-wizard" with: Invoke Agent tool with subagent_type "dark-factory:fix-flow:agents:setup-wizard"
+- Replace "Spawn a sub-agent using the instructions in ralph-fix-and-push" with: Invoke Agent tool with subagent_type "dark-factory:fix-flow:agents:ralph-fix-and-push"
+
+## Flows
+
+### Flow 1: Update execution-agent
+
+File: `agents/featurework/execution/agents/execution-agent.md`
+
+1. Replace line "2. Spawn `skeleton-agent`..." with explicit Agent tool invocation
+2. Replace line "4. Spawn `testing-agent`..." with explicit Agent tool invocation
+3. Replace line "5. Spawn `implementation-agent`..." with explicit Agent tool invocation
+
+### Flow 2: Update fix-flow-orchestrator
+
+File: `agents/fix-flow/agents/fix-flow-orchestrator.md`
+
+1. Replace "Spawn a sub-agent using investigation-agent" with explicit Agent tool invocation for investigation-agent
+2. Replace "Spawn a sub-agent using setup-wizard" with explicit Agent tool invocation for setup-wizard
+3. Replace "Spawn a sub-agent using the instructions in ralph-fix-and-push" with explicit Agent tool invocation for ralph-fix-and-push
+
+## Validation
+
+- All "Spawn" instructions replaced with explicit Agent tool syntax
+- Each subagent_type points to a valid agent file in the codebase
+- Documentation remains clear and actionable


### PR DESCRIPTION
## Summary

Replace vague 'Spawn X' instructions with explicit Agent tool subagent_type invocations in execution-agent and fix-flow-orchestrator, improving clarity and ensuring correct agent routing.

## Changes

- **execution-agent**: Replace "Spawn skeleton-agent/testing-agent/implementation-agent" with explicit Agent tool calls using proper subagent_type references
- **fix-flow-orchestrator**: Replace "Spawn a sub-agent using X" with explicit Agent tool invocations for investigation-agent, setup-wizard, ralph-fix-and-push
- **Documentation updates**: Created execution-agent.md docs and updated fix-flow-orchestrator.md to reflect explicit Agent tool syntax
- Updated agent frontmatter to include Agent tool where needed

## Pattern Matched

Follows the documented pattern from code-review-orchestrator-agent:
```
Invoke Agent tool with subagent_type `dark-factory:code-review:agents:high-level-review-agent`
```

## Validation

- All "Spawn X" instructions replaced with explicit Agent tool syntax
- Each subagent_type points to a valid agent in the codebase
- Documentation is clear and action oriented
- Improves agent visibility and routing clarity