### PR TITLE
fix(prep-feature-dir): auto-detect default branch instead of hardcoding main

### DIFF
--- a/agents/dark-factory/scripts/prep-feature-dir.sh
+++ b/agents/dark-factory/scripts/prep-feature-dir.sh
@@ -22,7 +22,17 @@ if git -C "$GIT_ROOT" worktree list | grep -qF "$WORKTREE_NAME"; then
     exit 0
 fi
 
-git -C "$GIT_ROOT" pull origin main || { echo "Error: git pull failed." >&2; exit 1; }
-git -C "$GIT_ROOT" worktree add "$WORK_DIR" -b "feature/${TASK_NAME}" || { echo "Error: git worktree add failed." >&2; exit 1; }
+# Determine the upstream default branch (main, master, develop, etc.).
+# Order: env override -> origin/HEAD symbolic-ref -> fallback to "main".
+DEFAULT_BRANCH="${DARK_FACTORY_BASE_BRANCH:-}"
+if [ -z "$DEFAULT_BRANCH" ]; then
+    DEFAULT_BRANCH=$(git -C "$GIT_ROOT" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@' || true)
+fi
+if [ -z "$DEFAULT_BRANCH" ]; then
+    DEFAULT_BRANCH="main"
+fi
+
+git -C "$GIT_ROOT" fetch origin "$DEFAULT_BRANCH" || { echo "Error: git fetch origin $DEFAULT_BRANCH failed." >&2; exit 1; }
+git -C "$GIT_ROOT" worktree add "$WORK_DIR" -b "feature/${TASK_NAME}" "origin/$DEFAULT_BRANCH" || { echo "Error: git worktree add failed." >&2; exit 1; }
 
 echo "WORK_DIR=${WORK_DIR}"


### PR DESCRIPTION
## Summary

`prep-feature-dir.sh` ran `git pull origin main` unconditionally, breaking on any repo whose default branch is `master`, `develop`, or anything else.

Hit while running dark-factory on a `master`-based project — the script aborted with `fatal: couldn't find remote ref main` and the worktree was never created, leaving the user to manually fall back to a hand-rolled worktree.

## Change

Resolution order for the base branch:

1. `\$DARK_FACTORY_BASE_BRANCH` env var (explicit override)
2. `git symbolic-ref --short refs/remotes/origin/HEAD` (auto-detect)
3. fallback to `main` (preserves prior behavior on repos where origin/HEAD isn't set)

Also switched `git pull origin <branch>` → `git fetch origin <branch>` plus explicit `worktree add ... origin/<branch>`, so the new worktree starts from the remote tip rather than relying on the local checkout being current. The previous `pull` mutated the source repo's checked-out branch, which is undesirable when the user has uncommitted work.

## Test plan

- [ ] Run on a `main`-based repo (no env var, no override) — auto-detects `main`, identical behavior to before
- [ ] Run on a `master`-based repo (the failing case) — auto-detects `master`, succeeds
- [ ] Run with `DARK_FACTORY_BASE_BRANCH=develop` — uses `develop`
- [ ] Run on a repo where `origin/HEAD` isn't set — falls back to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)