### PR TITLE
docs: add /reset command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ These two templates are the source of truth that every downstream agent — plan
 | `/dark-factory:manufacture` | Task description (e.g. "add OAuth login") | Full orchestration — routes to the right agent (feature, debug, or fix-flow) end-to-end, runs code review, opens a PR, and cleans up |
 | `/dark-factory:build-factory` | Optional terminal name | Opens a new gnome-terminal running `claude /remote-control` for parallel factory sessions |
 | `/dark-factory:install` | None | Install or reinstall the plugin (run from repo root after `git pull`) |
+| `/dark-factory:reset` | None | Switch back to the main branch in the main worktree and pull the latest code |


### PR DESCRIPTION
## Summary
- Adds documentation for the new `/reset` command to the Commands table in README.md
- The command switches back to the main branch in the main worktree and pulls the latest code

## Test plan
- [x] README table formatting is correct
- [x] Command entry follows the same format as existing commands
- [x] Description accurately describes the reset functionality