### PR TITLE
Refactor debugger flow into 3-agent orchestrator with SubagentStop commits

### DIFF
--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -115,7 +115,7 @@ dark-factory-agent(taskDescription, taskName):
           STOP
     
     - "fix-flow"  → invoke fix-flow-orchestrator({ taskDescription })
-    - "debugger"  → invoke debugger-agent({ taskDescription })
+    - "debugger"  → invoke debugger-orchestrator({ taskDescription })
     - "repair"    → invoke repair-agent({ taskDescription })
     
     For non-feature routes, if worker returns error or hard-stop:

--- a/agents/dark-factory/scripts/commit-on-subagent-stop.sh
+++ b/agents/dark-factory/scripts/commit-on-subagent-stop.sh
@@ -33,8 +33,13 @@ case "$agent_type" in
   setup-wizard)
     commit_msg="chore: add setup scripts"
     ;;
-  debugger-agent)
-    commit_msg="docs: add bug audit log"
+  reproduce-test-agent)
+    bug_slug=$(cat /tmp/dark-factory-bug-slug 2>/dev/null || echo "reproduction")
+    commit_msg="test: $bug_slug (red)"
+    ;;
+  debugger-fix-agent)
+    bug_slug=$(cat /tmp/dark-factory-bug-slug 2>/dev/null || echo "bug")
+    commit_msg="fix: $bug_slug"
     ;;
   repair-agent)
     commit_msg="fix: repair"

--- a/agents/debugger/agents/debugger-agent.md
+++ b/agents/debugger/agents/debugger-agent.md
@@ -2,7 +2,7 @@
 name: debugger-agent
 user-invocable: false
 description: Runs systematic debugging on a non-obvious bug by following the debug skill checklist step by step.
-tools: Read, Write, Edit, Bash, Glob, Agent, Skill
+tools: Read, Write, Bash, Glob, Agent, Skill
 model: sonnet
 skills: systematic-debugging, investigation-delegate
 allowed-tools: Bash(bash *), Bash(pytest *), Bash(python *), Bash(npm test *), Bash(grep -r *), Bash(find *), Bash(aws *), Bash(gh *), Bash(docker *), Bash(curl *)
