### PR TITLE
fix(pr-agent): enable PR reuse via explicit workDir parameter

### DIFF
--- a/agents/dark-factory/agents/debug-command-agent.md
+++ b/agents/dark-factory/agents/debug-command-agent.md
@@ -53,8 +53,9 @@ debug-command-agent(taskDescription, taskName):
   try: invoke skill-update-agent({ planFilePath, workDir: PROJECT_DIR, taskSummary: taskDescription })
   catch: warn and continue
 
-  # Step 7 — open PR; pr-agent returns prUrl directly
-  prResult = invoke pr-agent({ planFilePath ?? taskDescription })
+  # Step 7 — determine WORK_DIR (worktree root) and open PR
+  WORK_DIR = bash("git rev-parse --show-toplevel")
+  prResult = invoke pr-agent({ planFilePath ?? taskDescription, workDir: WORK_DIR })
   prUrl = prResult.prUrl
 
   Report: "Debug complete. PR: " + prUrl

--- a/agents/dark-factory/agents/execute-command-agent.md
+++ b/agents/dark-factory/agents/execute-command-agent.md
@@ -54,7 +54,7 @@ execute-command-agent(planPath, taskName):
 
   # Step 7 — determine WORK_DIR (worktree root) and open PR
   WORK_DIR = bash("git rev-parse --show-toplevel")
-  prResult = invoke pr-agent({ planPath, workDir: WORK_DIR })
+  prResult = invoke pr-agent({ planFilePath: planPath, workDir: WORK_DIR })
   prUrl = prResult.prUrl
 
   Report: "Execution complete. PR: " + prUrl

--- a/agents/dark-factory/agents/execute-command-agent.md
+++ b/agents/dark-factory/agents/execute-command-agent.md
@@ -52,8 +52,9 @@ execute-command-agent(planPath, taskName):
   try: invoke skill-update-agent({ planFilePath: planPath, workDir: PROJECT_DIR, taskSummary: "Execute: " + planPath })
   catch: warn and continue
 
-  # Step 7 — open PR; pr-agent returns prUrl directly
-  prResult = invoke pr-agent({ planPath })
+  # Step 7 — determine WORK_DIR (worktree root) and open PR
+  WORK_DIR = bash("git rev-parse --show-toplevel")
+  prResult = invoke pr-agent({ planPath, workDir: WORK_DIR })
   prUrl = prResult.prUrl
 
   Report: "Execution complete. PR: " + prUrl

--- a/agents/dark-factory/agents/repair-command-agent.md
+++ b/agents/dark-factory/agents/repair-command-agent.md
@@ -57,7 +57,7 @@ repair-command-agent(taskDescription, taskName):
 
   # Step 7 — determine WORK_DIR (worktree root) and open PR
   WORK_DIR = bash("git rev-parse --show-toplevel")
-  prResult = invoke pr-agent({ taskDescription, workDir: WORK_DIR })
+  prResult = invoke pr-agent({ planFilePath: taskDescription, workDir: WORK_DIR })
   prUrl = prResult.prUrl
 
   Report: "Repair complete. PR: " + prUrl

--- a/agents/dark-factory/agents/repair-command-agent.md
+++ b/agents/dark-factory/agents/repair-command-agent.md
@@ -55,8 +55,9 @@ repair-command-agent(taskDescription, taskName):
   try: invoke skill-update-agent({ planFilePath: null, workDir: PROJECT_DIR, taskSummary: taskDescription })
   catch: warn and continue
 
-  # Step 7 — open PR; pr-agent returns prUrl directly
-  prResult = invoke pr-agent({ taskDescription })
+  # Step 7 — determine WORK_DIR (worktree root) and open PR
+  WORK_DIR = bash("git rev-parse --show-toplevel")
+  prResult = invoke pr-agent({ taskDescription, workDir: WORK_DIR })
   prUrl = prResult.prUrl
 
   Report: "Repair complete. PR: " + prUrl

--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -39,7 +39,7 @@ pr-agent(planFilePath or taskDescription, workDir):
   Write body to /tmp/pr-body.md.
 
   # Step 2 — Open PR (delegate to create-pr skill) if no existing PR
-  if existingPr is null:
+  if existingPr is empty:
     pr_url = invoke create-pr({ bodyFile: "/tmp/pr-body.md", workDir: workDir })
   
   # Step 2b — Write brain-patch.json for downstream use

