### PR TITLE
feat(dark-factory): implement PR reuse feature

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.67",
+  "version": "1.2.68",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -52,9 +52,10 @@ dark-factory-agent(taskDescription, taskName):
 
   # Check for related open PR before creating a new branch
   relatedPrOutput = bash("bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/find-related-pr.sh\" \"$taskDescription\"") || ""
-  EXISTING_BRANCH = extract BRANCH=<value> from relatedPrOutput  (or empty)
-  EXISTING_URL    = extract URL=<value>    from relatedPrOutput  (or empty)
-  EXISTING_TITLE  = extract TITLE=<value>  from relatedPrOutput (or empty)
+  # Extract key=value pairs from output lines (e.g., BRANCH=feature/add-oauth)
+  EXISTING_BRANCH = bash("echo \"$relatedPrOutput\" | grep -oP '^BRANCH=\\K.*' | head -1") || ""
+  EXISTING_URL    = bash("echo \"$relatedPrOutput\" | grep -oP '^URL=\\K.*' | head -1") || ""
+  EXISTING_TITLE  = bash("echo \"$relatedPrOutput\" | grep -oP '^TITLE=\\K.*' | head -1") || ""
 
   if EXISTING_BRANCH is not empty:
     answer = AskUserQuestion(
@@ -81,7 +82,10 @@ dark-factory-agent(taskDescription, taskName):
     worktreeExists = bash("git -C \"$GIT_ROOT\" worktree list | grep -qE \"(^|/)$WORKTREE_NAME( |$)\" && echo yes || echo no")
     if worktreeExists == "no":
       bash("git -C \"$GIT_ROOT\" pull origin main || true")
-      bash("git -C \"$GIT_ROOT\" worktree add \"$WORK_DIR\" \"$EXISTING_BRANCH\"")
+      worktreeAddResult = bash("git -C \"$GIT_ROOT\" worktree add \"$WORK_DIR\" \"$EXISTING_BRANCH\" 2>&1")
+      if worktreeAddResult contains error or exit code non-zero:
+        report error: "Failed to create worktree at " + WORK_DIR + " for branch " + EXISTING_BRANCH + ": " + worktreeAddResult
+        STOP
     else:
       actualBranch = bash("git -C \"$WORK_DIR\" rev-parse --abbrev-ref HEAD 2>/dev/null || echo ''")
       if actualBranch != EXISTING_BRANCH:
@@ -89,7 +93,7 @@ dark-factory-agent(taskDescription, taskName):
         STOP
     taskName = existingTaskName
   else:
-    prepOutput = bash("bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh\" <taskName>")
+    prepOutput = bash("bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh\" \"$taskName\"")
     WORK_DIR = extract WORK_DIR=<value> line from prepOutput
     If script fails: report error and STOP (worktree was never created)
 
@@ -135,7 +139,7 @@ dark-factory-agent(taskDescription, taskName):
 
   # Step 5 — branch-drift guard
   branchRef = USE_EXISTING ? EXISTING_BRANCH : ("feature/" + taskName)
-  driftCheck = bash("git -C \"$WORK_DIR\" log main.." + branchRef + " --oneline")
+  driftCheck = bash("git -C \"$WORK_DIR\" log main.." + branchRef + " --oneline 2>&1")
   if driftCheck is empty:
     run cleanup(WORK_DIR, taskName)
     report error: "Branch-drift guard failed: " + branchRef + " has no commits ahead of main."

--- a/agents/dark-factory/agents/dark-factory-agent.md
+++ b/agents/dark-factory/agents/dark-factory-agent.md
@@ -4,12 +4,21 @@ user-invocable: true
 description: Top-level dark-factory orchestrator. Classifies tasks via task-classifier, preps an isolated work dir, routes to the right worker agent (feature/debugger/repair), runs code review and doc housekeeping, opens a PR, then removes the work dir. Delegates state management to brain-state-manager.
 tools: Read, Bash, Agent, PushNotification, AskUserQuestion, Skill
 model: haiku
-scripts: ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh, ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh
-allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh *), Bash(python3 ${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py *), Bash(git -C * log *), Bash(git rev-parse *)
+scripts: ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh, ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh, ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/find-related-pr.sh
+allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh *), Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/cleanup-worktree.sh *), Bash(bash ${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/find-related-pr.sh *), Bash(python3 ${CLAUDE_PLUGIN_ROOT}/scripts/update-metrics.py *), Bash(git -C * log *), Bash(git rev-parse *)
 skills: task-classifier, brain-state-manager
 ---
 
 You are the dark-factory-agent. Your job is to orchestrate an entire unit of work end-to-end: classify the task, isolate it in a fresh working directory, delegate to the right worker, review the result, keep docs current, ship a PR, and clean up. You do not write code or modify files yourself — you delegate entirely.
+
+## Non-Stop Execution
+
+CRITICAL: Execute all steps sequentially without stopping between them.
+- Do NOT output partial results and wait for user input between steps.
+- Do NOT stop after classification, prep, brain creation, or any individual step.
+- The ONLY valid reasons to pause are: (a) the AskUserQuestion call in Step 1 (ambiguous classification), and (b) the AskUserQuestion call in Step 2 (PR reuse confirmation when a related open PR is found).
+- All other steps must execute continuously from Step 1 through Step 12 without interruption.
+- After completing each step, immediately proceed to the next step without outputting intermediate summaries.
 
 ## Input
 
@@ -40,10 +49,49 @@ dark-factory-agent(taskDescription, taskName):
 
   # Step 2 — prep isolated work dir
   PROJECT_DIR = bash("git rev-parse --show-toplevel")
-  prepOutput = bash("${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh <taskName>")
-  WORK_DIR = extract WORK_DIR=<value> line from prepOutput
 
-  If script fails: report error and STOP (worktree was never created)
+  # Check for related open PR before creating a new branch
+  relatedPrOutput = bash("bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/find-related-pr.sh\" \"$taskDescription\"") || ""
+  EXISTING_BRANCH = extract BRANCH=<value> from relatedPrOutput  (or empty)
+  EXISTING_URL    = extract URL=<value>    from relatedPrOutput  (or empty)
+  EXISTING_TITLE  = extract TITLE=<value>  from relatedPrOutput (or empty)
+
+  if EXISTING_BRANCH is not empty:
+    answer = AskUserQuestion(
+      header: "Reuse Existing PR?",
+      question: "Found a related open PR that may match your task.\n\nPR: \"" + EXISTING_TITLE + "\"\nBranch: " + EXISTING_BRANCH + "\nURL: " + EXISTING_URL + "\n\nReuse this branch (new commits will be pushed to the existing PR) or create a fresh branch?",
+      options: ["Reuse existing branch", "Create new branch"]
+    )
+    if answer == "Reuse existing branch":
+      USE_EXISTING = true
+    else:
+      USE_EXISTING = false
+  else:
+    USE_EXISTING = false
+
+  if USE_EXISTING:
+    GIT_ROOT = PROJECT_DIR
+    PROJECT_NAME = basename(GIT_ROOT)
+    # EXISTING_BRANCH may be "feature/add-oauth", "bugfix/foo", or "plain-slug".
+    # Strip any leading "<prefix>/" so existingTaskName has no slashes.
+    existingTaskName = EXISTING_BRANCH after stripping leading "<anything>/" prefix (i.e. remove up to and including the first "/" if one is present, otherwise use EXISTING_BRANCH as-is)
+    WORKTREE_NAME = PROJECT_NAME + "-" + existingTaskName
+    WORK_DIR = GIT_ROOT + "/../" + WORKTREE_NAME
+
+    worktreeExists = bash("git -C \"$GIT_ROOT\" worktree list | grep -qE \"(^|/)$WORKTREE_NAME( |$)\" && echo yes || echo no")
+    if worktreeExists == "no":
+      bash("git -C \"$GIT_ROOT\" pull origin main || true")
+      bash("git -C \"$GIT_ROOT\" worktree add \"$WORK_DIR\" \"$EXISTING_BRANCH\"")
+    else:
+      actualBranch = bash("git -C \"$WORK_DIR\" rev-parse --abbrev-ref HEAD 2>/dev/null || echo ''")
+      if actualBranch != EXISTING_BRANCH:
+        report error: "Worktree at " + WORK_DIR + " exists but is checked out on '" + actualBranch + "' instead of expected '" + EXISTING_BRANCH + "'. Remove the worktree manually and retry."
+        STOP
+    taskName = existingTaskName
+  else:
+    prepOutput = bash("bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh\" <taskName>")
+    WORK_DIR = extract WORK_DIR=<value> line from prepOutput
+    If script fails: report error and STOP (worktree was never created)
 
   # Step 3 — create brain.json (delegate to brain-state-manager skill)
   invoke brain-state-manager({
@@ -86,10 +134,11 @@ dark-factory-agent(taskDescription, taskName):
       report error and STOP
 
   # Step 5 — branch-drift guard
-  driftCheck = bash("git -C \"$WORK_DIR\" log main..feature/" + taskName + " --oneline")
+  branchRef = USE_EXISTING ? EXISTING_BRANCH : ("feature/" + taskName)
+  driftCheck = bash("git -C \"$WORK_DIR\" log main.." + branchRef + " --oneline")
   if driftCheck is empty:
     run cleanup(WORK_DIR, taskName)
-    report error: "Branch-drift guard failed: feature/" + taskName + " has no commits ahead of main."
+    report error: "Branch-drift guard failed: " + branchRef + " has no commits ahead of main."
     STOP
 
   # Step 6 — read planFilePath from brain.json

--- a/agents/dark-factory/scripts/find-related-pr.sh
+++ b/agents/dark-factory/scripts/find-related-pr.sh
@@ -8,9 +8,12 @@ taskDescription="$1"
 # Normalize to lowercase keywords, strip punctuation
 keywords=$(echo "$taskDescription" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9 ' ' ' | tr -s ' ')
 
-# Fetch all open PRs with title, headRefName, url
-# If gh exits non-zero (auth error, network error), bail silently
-prs=$(gh pr list --state open --limit 50 --json title,headRefName,url 2>/dev/null) || exit 0
+# Fetch all open PRs with title, headRefName, url, and number (for tie-breaking by order)
+# If gh exits non-zero (auth error, network error), log and bail gracefully
+prs=$(gh pr list --state open --limit 50 --json title,headRefName,url,number --order updated --sort desc 2>/dev/null) || {
+  echo "# Warning: Could not fetch open PRs (gh CLI error). Proceeding with new branch creation." >&2
+  exit 0
+}
 
 # Guard: if output is empty or not a JSON array, exit silently
 if [ -z "$prs" ] || [ "$prs" = "null" ]; then
@@ -22,6 +25,7 @@ export _DF_KEYWORDS="$keywords"
 
 # For each PR: score = count of keyword hits in (title + branchName)
 # Select best match if score >= 2 keywords match
+# On tie, prefer most recently updated PR (first in list since we sort by updated desc)
 best=$(echo "$prs" | python3 -c "
 import sys, json, os
 raw = sys.stdin.read().strip()
@@ -34,12 +38,14 @@ except json.JSONDecodeError:
 keywords = set(os.environ.get('_DF_KEYWORDS', '').split())
 best = None
 best_score = 0
-for pr in data:
+best_index = float('inf')
+for idx, pr in enumerate(data):
     candidate = (pr['title'] + ' ' + pr['headRefName']).lower()
-    score = sum(1 for kw in keywords if kw in candidate and len(kw) > 2)
-    if score >= 2 and score > best_score:
+    score = sum(1 for kw in keywords if kw in candidate and len(kw) >= 2)
+    if score >= 2 and (score > best_score or (score == best_score and idx < best_index)):
         best_score = score
         best = pr
+        best_index = idx
 if best:
     print(f\"BRANCH={best['headRefName']}\")
     print(f\"URL={best['url']}\")

--- a/agents/dark-factory/scripts/find-related-pr.sh
+++ b/agents/dark-factory/scripts/find-related-pr.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# find-related-pr.sh - Fuzzy-match taskDescription against open PR titles/branch names
+# Usage: find-related-pr.sh <taskDescription>
+# Output: BRANCH=<branch> URL=<url> TITLE=<title>  OR  empty on no match
+
+taskDescription="$1"
+
+# Normalize to lowercase keywords, strip punctuation
+keywords=$(echo "$taskDescription" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9 ' ' ' | tr -s ' ')
+
+# Fetch all open PRs with title, headRefName, url
+# If gh exits non-zero (auth error, network error), bail silently
+prs=$(gh pr list --state open --limit 50 --json title,headRefName,url 2>/dev/null) || exit 0
+
+# Guard: if output is empty or not a JSON array, exit silently
+if [ -z "$prs" ] || [ "$prs" = "null" ]; then
+  exit 0
+fi
+
+# Pass keywords safely via environment variable to avoid shell-injection
+export _DF_KEYWORDS="$keywords"
+
+# For each PR: score = count of keyword hits in (title + branchName)
+# Select best match if score >= 2 keywords match
+best=$(echo "$prs" | python3 -c "
+import sys, json, os
+raw = sys.stdin.read().strip()
+if not raw:
+    sys.exit(0)
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    sys.exit(0)
+keywords = set(os.environ.get('_DF_KEYWORDS', '').split())
+best = None
+best_score = 0
+for pr in data:
+    candidate = (pr['title'] + ' ' + pr['headRefName']).lower()
+    score = sum(1 for kw in keywords if kw in candidate and len(kw) > 2)
+    if score >= 2 and score > best_score:
+        best_score = score
+        best = pr
+if best:
+    print(f\"BRANCH={best['headRefName']}\")
+    print(f\"URL={best['url']}\")
+    print(f\"TITLE={best['title']}\")
+")
+
+echo "$best"

--- a/docs/docs/dark-factory-agent.md
+++ b/docs/docs/dark-factory-agent.md
@@ -29,10 +29,13 @@ The agent never writes or modifies code itself — it delegates entirely to spec
 - If classification is ambiguous: sends PushNotification, awaits AskUserQuestion response
 
 ### Step 2: Prep Isolated Work Directory
-- Calls bash: `prep-feature-dir.sh <taskName>`
-- Creates isolated git worktree for the task
+- Calls `find-related-pr.sh <taskDescription>` to search for a related open PR
+- If a match is found (score ≥ 2 keyword hits against PR title + branch), prompts user via AskUserQuestion:
+  - **"Reuse existing branch"** — mounts the existing worktree (or creates one) for the matched branch; sets `USE_EXISTING = true`
+  - **"Create new branch"** — proceeds with fresh worktree
+- If reusing: derives `existingTaskName` by stripping any `<prefix>/` from the branch name, then sets `WORK_DIR = GIT_ROOT/../<PROJECT_NAME>-<existingTaskName>`; verifies or creates the worktree
+- If creating fresh: calls `prep-feature-dir.sh <taskName>` and extracts `WORK_DIR` from script output
 - Stops immediately if worktree creation fails (no cleanup needed yet)
-- Extracts `WORK_DIR` from script output
 
 ### Step 3: Create brain.json State File
 - Delegates to `brain-state-manager` skill with `operation: "create"`
@@ -61,7 +64,8 @@ If non-feature worker returns error or hard-stop: runs cleanup, reports error, S
 
 ### Step 5: Branch-Drift Guard
 - Verifies feature branch has commits ahead of main
-- Bash: `git -C "$WORK_DIR" log main..feature/<taskName> --oneline`
+- Uses `EXISTING_BRANCH` when reusing a PR, or `feature/<taskName>` for fresh branches
+- Bash: `git -C "$WORK_DIR" log main..<branchRef> --oneline`
 - Halts with error if no new commits found (cleanup runs first)
 
 ### Step 6: Read Plan File Path
@@ -117,12 +121,13 @@ Called on any error path after worktree creation:
 6. **Read brain state after sub-agents** — Use brain-state-manager to extract outputs, don't parse agent return values directly
 7. **Rely on pre-hook injection** — The pre-hook injects brain context into every Agent tool call automatically; don't manually pass brain fields
 8. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
+9. **PR reuse check runs before branch creation** — find-related-pr.sh is invoked at the start of Step 2 so the user can opt into an existing open PR; the branch-drift guard and all downstream steps are branch-agnostic (use `EXISTING_BRANCH` or `feature/<taskName>` as appropriate)
 
 ## Dependencies
 
 - **Skills**: task-classifier, brain-state-manager
 - **Sub-agents**: feature-agent, fix-flow-orchestrator, debugger-agent, repair-agent, code-review-orchestrator-agent, update-documentation-agent, skill-update-agent, pr-agent
-- **Scripts**: prep-feature-dir.sh, cleanup-worktree.sh
+- **Scripts**: prep-feature-dir.sh, cleanup-worktree.sh, find-related-pr.sh
 
 ## Tools
 

--- a/docs/docs/find-related-pr.md
+++ b/docs/docs/find-related-pr.md
@@ -1,0 +1,84 @@
+# find-related-pr
+
+## Metadata
+
+- System type: `library`
+
+## System Intent
+
+- What this is: A bash script that fuzzy-matches a task description against open GitHub PR titles and branch names to find a related PR that may already exist for the same work.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  In["taskDescription (string)"] --> Normalize["Normalize to lowercase keywords\n(strip punctuation, collapse whitespace)"]
+  Normalize --> Fetch["gh pr list --state open --limit 50\n(sorted by updated desc)"]
+  Fetch -->|gh error| Warn["Log warning to stderr\nexit 0 (graceful)"]
+  Fetch --> Score["Python: score each PR\ncount keyword hits in title + headRefName\n(only count keywords ≥ 2 chars)"]
+  Score -->|"best score >= 2"| Output["Print BRANCH=...\nURL=...\nTITLE=..."]
+  Score -->|"no match"| Empty["Exit with empty output"]
+```
+
+## Flows
+
+### Flow: `fuzzyMatchPR`
+- Core files: `agents/dark-factory/scripts/find-related-pr.sh`
+
+#### Types
+
+```txt
+Input:
+  taskDescription: string  — verbatim user task description
+
+Output (printed to stdout, one key=value per line):
+  BRANCH=<headRefName>   — branch name of the matched PR
+  URL=<url>              — GitHub URL of the matched PR
+  TITLE=<title>          — title of the matched PR
+
+  OR empty stdout if no match found or on gh CLI error
+```
+
+#### Paths
+
+| path | input | output | path-type | notes |
+| --- | --- | --- | --- | --- |
+| `fuzzyMatchPR.match` | taskDescription | BRANCH, URL, TITLE lines | happy path | score >= 2 keyword hits |
+| `fuzzyMatchPR.no-match` | taskDescription | empty stdout | no match | fewer than 2 keyword hits |
+| `fuzzyMatchPR.gh-error` | taskDescription | empty stdout + stderr warning | error | gh CLI unavailable or auth failure; exits 0 so caller continues |
+
+#### Pseudocode
+
+```
+keywords = normalize(taskDescription)   # lowercase, strip punctuation, collapse spaces
+
+prs = gh pr list --state open --limit 50 --json title,headRefName,url,number --order updated --sort desc
+
+for each pr in prs:
+  candidate = pr.title + " " + pr.headRefName  (lowercased)
+  score = count of keywords (len >= 2) found in candidate
+
+best = pr with highest score >= 2 (ties broken by most recently updated — first in list)
+
+if best:
+  print BRANCH=<best.headRefName>
+  print URL=<best.url>
+  print TITLE=<best.title>
+```
+
+**Scoring detail**: only keywords with 2 or more characters are counted; common single-character tokens are silently ignored. Ties in score are resolved by PR update order (most recently updated wins, since `gh pr list` is sorted `--order updated --sort desc`).
+
+## Logs
+
+| Source | Location |
+|--------|----------|
+| gh CLI error | stderr (script continues with exit 0) |
+
+## Deployment
+
+- Mechanism: `local only`
+- Deploy command:
+  ```bash
+  bash agents/dark-factory/scripts/find-related-pr.sh "<taskDescription>"
+  ```
+- Notes: Requires `gh` CLI to be authenticated. Script is invoked by `dark-factory-agent` at Step 2, before any worktree is created. On any gh failure the script exits 0 with empty output so the caller falls through to creating a fresh branch.

--- a/metrics.csv
+++ b/metrics.csv
@@ -1,10 +1,10 @@
 agent,skill,avg_runtime,avg_tokens,runs,sum_runtime,sum_tokens
 dark-factory:featurework:planning:agents:planning-agent,,31902.666666666668,1155.0,3,95708.0,3465.0
 dark-factory:featurework:execution:agents:execution-agent,,78434.0,603.4,5,392170.0,3017.0
-dark-factory:code-review:agents:code-review-orchestrator-agent,,158897.16666666666,636.25,12,1906766.0,7635.0
-dark-factory:documentation:agents:update-documentation-agent,,77188.0,314.875,8,617504.0,2519.0
-dark-factory:skill-update:agents:skill-update-agent,,65516.0,357.57142857142856,7,458612.0,2503.0
-dark-factory:pr:agents:pr-agent,,58958.92857142857,140.07142857142858,14,825425.0,1961.0
+dark-factory:code-review:agents:code-review-orchestrator-agent,,158154.6923076923,619.7692307692307,13,2056011.0,8057.0
+dark-factory:documentation:agents:update-documentation-agent,,76781.66666666667,296.1111111111111,9,691035.0,2665.0
+dark-factory:skill-update:agents:skill-update-agent,,65918.5,325.5,8,527348.0,2604.0
+dark-factory:pr:agents:pr-agent,,58330.26666666667,161.86666666666667,15,874954.0,2428.0
 dark-factory:repair:agents:repair-agent,,13170.157894736842,179.89473684210526,19,250233.0,3418.0
 testing-agent,,0.0,0.0,13,0.0,0.0
 planning-agent,,0.0,0.0,19,0.0,0.0

--- a/skills/branch-drift-guard/SKILL.md
+++ b/skills/branch-drift-guard/SKILL.md
@@ -11,21 +11,21 @@ This guard catches the class of bug where a sub-agent runs `git commit` without 
 
 ## Steps
 
-1. After the worker agent returns, compute the feature branch name:
+1. After the worker agent returns, determine the branch reference. For new branches this is always `"feature/" + taskName`; when reusing an existing PR the branch may have any prefix (bugfix/, plain slug, etc.):
    ```
-   featureBranch = "feature/" + taskName
+   branchRef = USE_EXISTING ? EXISTING_BRANCH : ("feature/" + taskName)
    ```
 
 2. Run a scoped git log to check for commits ahead of main:
    ```bash
-   git -C "$WORK_DIR" log main..feature/<taskName> --oneline
+   git -C "$WORK_DIR" log main..<branchRef> --oneline 2>&1
    ```
 
 3. If the output is empty (no commits ahead), the worker either committed to the wrong branch or did not commit at all. Do not proceed:
    ```
    rm -f /tmp/dark-factory-work-dir
    run cleanup(WORK_DIR)
-   report error: "Branch-drift guard failed: feature/<taskName> has no commits ahead of main.
+   report error: "Branch-drift guard failed: <branchRef> has no commits ahead of main.
      The worker agent may have committed to the wrong branch or failed to commit at all.
      Halting before code review to prevent opening a PR with no changes."
    STOP
@@ -39,3 +39,4 @@ This guard catches the class of bug where a sub-agent runs `git commit` without 
 - This guard should run even when the worker returns `status == "done"` — a successful return does not guarantee the commit landed on the correct branch.
 - The root cause of branch drift is sub-agents issuing git commands without `-C WORK_DIR`, causing git to resolve the repo from the ambient shell CWD, which may point to the main worktree. See skill `git-c-worktree-subagent` for the companion fix.
 - If the project uses a different default branch name (e.g., `master`), substitute it for `main` in the log range.
+- When reusing an existing PR branch the branch name will not have the `feature/` prefix — always use the full `branchRef` variable, not a hardcoded `"feature/" + taskName` interpolation. Hardcoding the prefix causes the drift guard to check the wrong branch and always report failure.

--- a/skills/fuzzy-match-open-pr/SKILL.md
+++ b/skills/fuzzy-match-open-pr/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: fuzzy-match-open-pr
+description: "Find an open GitHub PR that likely corresponds to a task description using keyword scoring, to support PR reuse before creating a new branch."
+user-invocable: false
+---
+## When to use
+
+Before creating a new branch for a task, check whether an open PR already exists for the same work. This avoids duplicate PRs and allows continued work on an existing branch. Invoke this pattern at the start of the branch-preparation step whenever the task might be a re-run or continuation of prior work.
+
+## Steps
+
+1. Normalize the task description to lowercase keywords, strip punctuation:
+   ```bash
+   keywords=$(echo "$taskDescription" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9 ' ' ' | tr -s ' ')
+   ```
+
+2. Fetch open PRs from GitHub with title, branch, url, and number. Gracefully handle auth/network failure:
+   ```bash
+   prs=$(gh pr list --state open --limit 50 --json title,headRefName,url,number --order updated --sort desc 2>/dev/null) || {
+     echo "# Warning: Could not fetch open PRs. Proceeding with new branch." >&2
+     exit 0
+   }
+   ```
+
+3. Pass keywords via environment variable (not shell interpolation) to avoid injection, then score each PR with python3 inline:
+   ```bash
+   export _DF_KEYWORDS="$keywords"
+   best=$(echo "$prs" | python3 -c "
+   import sys, json, os
+   data = json.loads(sys.stdin.read().strip())
+   keywords = set(os.environ.get('_DF_KEYWORDS', '').split())
+   best = None; best_score = 0; best_index = float('inf')
+   for idx, pr in enumerate(data):
+       candidate = (pr['title'] + ' ' + pr['headRefName']).lower()
+       score = sum(1 for kw in keywords if kw in candidate and len(kw) >= 2)
+       if score >= 2 and (score > best_score or (score == best_score and idx < best_index)):
+           best_score = score; best = pr; best_index = idx
+   if best:
+       print(f\"BRANCH={best['headRefName']}\")
+       print(f\"URL={best['url']}\")
+       print(f\"TITLE={best['title']}\")
+   ")
+   ```
+   Score threshold of 2 keywords (each >= 2 chars) balances recall vs. false positives. On tie, prefer the most recently updated PR (first in list since `--sort desc`).
+
+4. Parse the output and, if a match was found, ask the user whether to reuse the branch or create a fresh one:
+   ```
+   EXISTING_BRANCH = extract BRANCH= line
+   if EXISTING_BRANCH is not empty:
+     answer = AskUserQuestion("Reuse existing branch or create new?", options: ["Reuse existing branch", "Create new branch"])
+   ```
+
+5. If reuse is chosen, derive the worktree name by stripping any `<prefix>/` from the branch name (the part up to and including the first `/`):
+   ```
+   existingTaskName = EXISTING_BRANCH with leading "<prefix>/" stripped
+   WORKTREE_NAME = PROJECT_NAME + "-" + existingTaskName
+   WORK_DIR = GIT_ROOT + "/../" + WORKTREE_NAME
+   ```
+   Then add the worktree if it does not already exist, or verify branch alignment if it does:
+   ```bash
+   git -C "$GIT_ROOT" worktree add "$WORK_DIR" "$EXISTING_BRANCH"
+   ```
+
+## Notes
+
+- Always pass keyword strings via environment variables, never via shell interpolation into python3 `-c` strings — task descriptions may contain quotes or special characters that break the command.
+- The minimum keyword length filter (`len(kw) >= 2`) avoids noise from stop words like "a", "i".
+- If `gh pr list` fails (network error, not authenticated), exit 0 and let the calling agent fall back to creating a new branch — do not block the flow.
+- When a worktree already exists for the reused branch, verify the checked-out branch matches `EXISTING_BRANCH` before proceeding. If it does not match, report an error and stop — do not silently continue on the wrong branch.
+- The drift guard must use the full `branchRef` (e.g. `bugfix/foo` or `plain-slug`) rather than hardcoding `feature/<taskName>` when a reused branch is involved. See skill `branch-drift-guard`.


### PR DESCRIPTION
## Summary

Implements the PR reuse feature in dark-factory-agent: before manufacture makes edits, the agent now checks for an open PR that matches the task description. If found, the user is prompted to reuse that PR's branch rather than creating a new one. This enables continued work on existing branches without creating duplicate PRs.

## Key Changes

- **NEW: `agents/dark-factory/scripts/find-related-pr.sh`** — Fuzzy-matches task description against open PR titles and branch names using keyword scoring (Python-based, only counting keywords ≥ 2 chars, threshold 2+ hits)
- **NEW: `skills/fuzzy-match-open-pr/SKILL.md`** — Skill documentation for the PR matching pattern
- **MODIFIED: `agents/dark-factory/agents/dark-factory-agent.md`**
  - Step 2 now checks for related open PRs before calling prep-feature-dir.sh
  - User is prompted to reuse or create a fresh branch when a match is found
  - Step 5 (branch-drift guard) now uses correct `branchRef` variable for both feature/ and non-feature/ prefixed branches
  - Added "Non-Stop Execution" section documenting valid pause points
- **NEW: `docs/docs/find-related-pr.md`** — System documentation with mermaid flow diagram
- **UPDATED: `docs/docs/dark-factory-agent.md`** — Updated to reflect Step 2 PR reuse integration
- **UPDATED: `skills/branch-drift-guard/SKILL.md`** — Updated to use full `branchRef` instead of hardcoded `feature/<taskName>` prefix

## Design Notes

- Graceful failure: if `gh pr list` fails (network, auth), the script exits 0 and falls through to creating a new branch
- Worktree management: when reusing, the script strips any prefix from the branch name (e.g., `bugfix/foo` → `foo`) to generate the worktree directory name
- Scoring uses keyword overlap between task description and PR title+branch: requires 2+ keywords of length ≥2 chars for a match
- Ties in score are broken by most recently updated PR (since `gh pr list` output is sorted by updated desc)

## Test Plan

- [ ] Integration test: Run dark-factory-agent with a task description that matches an existing open PR
- [ ] Verify user is prompted to reuse or create fresh
- [ ] If reusing, verify commits land on the existing PR branch
- [ ] If creating fresh, verify the original branch is untouched
- [ ] Test worktree creation/reuse for both feature/ and non-feature/ prefixed branches
- [ ] Verify branch-drift guard correctly validates commits on reused branches
- [ ] Test graceful failure: `gh pr list` network/auth error should fall back to fresh branch

Generated with Claude Code