@@ -32,12 +32,46 @@ You are a systematic debugger. Your only job is to follow the steps in `flows/de
 3. Read all relevant logs and stack traces before touching code.
 4. Fill the bug file using bug-audit-log-template.
 5. Run the debugging checklist in order:
-   - Write a failing reproduction test first.
-   - Confirm the test fails before any fix.
-   - Identify root cause from evidence.
-   - Fix the root problem.
-   - Confirm the test passes.
-   - Remove the fix and confirm it fails again (when safe).
+   - **5.1** Write a failing reproduction test first.
+   - **5.2** Confirm the test fails before any fix.
+     - After confirming test failure, stage only the test file(s) and commit with message "test: <bug-slug> (red)":
+       ```bash
+       WORK_DIR="${DARK_FACTORY_WORK_DIR}"
+       if [ -z "$WORK_DIR" ] && [ -f /tmp/dark-factory-work-dir ]; then
+         WORK_DIR="$(cat /tmp/dark-factory-work-dir)"
+       fi
+       if [ -n "$WORK_DIR" ]; then
+         # Extract bug-slug from the bug file created in step 2
+         # Expected format: docs/bugs/<yyyy-mm-dd>-<bug-slug>.md
+         bug_file=$(git -C "$WORK_DIR" ls-files docs/bugs/*.md | head -1)
+         if [ -n "$bug_file" ]; then
+           bug_slug=$(basename "$bug_file" .md | sed 's/^[0-9-]*-//')
+           # Stage only test files (modify this pattern based on your test location)
+           git -C "$WORK_DIR" add tests/ || git -C "$WORK_DIR" add test/
+           git -C "$WORK_DIR" commit -m "test: $bug_slug (red)"
+         fi
+       fi
+       ```
+   - **5.3** Identify root cause from evidence.
+   - **5.4** Fix the root problem.
+   - **5.5** Confirm the test passes.
+     - After confirming test passes, stage only the fix file(s) and commit with message "fix: <bug-slug>":
+       ```bash
+       WORK_DIR="${DARK_FACTORY_WORK_DIR}"
+       if [ -z "$WORK_DIR" ] && [ -f /tmp/dark-factory-work-dir ]; then
+         WORK_DIR="$(cat /tmp/dark-factory-work-dir)"
+       fi
+       if [ -n "$WORK_DIR" ]; then
+         bug_file=$(git -C "$WORK_DIR" ls-files docs/bugs/*.md | head -1)
+         if [ -n "$bug_file" ]; then
+           bug_slug=$(basename "$bug_file" .md | sed 's/^[0-9-]*-//')
+           # Stage only the fixed source files (exclude test, docs, and bug file changes)
+           git -C "$WORK_DIR" diff --name-only | grep -v '^test' | grep -v '^docs' | xargs -r git -C "$WORK_DIR" add
+           git -C "$WORK_DIR" commit -m "fix: $bug_slug"
+         fi
+       fi
+       ```
+   - **5.6** Remove the fix and confirm it fails again (when safe).
 6. Record root cause, fix summary, and verification in the bug file.
 
 ## Brain Patch

--- a/agents/debugger/agents/debugger-fix-agent.md
+++ b/agents/debugger/agents/debugger-fix-agent.md
@@ -1,0 +1,69 @@
+---
+name: debugger-fix-agent
+user-invocable: false
+description: Identifies root cause from evidence, applies minimal fix, verifies causality, and stages fixed files. Triggers SubagentStop commit.
+tools: Read, Edit, Bash, Glob
+model: sonnet
+SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
+---
+
+You are the debugger-fix-agent. Your job is to identify the root cause, apply a minimal fix, verify it works, and stage it for the SubagentStop hook to commit.
+
+## Responsibilities
+
+1. **Receive inputs** (from debugger-orchestrator):
+   - `bugFilePath` — absolute path to bug audit log (contains evidence and reproduction test)
+   - `bugSlug` — extracted bug identifier (for commit message)
+   - `workDir` — absolute path to feature worktree
+
+2. **Identify root cause**:
+   - Read evidence from bug file (logs, stack traces, system context)
+   - Review reproduction test created by reproduce-test-agent
+   - Trace execution path to identify root cause
+   - Document findings clearly
+
+3. **Apply minimal fix**:
+   - Apply only the minimal change needed to fix root problem
+   - NO workarounds, hacks, or defensive patterns
+   - Target the actual root cause, not symptoms
+   - Keep changes focused and small
+
+4. **Verify causality**:
+   - Run reproduction test: should now PASS
+   - Verify test failure → fix removal → test failure again (causality check, when safe)
+   - Re-apply fix and confirm test passes
+   - Document verification steps
+
+5. **Update bug audit log**:
+   - Update bug file with:
+     - Root cause summary
+     - Description of fix applied
+     - Files modified
+     - Verification steps completed
+     - Test status: now passing
+
+6. **Stage fixed files**:
+   - Execute: `git -C $WORK_DIR add <fix-files>`
+   - Stage source code files that were modified
+   - Also stage the updated bug file: `git -C $WORK_DIR add docs/bugs/*`
+   - Verify: `git -C $WORK_DIR diff --cached` shows only fixes and updated bug log
+
+7. **SubagentStop hook fires**:
+   - Hook reads `/tmp/dark-factory-bug-slug` to get bug slug
+   - Hook commits with message: `"fix: <bug-slug>"`
+   - Hook uses: `git -C $WORK_DIR commit -m "fix: <bug-slug>"`
+
+## Rules
+
+- Identify and fix root cause only (no defensive programming)
+- Apply minimal change (smallest possible diff)
+- Do NOT write brain-patch.json (orchestrator owns that)
+- Stage only source code fixes and updated bug file
+- Do NOT stage test files (already committed by reproduce-test-agent)
+- All `git` operations must use: `git -C $WORK_DIR ...`
+- Causality verification is mandatory: remove fix → test fails → re-apply fix
+- Document all findings in the bug file before staging
+
+## Return
+
+When SubagentStop fires, this agent's execution ends and the hook commits the staged fix files.

--- a/agents/debugger/agents/debugger-orchestrator.md
+++ b/agents/debugger/agents/debugger-orchestrator.md
@@ -1,0 +1,101 @@
+---
+name: debugger-orchestrator
+user-invocable: false
+description: Top-level orchestrator for systematic debugging. Coordinates investigation, triage, test reproduction, and fix application across three specialized sub-agents with structural commit enforcement.
+tools: Read, Write, Agent, Bash, Skill
+model: haiku
+skills: investigation-delegate
+---
+
+You are the debugger orchestrator. Your job is to coordinate systematic debugging across three specialized sub-agents, each with its own SubagentStop commit hook.
+
+## Orchestration
+
+```
+debugger-orchestrator(taskDescription):
+
+  # Step 0: Understand the system context
+  result = invoke investigation-agent({
+    system: "",
+    question: taskDescription
+  })
+  
+  if result.error:
+    log("Investigation failed, proceeding with available knowledge")
+  else:
+    systemDocumentation = result.content
+
+  # Step 1: Triage — confirm bug warrants systematic debugging
+  Confirm:
+    - Bug is non-obvious (not a simple typo or obvious logic error)
+    - OR bug is state-dependent, intermittent, or requires understanding system interactions
+  If trivial/obvious: STOP and report "Bug is too simple for systematic debugging"
+
+  # Step 2: Find or create bug audit log file
+  Search docs/bugs/ for existing file matching failure signature
+  If found: BUG_FILE = existing file path
+  If not found:
+    - Create docs/bugs/<YYYY-MM-DD>-<slug>.md using bug-audit-log-template
+    - BUG_FILE = full path to newly created file
+    - BUG_SLUG = extracted from filename (everything after date prefix)
+
+  # Write slug to pointer file for sub-agents
+  bash("printf '%s' '<BUG_SLUG>' > /tmp/dark-factory-bug-slug")
+
+  # Step 3: Read all evidence before touching code
+  - Read logs, stack traces, error messages from BUG_FILE or context
+  - Review system documentation from Step 0
+  - Understand failure mode and symptom
+
+  # Step 4: Fill bug audit log template
+  Update BUG_FILE with:
+    - Failure signature and reproduction steps
+    - Error messages, logs, stack traces
+    - System context and affected components
+    - Initial observations before fix
+  Stage and commit: git -C $WORK_DIR add "docs/bugs/*" && git -C $WORK_DIR commit -m "docs: initial bug audit log"
+
+  # Step 5: Invoke reproduce-test-agent
+  Resolve WORK_DIR:
+    WORK_DIR = $DARK_FACTORY_WORK_DIR
+    if WORK_DIR empty: WORK_DIR = contents of /tmp/dark-factory-work-dir
+  
+  invoke reproduce-test-agent({
+    bugFilePath: BUG_FILE,
+    bugSlug: BUG_SLUG,
+    workDir: WORK_DIR
+  })
+  
+  if error:
+    report "reproduce-test-agent failed: " + error
+    STOP
+
+  # Step 6: Invoke debugger-fix-agent
+  invoke debugger-fix-agent({
+    bugFilePath: BUG_FILE,
+    bugSlug: BUG_SLUG,
+    workDir: WORK_DIR
+  })
+  
+  if error:
+    report "debugger-fix-agent failed: " + error
+    STOP
+
+  # Step 7: Write brain-patch.json (orchestrator owns final state)
+  Write $WORK_DIR/brain-patch.json:
+  ```json
+  {
+    "bugFiles": ["<absolute path to BUG_FILE>"],
+    "notes": ["debugger-orchestrator: Completed 3-agent refactoring flow: reproduce → fix → verify"]
+  }
+  ```
+```
+
+## Rules
+
+- Do NOT read `brain.json` directly — context is injected by pre-hook
+- Do NOT write `brain.json` directly — write `brain-patch.json` only
+- Use pointer file `/tmp/dark-factory-bug-slug` to share bug slug with sub-agents
+- Resolve WORK_DIR via env var first, then pointer file fallback
+- The `/tmp/dark-factory-bug-slug` file is used by commit-on-subagent-stop.sh in sub-agents
+- Never invoke the built-in `Explore` subagent_type directly. Always use `investigation-agent` for system research.

--- a/agents/debugger/agents/reproduce-test-agent.md
+++ b/agents/debugger/agents/reproduce-test-agent.md
@@ -1,0 +1,54 @@
+---
+name: reproduce-test-agent
+user-invocable: false
+description: Writes and executes a minimal failing reproduction test. Stages test files and triggers SubagentStop commit.
+tools: Read, Bash, Glob
+model: sonnet
+SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
+---
+
+You are the reproduce-test-agent. Your job is to create a minimal failing test that reproduces the bug, verify it fails, and stage it for the SubagentStop hook to commit.
+
+## Responsibilities
+
+1. **Receive inputs** (from debugger-orchestrator):
+   - `bugFilePath` — absolute path to bug audit log
+   - `bugSlug` — extracted bug identifier (for commit message)
+   - `workDir` — absolute path to feature worktree
+
+2. **Write failing reproduction test**:
+   - Create a minimal unit test (preferred) or integration test
+   - Test should directly exercise the failing behavior
+   - Test should be self-contained and fast to run
+   - Place test in appropriate location (tests/, test/, spec/, etc.)
+   - Include clear comment explaining what bug it reproduces
+
+3. **Run and confirm test fails**:
+   - Execute: `pytest`, `npm test`, `python -m unittest`, etc. (based on project)
+   - Confirm test FAILS with assertion error (not syntax/import error)
+   - Do NOT apply fix yet
+   - Log failure output for debugging reference
+
+4. **Stage test files**:
+   - Execute: `git -C $WORK_DIR add <test-files>`
+   - Stage ONLY the new test file(s), not other changes
+   - Verify: `git -C $WORK_DIR diff --cached` shows only test additions
+
+5. **SubagentStop hook fires**:
+   - Hook reads `/tmp/dark-factory-bug-slug` to get bug slug
+   - Hook commits with message: `"test: <bug-slug> (red)"`
+   - Hook uses: `git -C $WORK_DIR commit -m "test: <bug-slug> (red)"`
+
+## Rules
+
+- Create only ONE minimal test (don't write comprehensive test suite)
+- Test must FAIL before any fix is applied
+- Test failure should be assertion error, not syntax/import error
+- Do NOT apply any fix
+- Stage only test files (no source code changes)
+- Use pointer file `/tmp/dark-factory-bug-slug` if needed for troubleshooting
+- All `git` operations must use: `git -C $WORK_DIR ...`
+
+## Return
+
+When SubagentStop fires, this agent's execution ends and the hook commits the staged test files.

--- a/docs/docs/dark-factory-agent.md
+++ b/docs/docs/dark-factory-agent.md
@@ -57,7 +57,7 @@ Routes based on classification:
 - **"fix-flow"** → `fix-flow-orchestrator`
   - Investigates broken flow, generates fix scripts, applies targeted fixes
   
-- **"debugger"** → `debugger-agent`
+- **"debugger"** → `debugger-orchestrator` (3-agent pattern: orchestrator, reproduce-test-agent, debugger-fix-agent)
   - Systematic debugging for non-obvious bugs
   
 - **"repair"** → `repair-agent`
@@ -137,7 +137,7 @@ Called on any error path after worktree creation:
 ## Dependencies
 
 - **Skills**: task-classifier, brain-state-manager
-- **Sub-agents**: feature-agent, fix-flow-orchestrator, debugger-agent, repair-agent, code-review-orchestrator-agent, update-documentation-agent, skill-update-agent, pr-agent
+- **Sub-agents**: feature-agent, fix-flow-orchestrator, debugger-orchestrator (+ reproduce-test-agent, debugger-fix-agent), repair-agent, code-review-orchestrator-agent, update-documentation-agent, skill-update-agent, pr-agent
 - **Scripts**: prep-feature-dir.sh, cleanup-worktree.sh
 
 ## Tools

--- a/docs/docs/debugger-agent.md
+++ b/docs/docs/debugger-agent.md
@@ -1,181 +1,268 @@
-# debugger-agent
+# Debugger Flow Architecture
 
-**Role**: Systematic debugger for non-obvious, state-dependent, or intermittent bugs.
+**Classification**: debugger (systematic bug fixing via test-first workflow)
 
-**Model**: Sonnet (heavy reasoning for bug investigation and analysis).
+**Model**: Haiku orchestrator + Sonnet workers
 
-**User-Invocable**: No (invoked by dark-factory-agent).
+**User-Invocable**: No (invoked by dark-factory-agent when classification="debugger")
 
 ## Overview
 
-The debugger-agent runs systematic debugging following a rigorous checklist-based methodology. It is designed for bugs that are non-obvious, state-dependent, intermittent, or of unknown cause — not simple syntax errors or obvious logic bugs. The agent follows the debug skill checklist step-by-step without skipping, producing a bug audit log, two deterministic commits (red and green test states), and a verified fix.
+The debugger flow is a 3-agent orchestrator pattern that coordinates systematic debugging of non-obvious, state-dependent, or intermittent bugs. Each agent is responsible for a distinct phase and commits its work independently via SubagentStop hooks.
+
+The three agents are:
+1. **debugger-orchestrator** (haiku) — Entry point; coordinates triage, investigation, and sub-agent sequencing
+2. **reproduce-test-agent** (sonnet) — Writes failing reproduction test and commits with "test: <slug> (red)"
+3. **debugger-fix-agent** (sonnet) — Applies fix, verifies causality, and commits with "fix: <slug>"
+
+## Architecture
+
+```
+debugger-orchestrator
+├── Step 0: investigation-agent (understand system context)
+├── Step 1: Triage (confirm bug is non-obvious)
+├── Step 2: Create bug audit log file (docs/bugs/<date>-<slug>.md)
+├── Step 3: Read all evidence (logs, stack traces)
+├── Step 4: Fill bug audit log template
+├── Step 5: invoke reproduce-test-agent ──→ [red commit: "test: <slug> (red)"]
+├── Step 6: invoke debugger-fix-agent ──→ [green commit: "fix: <slug>"]
+└── Step 7: Write brain-patch.json
+```
 
 ## Input
 
-- `taskDescription` (string) — Description of the bug to debug (what is failing, expected behavior, actual behavior)
+- `taskDescription` (string) — Description of the bug to debug (failure signature, expected vs actual behavior)
 
-## Debugging Workflow (6 Steps)
+## Commit Sequence
 
-### Step 1: Confirm Bug Warrants Systematic Debugging
+The orchestration produces **two deterministic commits**:
 
-Verify the bug is:
-- Non-obvious (root cause not immediately clear)
-- State-dependent (behavior depends on system state, timing, or conditions)
-- Intermittent (fails inconsistently)
-- Unknown cause (not obviously a typo or simple logic error)
+1. **Red commit** (reproduce-test-agent SubagentStop): `"test: <bug-slug> (red)"`
+   - Stages: reproduction test file(s) only
+   - Triggers after reproduce-test-agent confirms test fails on unmodified code
 
-If the bug is obviously simple, report it and STOP (use repair-agent instead for simple fixes).
+2. **Green commit** (debugger-fix-agent SubagentStop): `"fix: <bug-slug>"`
+   - Stages: source code fix file(s) + updated bug audit log
+   - Triggers after debugger-fix-agent verifies test passes with fix applied
 
-### Step 2: Search for Existing Bug File
+## Workflow Steps
 
-1. Searches `docs/bugs/` for an existing file with the same failure signature
-2. If found: uses existing file, appends findings
-3. If not found: creates `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` (dated, hyphenated slug of bug description)
+### Step 0: Understand System Context
 
-### Step 3: Read All Relevant Evidence Before Touching Code
+Debugger-orchestrator invokes investigation-agent to gather authoritative documentation about the system components involved in the failure. This ensures accurate diagnosis before debugging begins.
 
-**Critical rule**: Do not modify code until evidence is understood.
+**If investigation succeeds**: Use documented system context during analysis
+**If investigation fails**: Proceed with available knowledge
 
-1. Reads all relevant logs, stack traces, and error messages
-2. Examines reproduction steps and failure conditions
-3. Identifies all test runs that exhibit the failure
-4. Gathers system state snapshots if applicable
+### Step 1: Triage
 
-### Step 4: Fill Bug Audit Log
+Confirm the bug warrants systematic debugging:
+- Bug is non-obvious (root cause not immediately clear)
+- OR bug is state-dependent, intermittent, or requires understanding system interactions
 
-Uses `bug-audit-log-template` to document:
+If the bug is trivial/obvious (simple typo, obvious logic error):
+- Report and STOP
+- Suggest using repair-agent for simple fixes
+
+### Step 2: Find or Create Bug File
+
+Search `docs/bugs/` for existing audit log matching the failure signature.
+
+**If found**: Use existing file (append new findings)
+**If not found**: Create `docs/bugs/<YYYY-MM-DD>-<bug-slug>.md`
+- Date: Today's date
+- Slug: Hyphenated short identifier for the bug
+- Example: `docs/bugs/2026-05-08-parser-eof-crash.md`
+
+Write the bug slug to `/tmp/dark-factory-bug-slug` for sub-agent access.
+
+### Step 3: Read All Relevant Evidence
+
+**Critical rule**: Do not modify code until evidence is fully understood.
+
+1. Read all relevant logs, stack traces, and error messages
+2. Examine reproduction steps and failure conditions
+3. Identify test runs that exhibit the failure
+4. Gather system state snapshots if applicable
+5. Review system documentation from Step 0
+
+### Step 4: Fill Bug Audit Log Template
+
+Document findings in the bug file using bug-audit-log-template:
+
 - **Failure Signature**: Exact error or failure mode observed
 - **Reproduction Steps**: Steps to reliably trigger the bug
 - **Expected Behavior**: What should happen
 - **Actual Behavior**: What actually happens
-- **Environment**: System, OS, Python/Node version, etc.
-- **Relevant Logs**: Stack traces, error messages, logs from failing runs
+- **Environment**: System, OS, versions
+- **Relevant Logs**: Stack traces, error messages
 - **Hypotheses**: Theories about root cause based on evidence (not yet confirmed)
 
-### Step 5: Run Debugging Checklist
+Commit this initial state: `git -C $WORK_DIR add docs/bugs/* && git -C $WORK_DIR commit -m "docs: initial bug audit log"`
 
-Follows this sequence in strict order:
+### Step 5: invoke reproduce-test-agent
 
-1. **5.1: Write a failing reproduction test**
-   - Minimal test case that reproduces the bug
-   - Arrange inputs per failure conditions
-   - Assert expected behavior
-   - Confirm test fails (assertion error, not import/syntax error)
+Debugger-orchestrator spawns reproduce-test-agent with:
+- `bugFilePath` — Absolute path to bug audit log
+- `bugSlug` — Bug slug extracted from filename (for commit message)
+- `workDir` — Absolute path to feature worktree
 
-2. **5.2: Confirm the test fails before any fix**
-   - Run test on unmodified code
-   - Verify it fails consistently (not intermittent test failure)
-   - Note the failure signature in bug file
-   - **After confirming failure, make the red commit**: stage only the test file(s) and commit with message `"test: <bug-slug> (red)"`
+**reproduce-test-agent responsibilities**:
+1. Write a minimal failing reproduction test
+   - Unit test preferred (fast, isolated)
+   - Can be integration test if needed
+   - Place in appropriate directory (tests/, test/, spec/, etc.)
+   - Include clear comment about the bug it reproduces
 
-3. **5.3: Identify root cause from evidence**
-   - Examine code paths involved in failure
-   - Review logs and stack traces from step 3
-   - Form hypothesis about root cause
+2. Run and confirm test fails
+   - Execute appropriate test runner: `pytest`, `npm test`, `python -m unittest`, etc.
+   - Confirm test **fails with assertion error** (not syntax/import error)
+   - Log failure output for debugging reference
+
+3. Stage test file(s) only
+   - Execute: `git -C $WORK_DIR add <test-files>`
+   - Verify: `git -C $WORK_DIR diff --cached` shows only test additions
+
+4. SubagentStop hook fires
+   - Hook reads `/tmp/dark-factory-bug-slug` to get bug slug
+   - Hook commits: `git -C $WORK_DIR commit -m "test: <bug-slug> (red)"`
+   - Agent execution ends
+
+### Step 6: invoke debugger-fix-agent
+
+Debugger-orchestrator spawns debugger-fix-agent with:
+- `bugFilePath` — Absolute path to bug audit log
+- `bugSlug` — Bug slug (for commit message)
+- `workDir` — Absolute path to feature worktree
+
+**debugger-fix-agent responsibilities**:
+1. Identify root cause from evidence
+   - Review evidence already in bug file
+   - Review reproduction test created by reproduce-test-agent
+   - Trace execution path to identify root cause
    - Validate hypothesis against all evidence
 
-4. **5.4: Fix the root problem**
-   - Apply minimal fix targeting identified root cause
-   - Do not apply workarounds or papering over symptoms
-   - Do not change unrelated code
+2. Apply minimal fix
+   - Apply only the minimal change needed to fix root problem
+   - NO workarounds, hacks, or defensive patterns
+   - Target the actual root cause, not symptoms
+   - Keep changes focused and small
 
-5. **5.5: Confirm the test passes**
-   - Run the reproduction test on fixed code
-   - Verify it passes consistently
-   - Document the fix in bug file
-   - **After confirming pass, make the green commit**: stage only the fix file(s) and commit with message `"fix: <bug-slug>"`
+3. Verify causality (mandatory)
+   - Run reproduction test: should now **PASS**
+   - Verify test failure → fix removal → test failure again (confirms fix is necessary)
+   - Re-apply fix and confirm test passes
+   - Document verification in bug file
 
-6. **5.6: Remove the fix and confirm it fails again** (when safe)
-   - Revert fix to unmodified code
-   - Re-run reproduction test
-   - Verify it fails as before (confirms fix actually addresses the issue, not coincidence)
-   - Re-apply fix
+4. Update bug audit log
+   - Add root cause summary and code location references
+   - Document fix applied and files modified
+   - Record verification steps completed
+   - Mark test status as "PASSING"
 
-### Step 6: Record Root Cause and Verification
+5. Stage fixed files
+   - Execute: `git -C $WORK_DIR add <fix-files> docs/bugs/*`
+   - Stage source code files that were modified
+   - Also stage the updated bug audit log
+   - Verify: `git -C $WORK_DIR diff --cached` shows only fixes and bug log updates
 
-Update bug file with:
-- **Root Cause**: Explanation of why the bug occurred (reference code locations)
-- **Fix Summary**: What was changed and why (reference commits)
-- **Verification**: Test name and results confirming the fix
+6. SubagentStop hook fires
+   - Hook reads `/tmp/dark-factory-bug-slug` to get bug slug
+   - Hook commits: `git -C $WORK_DIR commit -m "fix: <bug-slug>"`
+   - Agent execution ends
 
-## Commit Sequence
+### Step 7: Write brain-patch.json
 
-The debugger-agent produces three deterministic commits to the feature branch:
+After both sub-agents complete, debugger-orchestrator writes the final state:
 
-1. **Red commit** (after step 5.2): `"test: <bug-slug> (red)"` — stages only the reproduction test file(s)
-2. **Green commit** (after step 5.5): `"fix: <bug-slug>"` — stages only the fix file(s)
-3. **Docs commit** (SubagentStop hook, after checklist): `"docs: add bug audit log"` — stages the bug audit log and any supporting documentation
+Resolves WORK_DIR:
+```
+WORK_DIR = $DARK_FACTORY_WORK_DIR
+if WORK_DIR empty: WORK_DIR = contents of /tmp/dark-factory-work-dir
+if WORK_DIR still empty: skip silently
+```
 
-This sequence clearly shows the test-first discipline and the minimal scope of each fix.
-
-## Brain Patch Output
-
-After all bug files are written and debugging checklist is complete:
-
-Resolves WORK_DIR (see rule 7) and writes `$WORK_DIR/brain-patch.json`:
+Writes `$WORK_DIR/brain-patch.json`:
 ```json
 {
   "bugFiles": [
-    "/absolute/path/to/bug-file-1.md",
-    "/absolute/path/to/bug-file-2.md"
+    "/absolute/path/to/docs/bugs/<date>-<slug>.md"
+  ],
+  "notes": [
+    "debugger-orchestrator: Completed 3-agent refactoring flow: reproduce → fix → verify"
   ]
 }
 ```
 
 ## Key Design Rules
 
-1. **Follow the checklist in strict order** — Do not skip steps; each step validates the previous one
-2. **Read all evidence before coding** — Understand the bug completely before touching code
-3. **Write tests before fixing** — Test-first ensures the fix is actually necessary
-4. **Make red and green commits** — Commit the test after step 5.2 (before fix) and the fix after step 5.5 (after test passes)
-5. **Verify fix is necessary** — Remove fix and confirm test fails again (except when unsafe)
-6. **Do NOT read brain.json** — Context is already injected by pre-hook
-7. **Do NOT write brain.json directly** — Only write brain-patch.json
-8. **Resolve WORK_DIR via pointer file fallback** — Use `$DARK_FACTORY_WORK_DIR` if set; else read contents of `/tmp/dark-factory-work-dir`; skip brain-patch silently if both are empty
-9. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
+1. **Strict phase sequencing**: Reproduce → Fix → Verify (enforced by orchestrator)
+2. **Read all evidence before coding** — Understand bug completely before touching code
+3. **Write tests before fixing** — Test-first ensures fix is actually necessary
+4. **Minimal, focused fixes** — Target root cause only, no defensive patterns
+5. **Verify causality** — Remove fix and confirm test fails again (confirms necessity)
+6. **SubagentStop commits** — Each sub-agent commits its own work independently
+7. **No direct brain.json access** — Use brain-patch.json only
+8. **WORK_DIR via pointer file** — Orchestrator writes `/tmp/dark-factory-bug-slug` and `/tmp/dark-factory-work-dir` for sub-agents
+9. **Never use Explore directly** — Route codebase research through investigation-agent
 
 ## Dependencies
 
-- **Skills**: systematic-debugging (contains debug checklist)
-- **Templates**: bug-audit-log-template
+- **Skills**: investigation-delegate (for orchestrator's investigation-agent call)
+- **Templates**: bug-audit-log-template (for bug file structure)
+- **Sub-agents**: reproduce-test-agent, debugger-fix-agent
+- **Hooks**: commit-on-subagent-stop.sh (for sub-agent commits)
 
 ## Tools
 
-- Read, Write, Bash, Glob, Agent, Skill
+**Orchestrator (debugger-orchestrator)**:
+- Read, Write, Agent, Bash, Skill
+- Model: haiku
 
-## Allowed Bash Commands
+**Test Writer (reproduce-test-agent)**:
+- Read, Bash, Glob
+- Model: sonnet
+- Allowed: `Bash(bash *)`, `Bash(pytest *)`, `Bash(npm test *)`, `Bash(python *)`, `Bash(grep -r *)`, `Bash(find *)`
 
-`Bash(bash *)`, `Bash(pytest *)`, `Bash(python *)`, `Bash(npm test *)`, `Bash(grep -r *)`, `Bash(find *)`, `Bash(aws *)`, `Bash(gh *)`, `Bash(docker *)`, `Bash(curl *)`
+**Fixer (debugger-fix-agent)**:
+- Read, Edit, Bash, Glob
+- Model: sonnet
+- Allowed: `Bash(bash *)`, `Bash(pytest *)`, `Bash(npm test *)`, `Bash(python *)`, `Bash(grep -r *)`, `Bash(find *)`, `Bash(git -C * add *)`, `Bash(git -C * commit *)`
 
-Includes cloud-native tooling (`aws`, `gh`, `docker`, `curl`) so the agent can fetch remote logs, query cloud resources, and inspect container state without silently failing on cloud-hosted projects.
+## Artifacts Produced
+
+On the feature branch, the orchestration produces:
+
+1. **Reproduction test file(s)** — Committed in red commit by reproduce-test-agent
+2. **Source code fix file(s)** — Committed in green commit by debugger-fix-agent
+3. **Bug audit log** — `docs/bugs/<YYYY-MM-DD>-<bug-slug>.md` — Committed with green commit (updated by debugger-fix-agent)
+4. **Brain patch** — `$DARK_FACTORY_WORK_DIR/brain-patch.json` — State metadata for dark-factory-agent (not committed)
 
 ## Error Handling
 
-- If bug is obviously simple (not non-obvious/state-dependent): report and STOP
-- If test cannot be written: report blocker and STOP
-- If root cause cannot be identified after evidence review: document findings in bug file and report inconclusive
-- If fix cannot be applied: document blocker and STOP
+- **Bug too simple**: Triage reports and stops (suggest repair-agent)
+- **Cannot write test**: Report blocker and stop
+- **Cannot identify root cause**: Document findings and report inconclusive
+- **Cannot apply fix**: Document blocker and stop
 
-## SubagentStop Hook
+## SubagentStop Hooks
 
-The agent declares a `SubagentStop` hook in its YAML frontmatter:
+Both sub-agents declare SubagentStop hooks in their YAML frontmatter:
 
 ```yaml
 SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
 ```
 
-When the agent finishes (after step 5.6 and root cause documentation), this hook fires and commits all staged changes in the feature worktree with commit message `"docs: add bug audit log"`. This is the third and final commit in the sequence, after the red and green commits created in steps 5.2 and 5.5.
+**reproduce-test-agent SubagentStop**: Commits red test with message `"test: <bug-slug> (red)"`
 
-## Artifacts Produced
+**debugger-fix-agent SubagentStop**: Commits green fix with message `"fix: <bug-slug>"`
 
-The debugger-agent produces the following artifacts on the feature branch:
+Both hooks read `/tmp/dark-factory-bug-slug` to construct the dynamic commit message.
 
-1. **Test file(s)** — Reproduction test(s) for the bug (committed in red commit)
-2. **Fix file(s)** — Fixed source code (committed in green commit)
-3. **Bug audit log** — `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` — Full documentation of the bug, root cause, fix, and verification (committed in docs commit via SubagentStop hook)
-4. **Brain patch** — `$DARK_FACTORY_WORK_DIR/brain-patch.json` — Metadata linking to bug files (consumed by dark-factory-agent, not committed directly)
+## Commit Message Format
 
-The three commits in order are:
-- `test: <bug-slug> (red)` — test file(s) only
-- `fix: <bug-slug>` — source fix file(s) only
-- `docs: add bug audit log` — bug audit log and supporting docs
+- Red commit: `test: <bug-slug> (red)` — signals test is failing before fix
+- Green commit: `fix: <bug-slug>` — signals bug is fixed and test passes
+
+The `<bug-slug>` is extracted from the bug filename (everything after the date prefix).
+Example: For file `2026-05-08-parser-eof-crash.md`, slug is `parser-eof-crash`.

--- a/docs/docs/debugger-agent.md
+++ b/docs/docs/debugger-agent.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-The debugger-agent runs systematic debugging following a rigorous checklist-based methodology. It is designed for bugs that are non-obvious, state-dependent, intermittent, or of unknown cause — not simple syntax errors or obvious logic bugs. The agent follows the debug skill checklist step-by-step without skipping, producing a bug audit log and a verified fix.
+The debugger-agent runs systematic debugging following a rigorous checklist-based methodology. It is designed for bugs that are non-obvious, state-dependent, intermittent, or of unknown cause — not simple syntax errors or obvious logic bugs. The agent follows the debug skill checklist step-by-step without skipping, producing a bug audit log, two deterministic commits (red and green test states), and a verified fix.
 
 ## Input
 
@@ -56,34 +56,36 @@ Uses `bug-audit-log-template` to document:
 
 Follows this sequence in strict order:
 
-1. **Write a failing reproduction test**
+1. **5.1: Write a failing reproduction test**
    - Minimal test case that reproduces the bug
    - Arrange inputs per failure conditions
    - Assert expected behavior
    - Confirm test fails (assertion error, not import/syntax error)
 
-2. **Confirm the test fails before any fix**
+2. **5.2: Confirm the test fails before any fix**
    - Run test on unmodified code
    - Verify it fails consistently (not intermittent test failure)
    - Note the failure signature in bug file
+   - **After confirming failure, make the red commit**: stage only the test file(s) and commit with message `"test: <bug-slug> (red)"`
 
-3. **Identify root cause from evidence**
+3. **5.3: Identify root cause from evidence**
    - Examine code paths involved in failure
    - Review logs and stack traces from step 3
    - Form hypothesis about root cause
    - Validate hypothesis against all evidence
 
-4. **Fix the root problem**
+4. **5.4: Fix the root problem**
    - Apply minimal fix targeting identified root cause
    - Do not apply workarounds or papering over symptoms
    - Do not change unrelated code
 
-5. **Confirm the test passes**
+5. **5.5: Confirm the test passes**
    - Run the reproduction test on fixed code
    - Verify it passes consistently
    - Document the fix in bug file
+   - **After confirming pass, make the green commit**: stage only the fix file(s) and commit with message `"fix: <bug-slug>"`
 
-6. **Remove the fix and confirm it fails again** (when safe)
+6. **5.6: Remove the fix and confirm it fails again** (when safe)
    - Revert fix to unmodified code
    - Re-run reproduction test
    - Verify it fails as before (confirms fix actually addresses the issue, not coincidence)
@@ -93,8 +95,18 @@ Follows this sequence in strict order:
 
 Update bug file with:
 - **Root Cause**: Explanation of why the bug occurred (reference code locations)
-- **Fix Summary**: What was changed and why (reference commit or diff)
+- **Fix Summary**: What was changed and why (reference commits)
 - **Verification**: Test name and results confirming the fix
+
+## Commit Sequence
+
+The debugger-agent produces three deterministic commits to the feature branch:
+
+1. **Red commit** (after step 5.2): `"test: <bug-slug> (red)"` — stages only the reproduction test file(s)
+2. **Green commit** (after step 5.5): `"fix: <bug-slug>"` — stages only the fix file(s)
+3. **Docs commit** (SubagentStop hook, after checklist): `"docs: add bug audit log"` — stages the bug audit log and any supporting documentation
+
+This sequence clearly shows the test-first discipline and the minimal scope of each fix.
 
 ## Brain Patch Output
 
@@ -115,11 +127,12 @@ Resolves WORK_DIR (see rule 7) and writes `$WORK_DIR/brain-patch.json`:
 1. **Follow the checklist in strict order** — Do not skip steps; each step validates the previous one
 2. **Read all evidence before coding** — Understand the bug completely before touching code
 3. **Write tests before fixing** — Test-first ensures the fix is actually necessary
-4. **Verify fix is necessary** — Remove fix and confirm test fails again (except when unsafe)
-5. **Do NOT read brain.json** — Context is already injected by pre-hook
-6. **Do NOT write brain.json directly** — Only write brain-patch.json
-7. **Resolve WORK_DIR via pointer file fallback** — Use `$DARK_FACTORY_WORK_DIR` if set; else read contents of `/tmp/dark-factory-work-dir`; skip brain-patch silently if both are empty
-8. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
+4. **Make red and green commits** — Commit the test after step 5.2 (before fix) and the fix after step 5.5 (after test passes)
+5. **Verify fix is necessary** — Remove fix and confirm test fails again (except when unsafe)
+6. **Do NOT read brain.json** — Context is already injected by pre-hook
+7. **Do NOT write brain.json directly** — Only write brain-patch.json
+8. **Resolve WORK_DIR via pointer file fallback** — Use `$DARK_FACTORY_WORK_DIR` if set; else read contents of `/tmp/dark-factory-work-dir`; skip brain-patch silently if both are empty
+9. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
 
 ## Dependencies
 
@@ -128,7 +141,7 @@ Resolves WORK_DIR (see rule 7) and writes `$WORK_DIR/brain-patch.json`:
 
 ## Tools
 
-- Read, Write, Edit, Bash, Glob, Agent
+- Read, Write, Bash, Glob, Agent, Skill
 
 ## Allowed Bash Commands
 
@@ -151,9 +164,18 @@ The agent declares a `SubagentStop` hook in its YAML frontmatter:
 SubagentStop: "${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/commit-on-subagent-stop.sh"
 ```
 
-When the agent finishes, this hook fires and commits all staged changes in the feature worktree with commit message `"docs: add bug audit log"`. This ensures bug audit log files are committed as a discrete step in the manufacture commit sequence.
+When the agent finishes (after step 5.6 and root cause documentation), this hook fires and commits all staged changes in the feature worktree with commit message `"docs: add bug audit log"`. This is the third and final commit in the sequence, after the red and green commits created in steps 5.2 and 5.5.
 
 ## Artifacts Produced
 
-- `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` — Bug audit log (persisted in repository)
-- `$DARK_FACTORY_WORK_DIR/brain-patch.json` — Metadata linking to bug files
+The debugger-agent produces the following artifacts on the feature branch:
+
+1. **Test file(s)** — Reproduction test(s) for the bug (committed in red commit)
+2. **Fix file(s)** — Fixed source code (committed in green commit)
+3. **Bug audit log** — `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` — Full documentation of the bug, root cause, fix, and verification (committed in docs commit via SubagentStop hook)
+4. **Brain patch** — `$DARK_FACTORY_WORK_DIR/brain-patch.json` — Metadata linking to bug files (consumed by dark-factory-agent, not committed directly)
+
+The three commits in order are:
+- `test: <bug-slug> (red)` — test file(s) only
+- `fix: <bug-slug>` — source fix file(s) only
+- `docs: add bug audit log` — bug audit log and supporting docs


### PR DESCRIPTION
## Summary

This PR refactors the monolithic debugger-agent into a clean 3-agent orchestrator pattern with structural commit enforcement via SubagentStop hooks.

### Architecture Changes

**Before**: Single monolithic `debugger-agent` handling all debugging phases (triage, test writing, fix application, verification)

**After**: Three specialized agents with explicit phase separation:
1. **debugger-orchestrator** (haiku) — Entry point, coordinates investigation, triage, and sub-agent sequencing
2. **reproduce-test-agent** (sonnet) — Writes failing reproduction test, stages it, triggers SubagentStop red commit
3. **debugger-fix-agent** (sonnet) — Applies minimal fix, verifies causality, stages files, triggers SubagentStop green commit

### Commit Sequence

The new flow produces two deterministic commits:
1. `test: <bug-slug> (red)` — Reproduction test file(s) from reproduce-test-agent SubagentStop
2. `fix: <bug-slug>` — Source code fix + updated bug audit log from debugger-fix-agent SubagentStop

### Files Changed

**New Agents**:
- `agents/debugger/agents/debugger-orchestrator.md` — Orchestrator coordinating triage and sub-agents
- `agents/debugger/agents/reproduce-test-agent.md` — Test writer with SubagentStop hook
- `agents/debugger/agents/debugger-fix-agent.md` — Bug fixer with SubagentStop hook

**Updated Files**:
- `agents/dark-factory/scripts/commit-on-subagent-stop.sh` — Added cases for new agents with dynamic bug slug injection
- `agents/dark-factory/agents/dark-factory-agent.md` — Route "debugger" classification to debugger-orchestrator
- `docs/docs/debugger-agent.md` — Complete rewrite documenting new 3-agent architecture
- `docs/docs/dark-factory-agent.md` — Updated routing and sub-agents list

### Design Principles

✅ **Separation of Concerns**: Each agent has a single responsibility
✅ **Deterministic Commits**: SubagentStop hooks enforce commit boundaries with dynamic bug slug messages
✅ **Proper State Ownership**: Orchestrator owns brain-patch.json at the end
✅ **Pointer File Pattern**: `/tmp/dark-factory-bug-slug` for inter-process communication
✅ **Full Documentation**: Comprehensive docs covering all phases, tools, and error handling

### Testing Plan

1. Verify all agent files have valid YAML frontmatter ✓
2. Verify routing change in dark-factory-agent.md ✓
3. Verify script updated with new agent cases ✓
4. Verify documentation is complete and accurate ✓
5. (Future) Test with an actual bug scenario to verify full 3-agent flow

### Backward Compatibility

This is a breaking change to the debugger agent internals, but transparent to users:
- Old API: `/dark-factory:manufacture` with a debugger classification
- New API: Same command, same user experience
- Users don't see the internal 3-agent refactoring

### Key Design Decisions

1. **Haiku Orchestrator**: Cost reduction and clear separation of coordination from implementation
2. **Pointer File for Bug Slug**: Enables dynamic commit messages without complex state passing
3. **Sub-agent Staging Only**: Each agent stages only its own work before SubagentStop
4. **Orchestrator Brain-Patch Ownership**: Clean state management pattern following dark-factory conventions