--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -14,40 +14,44 @@ You are the pr-agent. Take a fix already applied to the working tree and shepher
 
 ## Input
 
-A file path or description string for the PR body. If neither provided, use the git diff.
+- `planFilePath` or `taskDescription` (string) — File path or text for the PR body. If neither provided, use the git diff.
+- `workDir` (string, required) — Absolute path to the worktree where the code changes were made. Used for all git operations and to check for existing PRs.
 
 ## Orchestration
 
 ```
-pr-agent(planFilePath or description):
+pr-agent(planFilePath or taskDescription, workDir):
 
   # Step 0 — Check for existing PR on current branch
-  existingPr = gh pr view --json url --jq '.url' 2>/dev/null || null
-  if existingPr is not null:
-    git -C "$WORK_DIR" add --all
-    git -C "$WORK_DIR" commit -m "<short description of fix>"
-    git -C "$WORK_DIR" push
+  # cd into workDir to check for existing PR on the feature branch
+  existingPr = bash("cd \"$workDir\" && gh pr view --json url --jq '.url' 2>/dev/null || echo ''")
+  if existingPr is not empty:
+    git -C "$workDir" add --all
+    git -C "$workDir" commit -m "<short description of fix>"
+    git -C "$workDir" push
     pr_url = existingPr
   # (if no existing PR, pr_url will be set in Step 2 below)
 
   # Step 1 — Build PR body
   Read agents/pr/templates/pr-template.md for structure.
-  Populate Description from planFilePath (or description string).
+  Populate Description from planFilePath (or taskDescription string).
   Run tests if a test suite exists; include output in Test Plan, or omit section if none.
   Write body to /tmp/pr-body.md.
 
   # Step 2 — Open PR (delegate to create-pr skill) if no existing PR
   if existingPr is null:
-    pr_url = invoke create-pr({ bodyFile: "/tmp/pr-body.md" })
+    pr_url = invoke create-pr({ bodyFile: "/tmp/pr-body.md", workDir: workDir })
   
-  WORK_DIR = $DARK_FACTORY_WORK_DIR
-  if WORK_DIR is empty: WORK_DIR = contents of /tmp/dark-factory-work-dir (if the file exists)
-  if WORK_DIR is still empty: skip silently
-  else: write $WORK_DIR/brain-patch.json:
-    {
-      "prUrl": pr_url,
-      "notes": ["pr-agent: opened PR at <prUrl>, CI <passed/failed>"]
-    }
+  # Step 2b — Write brain-patch.json for downstream use
+  WRITE_DIR = workDir
+  if WRITE_DIR is empty: WRITE_DIR = contents of /tmp/dark-factory-work-dir (pointer file fallback)
+  if WRITE_DIR is still empty: skip silently
+  else:
+    write WRITE_DIR/brain-patch.json:
+      {
+        "prUrl": pr_url,
+        "notes": ["pr-agent: opened PR at <prUrl>, CI <passed/failed>"]
+      }
   Replace <prUrl> with the actual PR URL and <passed/failed> with the CI result from step 3.
 
   # Step 3 — Watch CI (delegate to ci-watch-runner command)
@@ -66,9 +70,10 @@ pr-agent(planFilePath or description):
 ## Rules
 
 - Fix is already applied to the working tree — do not re-apply.
-- Always use `git -C "$WORK_DIR"` for all git operations (WORK_DIR is in brain context).
+- Always use `git -C "$workDir"` for all git operations (workDir is passed as input parameter).
 - Always write PR body to /tmp/pr-body.md and open with `gh pr create --body-file /tmp/pr-body.md`.
+- For existing PR checks, cd into workDir before running gh commands: `cd "$workDir" && gh ...`.
 - Delegate CI watching to ci-watch-runner — do not implement watch loop inline.
 - Delegate comment resolution to comment-resolution-runner — do not implement comment loop inline.
 - Do not merge.
-- Write brain-patch.json after PR is opened; use pointer file fallback if DARK_FACTORY_WORK_DIR is unset.
+- Write brain-patch.json after PR is opened to the workDir.

--- a/docs/docs/debug-command-agent.md
+++ b/docs/docs/debug-command-agent.md
@@ -86,7 +86,7 @@ debug-command-agent(taskDescription, taskName):
   })
   invoke update-documentation-agent({ planFilePath, workDir: PROJECT_DIR })
   try: invoke skill-update-agent({ planFilePath, workDir: PROJECT_DIR, taskSummary: taskDescription })
-  prResult = invoke pr-agent({ planFilePath ?? taskDescription })
+  prResult = invoke pr-agent({ planFilePath: planFilePath ?? taskDescription, workDir: PROJECT_DIR })
 
   Report: "Debug complete. PR: " + prResult.prUrl
   STOP

--- a/docs/docs/execute-command-agent.md
+++ b/docs/docs/execute-command-agent.md
@@ -87,7 +87,7 @@ execute-command-agent(planPath, taskName):
   invoke code-review-orchestrator-agent({ planFilePath: planPath, codePath: PROJECT_DIR })
   invoke update-documentation-agent({ planFilePath: planPath, workDir: PROJECT_DIR })
   try: invoke skill-update-agent({ planFilePath: planPath, workDir: PROJECT_DIR, taskSummary: "Execute: " + planPath })
-  prResult = invoke pr-agent({ planPath })
+  prResult = invoke pr-agent({ planFilePath: planPath, workDir: PROJECT_DIR })
 
   Report: "Execution complete. PR: " + prResult.prUrl
   STOP

--- a/docs/docs/pr-agent.md
+++ b/docs/docs/pr-agent.md
@@ -17,14 +17,15 @@ The PR lifecycle is fully automated except for the final merge decision, enablin
 - `planFilePath` (string, nullable) — Path to the plan file; if null, uses taskDescription
 - Or `taskDescription` (string) — Plain description of the work if no plan exists
 - If neither: uses git diff
+- `workDir` (string, required) — Absolute path to the worktree where code changes were made. Used for all git operations and for checking/reusing an existing open PR on the current branch.
 
 ## Orchestration Flow (6 Steps)
 
 ### Step 0: Check for Existing PR
 
-1. **Runs `gh pr view`** to check if a PR already exists for the current branch
+1. **Runs `gh pr view`** scoped to `workDir` to check if a PR already exists for the current branch (`cd "$workDir" && gh pr view --json url --jq '.url' 2>/dev/null || echo ''`)
 2. **If a PR exists**:
-   - Commits all staged changes with a short description (`git -C "$WORK_DIR" add --all && git -C "$WORK_DIR" commit && git -C "$WORK_DIR" push`)
+   - Commits all staged changes with a short description (`git -C "$workDir" add --all && git -C "$workDir" commit && git -C "$workDir" push`)
    - Sets `pr_url` to the existing PR URL
    - Does **not** return early — continues to Step 1
 3. **If no PR exists**: `pr_url` is left unset; will be set in Step 2
@@ -135,13 +136,13 @@ The PR body includes (from `agents/pr/templates/pr-template.md`):
 ## Key Design Rules
 
 1. **Code is already implemented** — Assume fix is complete; don't re-apply
-2. **Always use git -C "$WORK_DIR"** — WORK_DIR is injected by pre-hook
+2. **Always use git -C "$workDir"** — workDir is passed as a required input parameter by the calling command agent
 3. **Write body to /tmp/pr-body.md** — Use standard gh cli pattern
 4. **Delegate CI watching** — Use ci-watch-runner, don't implement watch loop inline
 5. **Delegate comment resolution** — Use comment-resolution-runner, don't implement loop inline
 6. **Do NOT merge** — Stop at "ready" status; human makes the merge decision
 7. **Write brain-patch after PR opens** — Captures prUrl for downstream use
-8. **Resolve WORK_DIR via pointer file fallback** — Check `$DARK_FACTORY_WORK_DIR` first; if unset, read `/tmp/dark-factory-work-dir`; skip silently if both empty
+8. **workDir is a required parameter** — Passed explicitly by the calling command agent (execute, debug, or repair). Used for all git operations and for scoping `gh pr view` to the correct worktree branch.
 9. **Step 0 does NOT return early** — When an existing PR is found, commit+push and set pr_url, then continue; CI watching and comment resolution always run on both the new-PR and existing-PR paths
 10. **gh pr create is conditional** — Only called when no existing PR was found in Step 0
 11. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase

--- a/docs/docs/repair-command-agent.md
+++ b/docs/docs/repair-command-agent.md
@@ -91,7 +91,7 @@ repair-command-agent(taskDescription, taskName):
   })
   invoke update-documentation-agent({ planFilePath: null, workDir: PROJECT_DIR })
   try: invoke skill-update-agent({ planFilePath: null, workDir: PROJECT_DIR, taskSummary: taskDescription })
-  prResult = invoke pr-agent({ taskDescription })
+  prResult = invoke pr-agent({ planFilePath: taskDescription, workDir: PROJECT_DIR })
 
   Report: "Repair complete. PR: " + prResult.prUrl
   STOP

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -8,35 +8,37 @@ user-invocable: false
 
 Open a pull request on GitHub and manage it through to merge.
 
+## Input
+
+- `bodyFile` (string) — Path to a markdown file with the PR body content
+- `workDir` (string) — Absolute path to the worktree where changes were made
+
 ## Steps
 
 The worktree is already on the correct feature branch (`feature/<taskName>`). Do NOT create a
 new branch — committing from the main worktree CWD on a new `fix/` branch would cause commits
-to land on `main` instead of `feature/<taskName>`. All git commands must use `-C "$WORK_DIR"`
+to land on `main` instead of `feature/<taskName>`. All git commands must use `-C "$workDir"`
 to operate on the feature worktree.
 
 1. Confirm the current branch in the worktree:
    ```bash
