### PR TITLE
feat(manufacture): add PR reuse feature with fuzzy matching

### DIFF
--- a/agents/dark-factory/scripts/find-related-pr.sh
+++ b/agents/dark-factory/scripts/find-related-pr.sh
@@ -9,14 +9,31 @@ taskDescription="$1"
 keywords=$(echo "$taskDescription" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9 ' ' ' | tr -s ' ')
 
 # Fetch all open PRs with title, headRefName, url
+# If gh exits non-zero (auth error, network error), bail silently
 prs=$(gh pr list --state open --limit 50 --json title,headRefName,url 2>/dev/null) || exit 0
+
+# Guard: if output is empty or not a JSON array, exit silently instead of letting
+# json.load raise JSONDecodeError on an empty/partial string.
+if [ -z "$prs" ] || [ "$prs" = "null" ]; then
+  exit 0
+fi
+
+# Pass keywords safely via environment variable to avoid shell-injection through
+# triple-quote delimiters inside the python3 -c string.
+export _DF_KEYWORDS="$keywords"
 
 # For each PR: score = count of keyword hits in (title + branchName)
 # Select best match if score >= 2 keywords match
 best=$(echo "$prs" | python3 -c "
-import sys, json, re
-data = json.load(sys.stdin)
-keywords = set(\"\"\"$keywords\"\"\".split())
+import sys, json, os
+raw = sys.stdin.read().strip()
+if not raw:
+    sys.exit(0)
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    sys.exit(0)
+keywords = set(os.environ.get('_DF_KEYWORDS', '').split())
 best = None
 best_score = 0
 for pr in data:

--- a/agents/dark-factory/scripts/find-related-pr.sh
+++ b/agents/dark-factory/scripts/find-related-pr.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# find-related-pr.sh - Fuzzy-match taskDescription against open PR titles/branch names
+# Usage: find-related-pr.sh <taskDescription>
+# Output: BRANCH=<branch> URL=<url> TITLE=<title>  OR  empty on no match
+
+taskDescription="$1"
+
+# Normalize to lowercase keywords, strip punctuation
+keywords=$(echo "$taskDescription" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9 ' ' ' | tr -s ' ')
+
+# Fetch all open PRs with title, headRefName, url
+prs=$(gh pr list --state open --limit 50 --json title,headRefName,url 2>/dev/null) || exit 0
+
+# For each PR: score = count of keyword hits in (title + branchName)
+# Select best match if score >= 2 keywords match
+best=$(echo "$prs" | python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+keywords = set(\"\"\"$keywords\"\"\".split())
+best = None
+best_score = 0
+for pr in data:
+    candidate = (pr['title'] + ' ' + pr['headRefName']).lower()
+    score = sum(1 for kw in keywords if kw in candidate and len(kw) > 2)
+    if score >= 2 and score > best_score:
+        best_score = score
+        best = pr
+if best:
+    print(f\"BRANCH={best['headRefName']}\")
+    print(f\"URL={best['url']}\")
+    print(f\"TITLE={best['title']}\")
+")
+
+echo "$best"

--- a/brain-patch.json
+++ b/brain-patch.json
@@ -1,0 +1,8 @@
+{
+  "artifacts": {
+    "created": ["/home/lewibs/github/dark_factory/dark_factory-pr-reuse-existing/agents/dark-factory/scripts/find-related-pr.sh"],
+    "modified": ["/home/lewibs/github/dark_factory/dark_factory-pr-reuse-existing/commands/manufacture.md"]
+  },
+  "skillsWritten": ["skills/gpu-readiness-debugging/SKILL.md"],
+  "summary": "Implemented PR reuse feature: added find-related-pr.sh script for fuzzy-matching task descriptions against open PRs, and modified manufacture.md Step 2 to check for related PRs before creating new branches. Users can now reuse existing branches for related tasks."
+}

--- a/brain-patch.json
+++ b/brain-patch.json
@@ -1,8 +1,4 @@
 {
-  "artifacts": {
-    "created": ["/home/lewibs/github/dark_factory/dark_factory-pr-reuse-existing/agents/dark-factory/scripts/find-related-pr.sh"],
-    "modified": ["/home/lewibs/github/dark_factory/dark_factory-pr-reuse-existing/commands/manufacture.md"]
-  },
-  "skillsWritten": ["skills/gpu-readiness-debugging/SKILL.md"],
-  "summary": "Implemented PR reuse feature: added find-related-pr.sh script for fuzzy-matching task descriptions against open PRs, and modified manufacture.md Step 2 to check for related PRs before creating new branches. Users can now reuse existing branches for related tasks."
+  "skillsWritten": ["skills/fuzzy-match-open-prs/SKILL.md", "skills/branch-prefix-strip-for-taskname/SKILL.md"],
+  "summary": "Extracted 2 patterns: fuzzy-matching open PRs by keyword scoring to detect reuse opportunities, and stripping branch prefixes before using branch names as taskName slugs"
 }

--- a/brain.json
+++ b/brain.json
@@ -1,19 +1,14 @@
 {
-  "taskDescription": "figure out why dark-factory did not use the agent like it was supposed to when invoked inside another session and fix it. Claude invoked /dark-factory:manufacture via the Skill tool, dark-factory-agent.md was not found at the expected path so it delegated directly to the subagent. After PR #423 was opened, the merge was handled manually rather than routing through dark-factory's PR lifecycle tooling (pr-agent, ci-watch-runner, comment-resolution-runner).",
-  "taskName": "fix-agent-flow-deviation",
-  "workDir": "/home/lewibs/github/dark_factory/dark_factory-fix-agent-flow-deviation",
+  "taskDescription": "When manufacture sets up a worktree near the start of a run, check open GitHub PRs for a related one by fuzzy-matching the task description against existing PR titles and branch names. If a likely match is found, ask the user to confirm before reusing that branch in the worktree instead of creating a new feature branch. If confirmed, check out the existing branch so that pr-agent existing Step 0b detection will push new commits to the existing PR rather than opening a new one. If no match is found or the user declines, proceed with the normal new-branch flow.",
+  "taskName": "pr-reuse-existing",
+  "workDir": "/home/lewibs/github/dark_factory/dark_factory-pr-reuse-existing",
   "projectDir": "/home/lewibs/github/dark_factory/dark_factory",
-  "classification": "debugger",
-  "planFilePath": null,
-  "bugFiles": [
-    "/home/lewibs/github/dark_factory/dark_factory-fix-agent-flow-deviation/docs/bugs/2026-05-08-agent-flow-deviation-nested-session.md"
-  ],
+  "classification": "feature",
+  "planFilePath": "/home/lewibs/github/dark_factory/dark_factory-pr-reuse-existing/docs/plans/2026-05-09-pr-reuse-existing.md",
+  "bugFiles": null,
   "prUrl": null,
   "docsWritten": null,
-  "skillsWritten": [
-    "skills/plugin-root-script-paths/SKILL.md",
-    "skills/pr-agent-does-not-merge/SKILL.md"
-  ],
+  "skillsWritten": null,
   "artifacts": {
     "created": [],
     "modified": []
@@ -34,28 +29,10 @@
     "cleanup-running": false,
     "cleanup-complete": false
   },
-  "notes": [
-    "debugger-agent: root cause was (1) bare relative path in commands/manufacture.md fails when CWD != plugin root in nested sessions, (2) create-pr/SKILL.md description 'through to merge' and missing no-merge rule allowed PR lifecycle bypass, fixed in commands/manufacture.md, skills/create-pr/SKILL.md, agents/dark-factory/agents/dark-factory-agent.md"
-  ],
+  "notes": [],
   "metrics": {
-    "dark-factory:code-review:agents:code-review-orchestrator-agent": {
-      "elapsed_ms": 45912,
-      "tokens": 1083,
-      "runs": 2
-    },
-    "dark-factory:documentation:agents:update-documentation-agent": {
-      "elapsed_ms": 74221,
-      "tokens": 280,
-      "runs": 2
-    },
-    "dark-factory:skill-update:agents:skill-update-agent": {
-      "elapsed_ms": 2421,
-      "tokens": 236,
-      "runs": 2
-    },
-    "dark-factory:pr:agents:pr-agent": {
-      "start_ms": 1778229637156
+    "execution-agent": {
+      "start_ms": 1778357448191
     }
-  },
-  "summary": "Extended plugin-root-script-paths skill to cover agent .md file references in command files (not just script paths); updated pr-agent-does-not-merge skill to note the FORBIDDEN rule enforcement in dark-factory-agent.md"
+  }
 }

--- a/commands/manufacture.md
+++ b/commands/manufacture.md
@@ -58,10 +58,45 @@ manufacture(taskDescription, taskName):
   
   If PLUGIN_ROOT is empty: report "Failed to resolve dark-factory plugin root. Checked installed_plugins.json at ~/.claude/plugins/installed_plugins.json using key 'dark-factory@dark-factory'. Ensure the plugin is installed by running /dark-factory:install." and STOP
 
-  prepOutput = bash("\"$PLUGIN_ROOT/agents/dark-factory/scripts/prep-feature-dir.sh\" <taskName>")
-  WORK_DIR = extract WORK_DIR=<value> line from prepOutput
+  # NEW: check for related open PR before creating a new branch
+  relatedPrOutput = bash("\"$PLUGIN_ROOT/agents/dark-factory/scripts/find-related-pr.sh\" \"$taskDescription\"") || ""
+  EXISTING_BRANCH = extract BRANCH=<value> from relatedPrOutput  (or empty)
+  EXISTING_URL    = extract URL=<value>    from relatedPrOutput  (or empty)
+  EXISTING_TITLE  = extract TITLE=<value>  from relatedPrOutput (or empty)
 
-  If script fails: report error and STOP (worktree was never created)
+  if EXISTING_BRANCH is not empty:
+    answer = AskUserQuestion(
+      header: "Reuse Existing PR?",
+      question: "Found a related open PR that may match your task.\n\nPR: \"" + EXISTING_TITLE + "\"\nBranch: " + EXISTING_BRANCH + "\nURL: " + EXISTING_URL + "\n\nReuse this branch (new commits will be pushed to the existing PR) or create a fresh branch?",
+      options: ["Reuse existing branch", "Create new branch"]
+    )
+    if answer == "Reuse existing branch":
+      USE_EXISTING = true
+    else:
+      USE_EXISTING = false
+  else:
+    USE_EXISTING = false
+
+  if USE_EXISTING:
+    # Derive WORK_DIR path (mirrors prep-feature-dir.sh naming convention)
+    GIT_ROOT = PROJECT_DIR
+    PROJECT_NAME = basename(GIT_ROOT)
+    # EXISTING_BRANCH is e.g. "feature/add-oauth"; taskName for worktree dir is the slug after "feature/"
+    existingTaskName = EXISTING_BRANCH after stripping leading "feature/"
+    WORKTREE_NAME = PROJECT_NAME + "-" + existingTaskName
+    WORK_DIR = GIT_ROOT + "/../" + WORKTREE_NAME
+
+    # Check if worktree already exists for this branch
+    worktreeExists = bash("git -C \"$GIT_ROOT\" worktree list | grep -qF \"$WORKTREE_NAME\" && echo yes || echo no")
+    if worktreeExists == "no":
+      bash("git -C \"$GIT_ROOT\" pull origin main || true")
+      bash("git -C \"$GIT_ROOT\" worktree add \"$WORK_DIR\" \"$EXISTING_BRANCH\"")
+    # taskName for brain.json should reflect the existing branch slug
+    taskName = existingTaskName
+  else:
+    prepOutput = bash("\"$PLUGIN_ROOT/agents/dark-factory/scripts/prep-feature-dir.sh\" \"$taskName\"")
+    WORK_DIR = extract WORK_DIR=<value> line from prepOutput
+    If script fails: report error and STOP
 
   # Step 3 — create brain.json (delegate to brain-state-manager skill)
   invoke brain-state-manager({

--- a/commands/manufacture.md
+++ b/commands/manufacture.md
@@ -2,8 +2,8 @@
 description: "Top-level dark-factory orchestrator. Preps an isolated work dir, routes to the right worker agent (feature/fix-flow/debugger/repair), runs code review and doc housekeeping, opens a PR, then removes the work dir. Delegates state management to brain-state-manager."
 tools: Read, Bash, Agent, PushNotification, AskUserQuestion, Skill, SendMessage
 model: haiku
-scripts: ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh, ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh
-allowed-tools: Bash(*/agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(*/agents/dark-factory/scripts/cleanup-worktree.sh *), Bash(python3 */scripts/update-metrics.py *), Bash(python3 -c *installed_plugins.json*), Bash(git -C * log *), Bash(git -C * add *), Bash(git -C * diff *), Bash(git -C * commit *), Bash(git -C * push *), Bash(cp *), Bash(git rev-parse *), Bash(rm -f /tmp/dark-factory-work-dir)
+scripts: ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh, ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh, ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/find-related-pr.sh
+allowed-tools: Bash(*/agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(*/agents/dark-factory/scripts/cleanup-worktree.sh *), Bash(*/agents/dark-factory/scripts/find-related-pr.sh *), Bash(python3 */scripts/update-metrics.py *), Bash(python3 -c *installed_plugins.json*), Bash(git -C * log *), Bash(git -C * add *), Bash(git -C * diff *), Bash(git -C * commit *), Bash(git -C * push *), Bash(cp *), Bash(git rev-parse *), Bash(rm -f /tmp/dark-factory-work-dir)
 skills: task-classifier, brain-state-manager
 ---
 
@@ -22,7 +22,7 @@ If `taskName` is not provided, derive a short slug from `taskDescription` (lower
 CRITICAL: Execute all steps sequentially without stopping between them.
 - Do NOT output partial results and wait for user input between steps.
 - Do NOT stop after classification, prep, brain creation, or any individual step.
-- The ONLY valid reason to pause is the AskUserQuestion call in Step 1 (ambiguous classification).
+- The ONLY valid reasons to pause are: (a) the AskUserQuestion call in Step 1 (ambiguous classification), and (b) the AskUserQuestion call in Step 2 (PR reuse confirmation when a related open PR is found).
 - All other steps must execute continuously from Step 1 through Step 12 without interruption.
 - After completing each step, immediately proceed to the next step without outputting intermediate summaries.
 
@@ -81,16 +81,26 @@ manufacture(taskDescription, taskName):
     # Derive WORK_DIR path (mirrors prep-feature-dir.sh naming convention)
     GIT_ROOT = PROJECT_DIR
     PROJECT_NAME = basename(GIT_ROOT)
-    # EXISTING_BRANCH is e.g. "feature/add-oauth"; taskName for worktree dir is the slug after "feature/"
-    existingTaskName = EXISTING_BRANCH after stripping leading "feature/"
+    # EXISTING_BRANCH may be "feature/add-oauth", "bugfix/foo", "user/bar", or "plain-slug".
+    # Strip any leading "<prefix>/" so that existingTaskName is always a plain slug with no slashes.
+    # This prevents downstream consumers (brain-state-manager, cleanup-worktree.sh) from receiving
+    # a taskName that contains "/" characters.
+    existingTaskName = EXISTING_BRANCH after stripping leading "<anything>/" prefix (i.e. remove up to and including the first "/" if one is present, otherwise use EXISTING_BRANCH as-is)
     WORKTREE_NAME = PROJECT_NAME + "-" + existingTaskName
     WORK_DIR = GIT_ROOT + "/../" + WORKTREE_NAME
 
     # Check if worktree already exists for this branch
-    worktreeExists = bash("git -C \"$GIT_ROOT\" worktree list | grep -qF \"$WORKTREE_NAME\" && echo yes || echo no")
+    worktreeExists = bash("git -C \"$GIT_ROOT\" worktree list | grep -qE \"(^|/)$WORKTREE_NAME( |$)\" && echo yes || echo no")
     if worktreeExists == "no":
       bash("git -C \"$GIT_ROOT\" pull origin main || true")
       bash("git -C \"$GIT_ROOT\" worktree add \"$WORK_DIR\" \"$EXISTING_BRANCH\"")
+    else:
+      # Worktree already exists — verify the checked-out branch matches EXISTING_BRANCH
+      # to guard against a corrupted or mismatched worktree silently landing commits on the wrong branch
+      actualBranch = bash("git -C \"$WORK_DIR\" rev-parse --abbrev-ref HEAD 2>/dev/null || echo ''")
+      if actualBranch != EXISTING_BRANCH:
+        report error: "Worktree at " + WORK_DIR + " exists but is checked out on '" + actualBranch + "' instead of expected '" + EXISTING_BRANCH + "'. Remove the worktree manually and retry."
+        STOP
     # taskName for brain.json should reflect the existing branch slug
     taskName = existingTaskName
   else:
@@ -156,13 +166,16 @@ manufacture(taskDescription, taskName):
       report error and STOP
 
   # Step 5 — branch-drift guard
-  driftCheck = bash("git -C \"$WORK_DIR\" log main..feature/" + taskName + " --oneline")
+  # Use EXISTING_BRANCH when reusing an existing PR branch (it may not follow the "feature/" prefix),
+  # otherwise construct the expected ref as "feature/<taskName>".
+  branchRef = USE_EXISTING ? EXISTING_BRANCH : ("feature/" + taskName)
+  driftCheck = bash("git -C \"$WORK_DIR\" log main.." + branchRef + " --oneline")
   if driftCheck is empty:
     # Collect diagnostic information before cleanup
     worktreeLog = bash("git -C \"$WORK_DIR\" log --oneline -5")
     worktreeStatus = bash("git -C \"$WORK_DIR\" status")
     run cleanup(WORK_DIR, taskName)
-    report error: "Branch-drift guard failed: feature/" + taskName + " has no commits ahead of main.\nWorktree log (last 5):\n" + worktreeLog + "\nWorktree status:\n" + worktreeStatus
+    report error: "Branch-drift guard failed: " + branchRef + " has no commits ahead of main.\nWorktree log (last 5):\n" + worktreeLog + "\nWorktree status:\n" + worktreeStatus
     STOP
 
   # Step 6 — read planFilePath from brain.json
@@ -232,12 +245,9 @@ Called on error or after feature-agent completes.
 ```
 invoke brain-state-manager({ operation: "delete", workDir: WORK_DIR })
 bash("rm -f /tmp/dark-factory-work-dir")
-# Resolve plugin root with explicit dark-factory plugin lookup (CLAUDE_PLUGIN_ROOT not available in Bash subprocesses)
-PLUGIN_ROOT = bash("python3 -c \"import json,os,sys; d=json.load(open(os.path.expanduser('~/.claude/plugins/installed_plugins.json'))); p=d['plugins'].get('dark-factory@dark-factory',[{}]); print(p[0].get('installPath','') if p else '')\"")
-if PLUGIN_ROOT is empty:
-    # Fallback: try to extract from 'claude plugins list' output
-    PLUGIN_ROOT = bash("claude plugins list 2>/dev/null | grep dark-factory | awk '{print $NF}' || true")
-  if PLUGIN_ROOT is empty: report "Failed to resolve dark-factory plugin root. Checked installed_plugins.json at ~/.claude/plugins/installed_plugins.json using key 'dark-factory@dark-factory'. Ensure the plugin is installed by running /dark-factory:install." and return
+# PLUGIN_ROOT was already resolved in Step 2 — reuse it here. Do NOT re-resolve from
+# installed_plugins.json; that would duplicate resolution logic and allow the two values to diverge.
+if PLUGIN_ROOT is empty: report "Failed to resolve dark-factory plugin root (was not set in Step 2). Ensure the plugin is installed by running /dark-factory:install." and return
 bash("\"$PLUGIN_ROOT/agents/dark-factory/scripts/cleanup-worktree.sh\" \"$WORK_DIR\" \"$taskName\"")
 ```
 

--- a/docs/docs/find-related-pr.md
+++ b/docs/docs/find-related-pr.md
@@ -1,0 +1,120 @@
+# find-related-pr
+
+## Metadata
+
+- System type: `library`
+
+## System Intent
+
+- What this is: A bash script that fuzzy-matches a task description against all open GitHub PRs (title + branch name) and emits structured key=value output identifying the best match. Consumed by `dark-factory-agent` Step 2 to offer PR reuse before creating a new branch.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  In["find-related-pr.sh\ntaskDescription (arg 1)"] --> Norm["Normalize: lowercase\nstrip punctuation → keywords"]
+  Norm --> GH["gh pr list --state open\n--limit 50 --json title,headRefName,url"]
+  GH -->|"gh error / empty"| Out_Empty["exit 0 (empty stdout)"]
+  GH -->|"JSON array"| Score["python3: score each PR\n(keyword hits in title + branchName)"]
+  Score -->|"best score >= 2"| Out_Match["stdout:\nBRANCH=...\nURL=...\nTITLE=..."]
+  Score -->|"no score >= 2"| Out_Empty
+```
+
+## Flows
+
+### Flow: `findRelatedPr.match`
+
+- Test files: `N/A`
+- Core files: `agents/dark-factory/scripts/find-related-pr.sh`
+
+#### Types
+
+```txt
+FindRelatedPrInput {
+  taskDescription: string (required — verbatim user task request, passed as $1)
+}
+
+PRMatch {
+  branchName: string   (e.g. "feature/add-oauth")
+  prUrl: string        (e.g. "https://github.com/org/repo/pull/42")
+  prTitle: string      (human-readable title of the matched PR)
+}
+
+FindRelatedPrOutput {
+  stdout: "BRANCH=<branchName>\nURL=<prUrl>\nTITLE=<prTitle>"  (on match)
+       | ""                                                      (on no match)
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `findRelatedPr.match.found` | `FindRelatedPrInput` | stdout with BRANCH/URL/TITLE lines | happy path | best score >= 2 keyword hits (each keyword length > 2) |
+| `findRelatedPr.match.none` | `FindRelatedPrInput` | empty stdout | alternate | no PR reached threshold; caller treats as no-match |
+| `findRelatedPr.match.gh-error` | `FindRelatedPrInput` | empty stdout, exit 0 | alternate | gh CLI unavailable or auth failure; `2>/dev/null \|\| exit 0` silences error |
+| `findRelatedPr.match.empty-list` | `FindRelatedPrInput` | empty stdout, exit 0 | alternate | repo has no open PRs; early exit guards against JSON parse error |
+| `findRelatedPr.match.json-error` | `FindRelatedPrInput` | empty stdout, exit 0 | alternate | malformed JSON from gh; python3 catches JSONDecodeError and exits 0 |
+
+#### Pseudocode
+
+```
+# find-related-pr.sh <taskDescription>
+
+taskDescription="$1"
+
+# Normalize: lowercase, strip non-alphanumeric (except spaces), collapse spaces
+keywords=$(echo "$taskDescription" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9 ' ' ' | tr -s ' ')
+
+# Fetch up to 50 open PRs; bail silently on gh error
+prs=$(gh pr list --state open --limit 50 --json title,headRefName,url 2>/dev/null) || exit 0
+
+# Guard against empty or null response before handing to python3
+if [ -z "$prs" ] || [ "$prs" = "null" ]; then exit 0; fi
+
+# Pass keywords via env var (not inline string) to avoid shell injection
+export _DF_KEYWORDS="$keywords"
+
+# Score each PR: count keyword hits in (title + headRefName), lowercase
+# Select the PR with the highest score if score >= 2 and each matching keyword is > 2 chars
+best=$(echo "$prs" | python3 -c "
+import sys, json, os
+raw = sys.stdin.read().strip()
+if not raw:
+    sys.exit(0)
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    sys.exit(0)
+keywords = set(os.environ.get('_DF_KEYWORDS', '').split())
+best = None
+best_score = 0
+for pr in data:
+    candidate = (pr['title'] + ' ' + pr['headRefName']).lower()
+    score = sum(1 for kw in keywords if kw in candidate and len(kw) > 2)
+    if score >= 2 and score > best_score:
+        best_score = score
+        best = pr
+if best:
+    print(f\"BRANCH={best['headRefName']}\")
+    print(f\"URL={best['url']}\")
+    print(f\"TITLE={best['title']}\")
+")
+
+echo "$best"
+```
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| find-related-pr.sh | stderr only (suppressed via `2>/dev/null`); stdout is machine-parseable key=value pairs |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  /dark-factory:install
+  ```
+- Notes: Requires `gh` CLI authenticated to the target repository. The script is invoked by `dark-factory-agent` Step 2 with the raw `taskDescription` as argument 1. The fuzzy-match threshold (score >= 2, keyword length > 2) can be tuned in the script without touching `commands/manufacture.md`. The script always exits 0 — errors are treated as no-match to keep the manufacture pipeline non-blocking.

--- a/docs/docs/manufacture-documentation-skill-agents.md
+++ b/docs/docs/manufacture-documentation-skill-agents.md
@@ -1,0 +1,109 @@
+# manufacture-documentation-skill-agents
+
+## Metadata
+
+- System type: `flow`
+
+## System Intent
+
+- What this is: The manufacture pipeline always runs `update-documentation-agent` (Step 8) and `skill-update-agent` (Step 9) on every successful manufacture task, regardless of the classification route (feature, fix-flow, debugger, repair) or the scope of the change. There is no conditional gate that skips them for small or trivial changes.
+
+## How update-documentation-agent is invoked
+
+`update-documentation-agent` is invoked unconditionally at Step 8 of `manufacture.md`, immediately after code review succeeds:
+
+```
+# Step 8 — update docs (must complete before PR)
+invoke update-documentation-agent({ planFilePath, workDir: WORK_DIR })
+```
+
+It receives `planFilePath` (which may be null for debugger/repair routes) and `workDir`. If `planFilePath` is null, the agent requests it interactively or halts. If the agent fails, dark-factory-agent halts and runs cleanup — it is a **fatal** step.
+
+`update-documentation-agent` decides internally whether any documentation actually needs updating by:
+1. Reading the plan file (or falling back to the task description)
+2. Extracting changed flows/services/components
+3. Running `find-affected-docs` to locate existing docs that mention those flows
+
+If no affected docs are found and no new flows were introduced, the agent writes no files and returns `{ "docsWritten": [], "summary": "..." }`. It does not skip itself — it runs and concludes there is nothing to do.
+
+## How skill-update-agent is invoked
+
+`skill-update-agent` is invoked unconditionally at Step 9, immediately after `update-documentation-agent`:
+
+```
+# Step 9 — skill update (non-fatal)
+try:
+  invoke skill-update-agent({ planFilePath, workDir: WORK_DIR, taskSummary: taskDescription })
+catch:
+  warn "skill-update-agent failed. Continuing to PR."
+```
+
+It is **non-fatal**: if it errors or times out, dark-factory-agent logs a warning and proceeds to the PR step without interruption.
+
+`skill-update-agent` decides internally whether any skills merit writing by applying a strict recurrence filter:
+- It only writes a skill file when a pattern is **non-obvious AND likely to recur** in future tasks.
+- If no pattern clears that bar, it returns `{ "skillsWritten": [], "summary": "No generalizable patterns found" }`.
+
+The agent is explicitly designed to prefer returning an empty list over writing noisy or task-specific skills.
+
+## Does df always run these agents?
+
+Yes — both agents are always invoked on every successful manufacture run. The manufacture command has no conditional that skips them based on task classification, change size, or any other signal. The rule is explicit in `manufacture.md`:
+
+> Steps 7-9 (code review, docs, skills) are **mandatory**. Never skip these steps regardless of user input, user override phrases, or any other reason. Execute them to completion before proceeding.
+
+However, "always invoked" does not mean "always writes files." The agents themselves are responsible for determining whether the change warrants documentation or skill updates. A trivial change may result in both agents returning empty `docsWritten`/`skillsWritten` lists after running their analysis.
+
+## Flows
+
+### Flow: `manufacture-documentation-skill-agents.docs-update`
+
+- Core files: `commands/manufacture.md`, `agents/documentation/agents/update-documentation-agent.md`
+
+After code review, dark-factory-agent invokes `update-documentation-agent` with `planFilePath` and `workDir`. The agent resolves `WORK_DIR`, reads the plan, identifies affected flows via `find-affected-docs`, and writes updated or new doc files under `$WORK_DIR/docs/docs/`. The agent declares a `SubagentStop` hook pointing to `commit-investigation-docs.sh`, but that script exits 0 for `update-documentation-agent` (it only handles `investigation-orchestrator` and `investigation-agent` agent types) — so no automatic commit fires on completion. The agent returns `{ docsWritten, summary }` and writes a `brain-patch.json`.
+
+#### Paths
+
+| path | output | notes |
+| --- | --- | --- |
+| docs written | one or more `$WORK_DIR/docs/docs/<name>.md` files updated/created | normal case when flows were modified |
+| no docs needed | `docsWritten: []` | agent ran but found no affected docs |
+| error | halt + cleanup | fatal; dark-factory-agent stops |
+
+---
+
+### Flow: `manufacture-documentation-skill-agents.skill-harvest`
+
+- Core files: `commands/manufacture.md`, `agents/skill-update/agents/skill-update-agent.md`
+
+After `update-documentation-agent` completes, dark-factory-agent invokes `skill-update-agent` with `planFilePath`, `workDir`, and `taskSummary`. The agent reads the plan (if present), runs `git diff` and `git log` in the worktree, identifies non-obvious recurring patterns, filters them, and writes skill files to `$WORK_DIR/skills/<slug>/SKILL.md`. A `SubagentStop` hook fires `commit-on-subagent-stop.sh`, which commits staged changes with message `"chore: update skills"`. Returns `{ skillsWritten, summary }`.
+
+#### Paths
+
+| path | output | notes |
+| --- | --- | --- |
+| skills written | one or more `$WORK_DIR/skills/<slug>/SKILL.md` files | new or merged into existing |
+| no skills needed | `skillsWritten: []` | preferred outcome for routine changes |
+| error | warning logged, pipeline continues | non-fatal |
+
+## Failure Points
+
+### F1: update-documentation-agent writes to main repo (not WORK_DIR)
+- If `workDir` is not passed or WORK_DIR resolution fails, the agent halts immediately rather than falling back to CWD.
+- Effect: Manufacture halts with an error before any doc files are written.
+
+### F2: update-documentation-agent is fatal — blocks PR
+- Unlike skill-update-agent, docs update is a blocking step. Any error (unreadable plan, find-affected-docs failure, write failure) halts the pipeline and runs cleanup.
+- Effect: PR is never opened; worktree is deleted.
+
+### F3: update-documentation-agent SubagentStop hook is a no-op
+- `update-documentation-agent` declares `commit-investigation-docs.sh` as its SubagentStop hook, but that script only handles `investigation-orchestrator` and `investigation-agent` agent types and exits 0 for all others. Doc writes made by this agent are not automatically committed by a hook.
+- Effect: Documentation files written to `$WORK_DIR/docs/docs/` may not be committed unless the agent or downstream step stages and commits them explicitly.
+
+### F4: skill-update-agent noise accumulation
+- If the recurrence filter is applied loosely, task-specific patterns accumulate in `skills/`, creating maintenance debt.
+- Effect: Future agents load irrelevant skill context, increasing noise.
+
+### F5: skill-update-agent times out on large diffs
+- `git diff HEAD~1` on large diffs combined with heavy Sonnet reasoning can exceed the agent's context or time budget.
+- Effect: Non-fatal; pipeline continues to PR. Skills for that run are not harvested.

--- a/docs/docs/manufacture.md
+++ b/docs/docs/manufacture.md
@@ -19,7 +19,15 @@ flowchart TD
   DFA -->|"invoke skill"| TC["task-classifier\n(skill)"]
   TC -->|"classification: feature | fix-flow | debugger | repair"| DFA
 
-  DFA -->|"prep-feature-dir.sh"| WT["isolated git worktree\n(feature/taskName branch)"]
+  DFA -->|"find-related-pr.sh"| FindPR{"Related open PR\nfound?"}
+  FindPR -->|"yes"| AskUser["AskUserQuestion\n(Reuse or New?)"]
+  AskUser -->|"Reuse existing branch"| CheckoutWT["git worktree add\nexisting branch"]
+  AskUser -->|"Create new branch"| PrepNew["prep-feature-dir.sh\nnew branch"]
+  FindPR -->|"no"| PrepNew
+
+  CheckoutWT --> Brain
+  PrepNew -->|"prep-feature-dir.sh"| WT["isolated git worktree\n(feature/taskName branch)"]
+  WT --> Brain
   DFA -->|"brain-state-manager: create"| Brain["brain.json\n(shared state)"]
 
   DFA -->|"classification == feature"| FA["feature-agent\n(haiku orchestrator)"]
@@ -54,6 +62,28 @@ flowchart TD
 ```
 
 ## Flows
+
+### Flow: `manufacture.prReuseCheck`
+
+- Core files: `commands/manufacture.md`, `agents/dark-factory/scripts/find-related-pr.sh`
+
+Before creating a new branch, Step 2 of `dark-factory-agent` runs `find-related-pr.sh` with `taskDescription` as input. The script fuzzy-matches the description against all open PRs (title + branch name) via `gh pr list`. If a match is found (score >= 2 keyword hits, each keyword > 2 chars), the user is prompted via `AskUserQuestion` to reuse the existing branch or create a fresh one.
+
+If the user selects "Reuse existing branch," `dark-factory-agent` computes the worktree path from the existing branch name (stripping any `<prefix>/` leading segment), then either attaches the existing worktree or creates a new one via `git worktree add`. It validates that if the worktree already exists, its checked-out branch matches `EXISTING_BRANCH`. The `taskName` is set to the slug portion of the existing branch for brain.json and cleanup. `pr-agent` Step 0b detects the existing PR automatically via branch presence, so no special pr-agent configuration is required.
+
+If no match is found, or the `gh` CLI errors, or the user selects "Create new branch," the flow falls through to `prep-feature-dir.sh` unchanged.
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `manufacture.prReuseCheck.match-confirmed` | `taskDescription` | worktree on existing branch, WORK_DIR set | happy path | commits pushed to existing PR via pr-agent Step 0b |
+| `manufacture.prReuseCheck.match-declined` | `taskDescription` | prep-feature-dir.sh runs, new branch | alternate | user saw match but chose "Create new branch" |
+| `manufacture.prReuseCheck.no-match` | `taskDescription` | prep-feature-dir.sh runs, new branch | alternate | find-related-pr.sh returned empty |
+| `manufacture.prReuseCheck.worktree-branch-mismatch` | `taskDescription` | error + STOP | error | existing worktree checked out on wrong branch |
+| `manufacture.prReuseCheck.gh-unavailable` | `taskDescription` | prep-feature-dir.sh runs, new branch | alternate | gh CLI error silently treated as no-match |
+
+---
 
 ### Flow: `manufacture.feature`
 
@@ -183,6 +213,14 @@ This allows manufacture to recover from interrupted runs by reusing task names w
 ### F17: Review comments unresolvable (Step 10 / pr-agent Step 4)
 - `comment-resolution-runner` iterates up to 5 times. If reviewer comments require human judgment or code that the agent cannot produce, the runner cannot resolve all threads.
 - Effect: pr-agent returns failure; dark-factory-agent continues to cleanup (PR remains open with unresolved threads).
+
+### F21: PR reuse worktree branch mismatch (Step 2)
+- When a user confirms PR reuse and an existing worktree already exists for the derived `WORKTREE_NAME`, `dark-factory-agent` checks that the worktree's checked-out branch matches `EXISTING_BRANCH`. If they differ (e.g., the worktree was previously used for a different task), the agent stops with an error requiring manual cleanup.
+- Effect: Pipeline halts before brain.json is created; no worktree cleanup needed since it pre-existed.
+
+### F22: find-related-pr.sh false positive (Step 2)
+- The fuzzy matcher requires a score >= 2 keyword hits (each keyword > 2 chars). Short or generic task descriptions (e.g., "fix bug") may match unrelated PRs or fail to match related ones.
+- Effect: User is shown a misleading reuse prompt; declining falls through to new-branch flow without harm. A false negative (no match shown) causes a duplicate branch to be created.
 
 ### F18: Metrics flush failure (Step 12)
 - `update-metrics.py` and the subsequent `git commit/push` are non-fatal (`|| true`). However, if the metrics commit fails, the PR diff will not include updated metrics, and the local `metrics.csv` copy may also fail.

--- a/docs/plans/2026-05-09-pr-reuse-existing.md
+++ b/docs/plans/2026-05-09-pr-reuse-existing.md
@@ -1,0 +1,213 @@
+# PR Reuse Existing Branch
+
+## System Intent
+
+- What is being built: Before manufacture creates a new feature branch, it checks open GitHub PRs for a related one by fuzzy-matching the task description against existing PR titles and branch names. If a match is found, the user is prompted to confirm reuse. If confirmed, the existing branch is checked out in the worktree so pr-agent's Step 0b detection routes commits to the existing PR. If no match or user declines, the normal new-branch flow proceeds unchanged.
+- Primary consumer(s): manufacture command (commands/manufacture.md); indirectly pr-agent via Step 0b existing-PR detection
+- Boundary (black-box scope only): Step 2 of manufacture.md and a new helper script `find-related-pr.sh`. No changes to prep-feature-dir.sh, pr-agent, or brain-state-manager.
+
+## Stage Gate Tracker
+
+- [ ] Stage 1 Mermaid approved
+- [ ] Stage 2 Flows approved
+- [ ] Stage 3 Logs + Deployment approved or skipped
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  In[manufacture Step 2\ntaskDescription + taskName]:::unchanged -->|run| FindPR[find-related-pr.sh\ngh pr list fuzzy match]:::created
+  FindPR -->|match found| AskUser[AskUserQuestion\nconfirm reuse?]:::created
+  FindPR -->|no match| PrepNew[prep-feature-dir.sh\nnew branch flow]:::unchanged
+  AskUser -->|confirmed| CheckoutExisting[git worktree add\nexisting branch]:::created
+  AskUser -->|declined| PrepNew
+  CheckoutExisting -->|WORK_DIR set| Brain[brain-state-manager create\n+ pointer file]:::unchanged
+  PrepNew -->|WORK_DIR set| Brain
+  Brain --> Out[Step 3 onwards\nunchanged]:::unchanged
+
+classDef unchanged fill:#d3d3d3,stroke:#666,stroke-width:1px;
+classDef created fill:#a8e6a3,stroke:#666,stroke-width:1px;
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Flows
+
+- Flow naming rule: ``### Flow: `<flowname>` ``
+- `N/A` for test files means explicit no-test-required waiver (not a missing mapping).
+
+### Global Types
+
+```txt
+StandardError {
+  message: string (human-readable description of what went wrong)
+}
+
+PRMatch {
+  branchName: string   (e.g. "feature/add-oauth")
+  prUrl: string        (e.g. "https://github.com/org/repo/pull/42")
+  prTitle: string      (human-readable title of the matched PR)
+}
+```
+
+### Flow: `relatedPrFoundAndConfirmed`
+
+- Test files: `N/A`
+- Core files: `commands/manufacture.md`, `agents/dark-factory/scripts/find-related-pr.sh`
+
+#### Types
+
+```txt
+FindRelatedPrInput {
+  taskDescription: string (required — verbatim user task request)
+}
+
+FindRelatedPrOutput {
+  match: PRMatch | null
+}
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `relatedPrFoundAndConfirmed.match-confirmed` | `FindRelatedPrInput` | worktree on existing branch, WORK_DIR set | `happy path` | pr-agent Step 0b will detect existing PR and push to it | |
+| `relatedPrFoundAndConfirmed.match-declined` | `FindRelatedPrInput` | falls through to normal new-branch flow | `alternate` | user saw match but declined reuse | |
+| `relatedPrFoundAndConfirmed.no-match` | `FindRelatedPrInput` | falls through to normal new-branch flow | `alternate` | find-related-pr.sh returned empty | |
+| `relatedPrFoundAndConfirmed.script-error` | `FindRelatedPrInput` | `StandardError` | `error` | gh CLI unavailable or repo not found; treat as no-match and proceed | |
+
+#### Pseudocode
+
+```
+# find-related-pr.sh <taskDescription>
+# Outputs: BRANCH=<branch> URL=<url> TITLE=<title>  OR  empty stdout on no match
+
+taskDescription="$1"
+# Normalize to lowercase keywords, strip punctuation
+keywords=$(echo "$taskDescription" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9 ' ' ' | tr -s ' ')
+
+# Fetch all open PRs with title, headRefName, url
+prs=$(gh pr list --state open --limit 50 --json title,headRefName,url 2>/dev/null) || exit 0
+
+# For each PR: score = count of keyword hits in (title + branchName)
+# Select best match if score >= 2 keywords match
+best=$(echo "$prs" | python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+keywords = set(\"\"\"$keywords\"\"\".split())
+best = None
+best_score = 0
+for pr in data:
+    candidate = (pr['title'] + ' ' + pr['headRefName']).lower()
+    score = sum(1 for kw in keywords if kw in candidate and len(kw) > 2)
+    if score >= 2 and score > best_score:
+        best_score = score
+        best = pr
+if best:
+    print(f\"BRANCH={best['headRefName']}\")
+    print(f\"URL={best['url']}\")
+    print(f\"TITLE={best['title']}\")
+")
+
+echo "$best"
+```
+
+```
+# manufacture.md Step 2 (modified):
+
+PROJECT_DIR = bash("git rev-parse --show-toplevel")
+PLUGIN_ROOT = <resolve as before>
+
+# NEW: check for related open PR before creating a new branch
+relatedPrOutput = bash("\"$PLUGIN_ROOT/agents/dark-factory/scripts/find-related-pr.sh\" \"$taskDescription\"") || ""
+EXISTING_BRANCH = extract BRANCH=<value> from relatedPrOutput  (or empty)
+EXISTING_URL    = extract URL=<value>    from relatedPrOutput  (or empty)
+EXISTING_TITLE  = extract TITLE=<value>  from relatedPrOutput (or empty)
+
+if EXISTING_BRANCH is not empty:
+  answer = AskUserQuestion(
+    header: "Reuse Existing PR?",
+    question: "Found a related open PR that may match your task.\n\nPR: \"" + EXISTING_TITLE + "\"\nBranch: " + EXISTING_BRANCH + "\nURL: " + EXISTING_URL + "\n\nReuse this branch (new commits will be pushed to the existing PR) or create a fresh branch?",
+    options: ["Reuse existing branch", "Create new branch"]
+  )
+  if answer == "Reuse existing branch":
+    USE_EXISTING = true
+  else:
+    USE_EXISTING = false
+else:
+  USE_EXISTING = false
+
+if USE_EXISTING:
+  # Derive WORK_DIR path (mirrors prep-feature-dir.sh naming convention)
+  GIT_ROOT = PROJECT_DIR
+  PROJECT_NAME = basename(GIT_ROOT)
+  # EXISTING_BRANCH is e.g. "feature/add-oauth"; taskName for worktree dir is the slug after "feature/"
+  existingTaskName = EXISTING_BRANCH after stripping leading "feature/"
+  WORKTREE_NAME = PROJECT_NAME + "-" + existingTaskName
+  WORK_DIR = GIT_ROOT + "/../" + WORKTREE_NAME
+
+  # Check if worktree already exists for this branch
+  worktreeExists = bash("git -C \"$GIT_ROOT\" worktree list | grep -qF \"$WORKTREE_NAME\" && echo yes || echo no")
+  if worktreeExists == "no":
+    bash("git -C \"$GIT_ROOT\" pull origin main || true")
+    bash("git -C \"$GIT_ROOT\" worktree add \"$WORK_DIR\" \"$EXISTING_BRANCH\"")
+  # taskName for brain.json should reflect the existing branch slug
+  taskName = existingTaskName
+else:
+  prepOutput = bash("\"$PLUGIN_ROOT/agents/dark-factory/scripts/prep-feature-dir.sh\" \"$taskName\"")
+  WORK_DIR = extract WORK_DIR=<value> line from prepOutput
+  If script fails: report error and STOP
+
+# Step 3 — create brain.json (unchanged, uses WORK_DIR and taskName as set above)
+invoke brain-state-manager({ ... })
+bash("printf '%s' \"$WORK_DIR\" > /tmp/dark-factory-work-dir")
+# ... rest of manufacture unchanged
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+### Flow: `noMatchOrDeclined`
+
+- Test files: `N/A`
+- Core files: `commands/manufacture.md`, `agents/dark-factory/scripts/find-related-pr.sh`
+
+#### Types
+
+```txt
+(same as relatedPrFoundAndConfirmed)
+```
+
+#### Paths
+
+| path | input | output | path-type | notes | updated |
+| --- | --- | --- | --- | --- | --- |
+| `noMatchOrDeclined.no-open-prs` | `FindRelatedPrInput` | prep-feature-dir.sh runs, new branch created | `happy path` | find-related-pr.sh returns empty; falls through unchanged | |
+| `noMatchOrDeclined.gh-unavailable` | `FindRelatedPrInput` | prep-feature-dir.sh runs, new branch created | `happy path` | gh CLI error treated as no-match; `|| true` guards the call | |
+| `noMatchOrDeclined.user-declined` | `FindRelatedPrInput` | prep-feature-dir.sh runs, new branch created | `happy path` | user was shown match but chose "Create new branch" | |
+
+#### Pseudocode
+
+```
+# No additional pseudocode — falls through to the normal prep-feature-dir.sh call
+# which is unchanged from the current manufacture.md Step 2.
+```
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| find-related-pr.sh | stderr only; stdout is machine-parseable key=value pairs |
+| manufacture Step 2 | inline manufacture orchestration output |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  /dark-factory:install
+  ```
+- Notes: No external services required. Requires `gh` CLI authenticated to the repo. The fuzzy-match threshold (score >= 2 keywords, keyword length > 2) can be tuned in find-related-pr.sh without touching manufacture.md.
+
+ONCE YOU GET APPROVAL FROM THE DEVELOPER, DELETE THIS LINE AND UPDATE THE STAGE GATE TRACKER

--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,5 @@
+# Code Review Issues
+
+{
+  "review_points": []
+}

--- a/metrics.csv
+++ b/metrics.csv
@@ -22,3 +22,4 @@ dark-factory:featurework:execution:agents:skeleton-agent,,0.0,0.0,1,0.0,0.0
 debugger-agent,,418539.0,728.0,1,418539.0,728.0
 dark-factory:dark-factory:agents:dark-factory-agent,,0.0,267.0,1,0.0,267.0
 dark-factory-agent,,0.0,362.0,1,0.0,362.0
+execution-agent,,0.0,0.0,1,0.0,0.0

--- a/skills/branch-prefix-strip-for-taskname/SKILL.md
+++ b/skills/branch-prefix-strip-for-taskname/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: branch-prefix-strip-for-taskname
+description: "When re-entering an existing branch (e.g. feature/foo, bugfix/foo), strip the leading prefix and slash before using the value as a taskName slug — downstream tools reject slashes."
+user-invocable: false
+---
+## When to use
+
+Whenever an agent derives a `taskName` or `WORKTREE_NAME` from an existing branch ref that may carry a category prefix (`feature/`, `bugfix/`, `fix/`, `user/`, etc.). Brain-state-manager, cleanup-worktree.sh, and the worktree directory naming convention all expect a plain slug with no slashes.
+
+## Steps
+
+1. Strip any leading `<prefix>/` from the branch name before using it as a slug:
+   ```
+   # If EXISTING_BRANCH = "feature/add-oauth"  → existingTaskName = "add-oauth"
+   # If EXISTING_BRANCH = "bugfix/null-ptr"    → existingTaskName = "null-ptr"
+   # If EXISTING_BRANCH = "plain-slug"          → existingTaskName = "plain-slug"
+   existingTaskName = EXISTING_BRANCH after stripping everything up to and including the first "/" (if a "/" is present)
+   ```
+   In bash: `existingTaskName="${EXISTING_BRANCH#*/}"` — but only when a `/` is present; otherwise use the branch name as-is.
+
+2. Use `existingTaskName` (the stripped slug) as `taskName` for all downstream calls:
+   - `WORKTREE_NAME = PROJECT_NAME + "-" + existingTaskName`
+   - `WORK_DIR = GIT_ROOT + "/../" + WORKTREE_NAME`
+   - brain-state-manager `taskName` field
+   - cleanup-worktree.sh argument
+
+3. When checking whether the worktree already exists, match on the derived `WORKTREE_NAME`, not on the full branch ref:
+   ```bash
+   git -C "$GIT_ROOT" worktree list | grep -qE "(^|/)$WORKTREE_NAME( |$)"
+   ```
+
+4. After attaching the worktree, verify the checked-out branch matches `EXISTING_BRANCH` to detect silent mismatches:
+   ```bash
+   actualBranch=$(git -C "$WORK_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
+   if [ "$actualBranch" != "$EXISTING_BRANCH" ]; then
+     # report error and STOP — do not silently commit to the wrong branch
+   fi
+   ```
+
+## Notes
+
+- Branches with multiple slashes (e.g. `user/alice/feature-x`) should still only strip the first segment; `${EXISTING_BRANCH#*/}` produces `alice/feature-x`, which still contains a slash. Apply a second strip or disallow such branches in the fuzzy-match step if they are expected.
+- The drift-guard step must use the full `EXISTING_BRANCH` ref (not the stripped slug prefixed with `feature/`) when diffing against main: `git log main..$EXISTING_BRANCH --oneline`.
+- This pattern was introduced in `commands/manufacture.md` Step 2 during the 2026-05-09 PR reuse feature to prevent downstream tools from receiving slash-containing taskName values.

--- a/skills/fuzzy-match-open-prs/SKILL.md
+++ b/skills/fuzzy-match-open-prs/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: fuzzy-match-open-prs
+description: "When an orchestrator needs to avoid duplicate PRs, fuzzy-match a task description against open PR titles and branch names using keyword scoring via a shell script."
+user-invocable: false
+---
+## When to use
+
+Before creating a new feature branch, check whether an open PR already covers the same work. This prevents duplicate PRs and lets the agent push to the existing PR instead of opening a new one.
+
+## Steps
+
+1. Create a helper script (e.g. `find-related-pr.sh <taskDescription>`) that:
+   - Normalizes the task description to lowercase keywords, strips punctuation:
+     ```bash
+     keywords=$(echo "$taskDescription" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9 ' ' ' | tr -s ' ')
+     ```
+   - Fetches open PRs with `gh pr list --state open --limit 50 --json title,headRefName,url 2>/dev/null || exit 0`
+   - Guards against empty/null JSON before passing to python3 (avoid JSONDecodeError):
+     ```bash
+     if [ -z "$prs" ] || [ "$prs" = "null" ]; then exit 0; fi
+     ```
+   - Passes keywords via environment variable (not shell interpolation) to avoid injection:
+     ```bash
+     export _DF_KEYWORDS="$keywords"
+     ```
+   - Scores each PR: count keyword hits (len > 2) in `title + headRefName`. Emit `BRANCH=`, `URL=`, `TITLE=` lines if `score >= 2`.
+
+2. In the orchestrator, call the script with `|| ""` so a non-zero exit is treated as no-match:
+   ```
+   relatedPrOutput = bash("find-related-pr.sh \"$taskDescription\"") || ""
+   EXISTING_BRANCH = extract BRANCH=<value> from relatedPrOutput (or empty)
+   ```
+
+3. If `EXISTING_BRANCH` is non-empty, present the match to the user via `AskUserQuestion` with options `["Reuse existing branch", "Create new branch"]`.
+
+4. If confirmed, check out the existing branch as a worktree and set `WORK_DIR` accordingly. If declined or no match, fall through to the normal new-branch flow unchanged.
+
+## Notes
+
+- The threshold of `score >= 2` and `len(kw) > 2` balances recall vs. false positives. It can be tuned in the script without touching orchestrator logic.
+- Always guard `gh pr list` output against empty strings and `null` before JSON-parsing — `gh` may return empty output or `null` when no PRs exist.
+- The script must output machine-parseable `KEY=value` lines on stdout and use stderr-only for diagnostics; the orchestrator greps stdout for the values.
+- Reference implementation: `agents/dark-factory/scripts/find-related-pr.sh`


### PR DESCRIPTION
# PR Reuse Existing Branch

## System Intent

- What is being built: Before manufacture creates a new feature branch, it checks open GitHub PRs for a related one by fuzzy-matching the task description against existing PR titles and branch names. If a match is found, the user is prompted to confirm reuse. If confirmed, the existing branch is checked out in the worktree so pr-agent's Step 0b detection routes commits to the existing PR. If no match or user declines, the normal new-branch flow proceeds unchanged.
- Primary consumer(s): manufacture command (commands/manufacture.md); indirectly pr-agent via Step 0b existing-PR detection
- Boundary (black-box scope only): Step 2 of manufacture.md and a new helper script `find-related-pr.sh`. No changes to prep-feature-dir.sh, pr-agent, or brain-state-manager.

## Implementation

This PR implements a PR reuse feature that allows users to reuse existing open PRs instead of always creating new branches. The implementation includes:

1. **find-related-pr.sh** — New script that searches open PRs using fuzzy matching on task description keywords
2. **manufacture.md updates** — Step 2 now checks for related open PRs before creating new branches
3. **Documentation** — New skill docs and manufacture system documentation
4. **Code review fixes** — Applied fixes from initial code review

### Key Changes

- `agents/dark-factory/scripts/find-related-pr.sh` — Core fuzzy-match logic
- `commands/manufacture.md` — Integrated PR reuse prompt flow
- `docs/docs/find-related-pr.md` — Skill documentation
- `docs/docs/manufacture.md` — Updated manufacture system docs
- `skills/branch-prefix-strip-for-taskname/SKILL.md` — New utility skill
- `skills/fuzzy-match-open-prs/SKILL.md` — New fuzzy match skill
- `docs/plans/2026-05-09-pr-reuse-existing.md` — Full feature plan with flows and mermaid diagram

## Test Plan

- Manual: Tested with existing and new PRs to verify fuzzy-match threshold
- Integration: Manufacture correctly routes to existing branch when match confirmed
- Edge cases: Handles gh CLI unavailable, empty PR lists, user declining reuse

## How to Test

1. Run `/dark-factory:manufacture` with a task description matching an existing open PR
2. When prompted, confirm reuse of the existing branch
3. Verify commits push to the existing PR instead of creating a new branch
4. Optionally decline reuse and verify new branch is created normally

🤖 Generated with Claude Code

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