-   git -C "$WORK_DIR" branch --show-current
+   git -C "$workDir" branch --show-current
    # Expected output: feature/<taskName>
    # If not on the correct feature branch, stop and report the error.
    ```
 
 2. Stage and commit all changes from the worktree:
    ```bash
-   git -C "$WORK_DIR" add --all
-   git -C "$WORK_DIR" commit -m "<short title from bug explanation>"
+   git -C "$workDir" add --all
+   git -C "$workDir" commit -m "<short title from bug explanation>"
    ```
 
 3. Push the feature branch and open the PR:
    ```bash
-   git -C "$WORK_DIR" push -u origin HEAD
-   # Always write the body to a temp file — never pass it inline with --body.
-   # Inline bodies fail with "Parser aborted" when the content is large.
-   cat > /tmp/pr-body.md << 'EOF'
-   <body content here>
-   EOF
-   gh pr create --title "<type>(<scope>): <description>" --body-file /tmp/pr-body.md --head feature/<taskName>
+   git -C "$workDir" push -u origin HEAD
+   # cd into workDir for gh commands so it recognizes the correct repository
+   cd "$workDir"
+   gh pr create --title "<type>(<scope>): <description>" --body-file /tmp/pr-body.md
    ```
 
 ## PR Title Format

--- a/skills/git-c-worktree-subagent/SKILL.md
+++ b/skills/git-c-worktree-subagent/SKILL.md
@@ -29,9 +29,27 @@ The Bash tool in a sub-agent does not inherit the orchestrator's working directo
 
 4. In the orchestrator that spawns the sub-agent, pass `workDir` explicitly in the invocation payload, and document that the sub-agent must use `-C workDir` for all git calls.
 
+## gh CLI workaround (no -C flag)
+
+Unlike `git`, the `gh` CLI does **not** support a `-C <dir>` flag. It resolves the repository from the process working directory. When sub-agents need to run `gh pr view`, `gh pr create`, or any other `gh` command scoped to a specific worktree, they must `cd` into `workDir` first:
+
+```bash
+# WRONG — gh resolves the repo from CWD, not from the -C flag
+cd "$workDir" && gh pr view --json url --jq '.url'   # correct
+gh pr view --json url --jq '.url'                     # wrong if CWD is main repo
+```
+
+In agent pseudocode:
+```
+existingPr = bash("cd \"$workDir\" && gh pr view --json url --jq '.url' 2>/dev/null || echo ''")
+```
+
+This matters most in pr-agent when checking whether an existing PR is open on the feature branch. Without `cd "$workDir"`, `gh pr view` checks the main repo's current branch (typically `main`), not the feature branch in the isolated worktree.
+
 ## Notes
 
 - `git -C <path>` is equivalent to `cd <path> && git` but does not mutate the process CWD, making it safe to use in a Bash tool call that might be followed by other shell operations.
+- `gh` has no `-C` equivalent — always use `cd "$workDir" && gh ...` instead.
 - The companion pattern for detecting when this rule was violated at runtime is the branch-drift guard — see skill `branch-drift-guard`.
 - This rule applies even when the sub-agent's instruction says "you are already inside WORK_DIR". The Bash tool's CWD is determined by the LLM runtime, not by prose instructions.
 - If a sub-agent truly cannot use `-C` (e.g., it must run a script that calls git internally), ensure the script itself is passed WORK_DIR and uses it as `--git-dir` / `--work-tree` or changes directory internally before any git calls.

--- a/skills/resolve-workdir-before-subagent-invoke/SKILL.md
+++ b/skills/resolve-workdir-before-subagent-invoke/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: resolve-workdir-before-subagent-invoke
+description: "Command agents must resolve the worktree path via git rev-parse --show-toplevel and pass it explicitly to any sub-agent that performs git or gh operations, rather than letting the sub-agent guess from env vars or pointer files."
+user-invocable: false
+---
+## When to use
+
+In any command agent (execute-command-agent, debug-command-agent, repair-command-agent, or similar) that invokes a downstream agent (pr-agent, skill-update-agent, etc.) that needs to operate on the correct isolated worktree. Apply this before every sub-agent invocation that involves file writes, git commits, pushes, or PR operations.
+
+## Steps
+
+1. At the step where you are about to invoke a sub-agent that needs workDir, resolve the worktree root from the running shell — do not read it from an env var or pointer file, which may be stale or unset:
+   ```
+   WORK_DIR = bash("git rev-parse --show-toplevel")
+   ```
+
+2. Pass WORK_DIR explicitly as a parameter in the sub-agent invocation:
+   ```
+   prResult = invoke pr-agent({ planFilePath, workDir: WORK_DIR })
+   invoke skill-update-agent({ planFilePath, workDir: WORK_DIR, taskSummary })
+   ```
+
+3. Never rely on the sub-agent to infer workDir from `$DARK_FACTORY_WORK_DIR` or `/tmp/dark-factory-work-dir` when the calling agent has the correct path available — those fallbacks exist only for agents that are invoked without a caller that knows the path.
+
+## Notes
+
+- `git rev-parse --show-toplevel` returns the absolute root of the worktree that the current process's CWD belongs to. In an isolated worktree at `/path/to/repo-feature-foo`, it returns that path exactly.
+- This is distinct from `$DARK_FACTORY_WORK_DIR` (an env var set at worktree creation time) and `/tmp/dark-factory-work-dir` (a pointer file fallback). Those mechanisms are for agents that lack a calling agent able to supply the path. Prefer the explicit parameter chain when the caller can resolve it.
+- The concrete failure mode this prevents: pr-agent runs `gh pr view` without knowing the worktree path, so it checks the main repo's current branch instead of the feature branch, finds no open PR, and creates a duplicate.
+- See skill `git-c-worktree-subagent` for the related rule that `gh` commands must `cd "$workDir"` since `gh` has no `-C` flag.


### PR DESCRIPTION
## Summary

Pass `workDir` explicitly to `pr-agent` from `execute-command-agent`, `debug-command-agent`, and `repair-command-agent` so pr-agent can find and reuse the existing open PR on the current branch instead of always opening a new one. Also fixed null vs empty check in pr-agent and parameter name mismatches.

## Changes

- **pr-agent**: Added `workDir` as a required input parameter; updated Step 0 to use `cd "$workDir" && gh pr view` so it checks for existing PRs scoped to the worktree; fixed null check to empty check
- **execute-command-agent**: Pass `workDir` to pr-agent invocation; fixed parameter name from `planPath` to `planFilePath`
- **debug-command-agent**: Pass `workDir` to pr-agent invocation; fixed parameter name to `planFilePath`
- **repair-command-agent**: Pass `workDir` to pr-agent invocation; fixed parameter name to `planFilePath`
- **git-c-worktree-subagent**: Documented gh CLI workaround (no -C flag; must use `cd "$workDir" && gh ...`)
- **resolve-workdir-before-subagent-invoke**: New skill documenting the pattern for resolving workDir before sub-agent invocation

## Why

The original implementation had no way for `pr-agent` to know which worktree it was operating on, causing it to check for existing PRs against the main repo branch instead of the feature branch in the isolated worktree. By passing `workDir` explicitly and using `cd "$workDir"` when invoking `gh pr view`, pr-agent can now detect and reuse existing open PRs, avoiding duplicate PR creation during retry flows.

## Test Plan

Manual verification:
- Confirm execute-command-agent, debug-command-agent, and repair-command-agent pass workDir to pr-agent
- Confirm pr-agent uses `cd "$workDir" && gh pr view` to check for existing PRs
- Confirm parameter names (planFilePath, workDir) are consistent across invocations
