### PR TITLE
fix(debugger-agent): move investigation-agent to step 6 after failing test

### DIFF
--- a/agents/debugger/agents/debugger-agent.md
+++ b/agents/debugger/agents/debugger-agent.md
@@ -12,7 +12,12 @@ You are a systematic debugger. Your only job is to follow the steps in `flows/de
 
 ## Steps
 
-0. **Understand the system** — Before proceeding with systematic debugging, invoke `investigation-agent` with the bug description to understand the system context. This ensures you have authoritative documentation about the components involved in the failure before diving into debugging.
+1. Confirm the bug warrants systematic debugging (non-obvious, state-dependent, intermittent, unknown cause).
+2. Search the project `docs/bugs/` for an existing file with the same failure signature. Create `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` if none found.
+3. Read all relevant logs and stack traces before touching code.
+4. Fill the bug file using bug-audit-log-template.
+5. Write a failing reproduction test first, then confirm the test fails before any fix.
+6. **Understand the system** — Now that you have a reproducible failure, invoke `investigation-agent` to understand the system context. This ensures you understand the system within the context of a known, reproducible failure (not in the abstract).
    ```
    result = invoke investigation-agent({
      system: "",
@@ -25,19 +30,11 @@ You are a systematic debugger. Your only job is to follow the steps in `flows/de
      # Use result.content as reference documentation during debugging
      systemDocumentation = result.content
    ```
-
-1. Confirm the bug warrants systematic debugging (non-obvious, state-dependent, intermittent, unknown cause).
-2. Search the project `docs/bugs/` for an existing file with the same failure signature. Create `docs/bugs/<yyyy-mm-dd>-<bug-slug>.md` if none found.
-3. Read all relevant logs and stack traces before touching code.
-4. Fill the bug file using bug-audit-log-template.
-5. Run the debugging checklist in order:
-   - Write a failing reproduction test first.
-   - Confirm the test fails before any fix.
-   - Identify root cause from evidence.
-   - Fix the root problem.
-   - Confirm the test passes.
-   - Remove the fix and confirm it fails again (when safe).
-6. Record root cause, fix summary, and verification in the bug file.
+7. Identify root cause from evidence.
+8. Fix the root problem.
+9. Confirm the test passes.
+10. Remove the fix and confirm it fails again (when safe).
+11. Record root cause, fix summary, and verification in the bug file.
 
 ## Brain Patch
 

--- a/docs/docs/debugger-agent.md
+++ b/docs/docs/debugger-agent.md
@@ -14,7 +14,7 @@ The debugger-agent runs systematic debugging following a rigorous checklist-base
 
 - `taskDescription` (string) — Description of the bug to debug (what is failing, expected behavior, actual behavior)
 
-## Debugging Workflow (6 Steps)
+## Debugging Workflow (11 Steps)
 
 ### Step 1: Confirm Bug Warrants Systematic Debugging
 
@@ -52,44 +52,60 @@ Uses `bug-audit-log-template` to document:
 - **Relevant Logs**: Stack traces, error messages, logs from failing runs
 - **Hypotheses**: Theories about root cause based on evidence (not yet confirmed)
 
-### Step 5: Run Debugging Checklist
+### Step 5: Write Failing Reproduction Test
 
-Follows this sequence in strict order:
+- Create minimal test case that reproduces the bug
+- Arrange inputs per failure conditions
+- Assert expected behavior
+- Run test on unmodified code to confirm it fails (assertion error, not import/syntax error)
+- Verify test fails consistently (not intermittent test failure)
+- Note the failure signature in bug file
 
-1. **Write a failing reproduction test**
-   - Minimal test case that reproduces the bug
-   - Arrange inputs per failure conditions
-   - Assert expected behavior
-   - Confirm test fails (assertion error, not import/syntax error)
+### Step 6: Understand the System Context
 
-2. **Confirm the test fails before any fix**
-   - Run test on unmodified code
-   - Verify it fails consistently (not intermittent test failure)
-   - Note the failure signature in bug file
+Now that you have a reproducible failure, invoke `investigation-agent` to understand the system context. This ensures you understand the system within the context of a known, reproducible failure (not in the abstract). This approach aligns with "The Art of Debugging" methodology.
 
-3. **Identify root cause from evidence**
-   - Examine code paths involved in failure
-   - Review logs and stack traces from step 3
-   - Form hypothesis about root cause
-   - Validate hypothesis against all evidence
+```
+result = invoke investigation-agent({
+  system: "",
+  question: "<taskDescription>"
+})
 
-4. **Fix the root problem**
-   - Apply minimal fix targeting identified root cause
-   - Do not apply workarounds or papering over symptoms
-   - Do not change unrelated code
+if result.error:
+  log("Investigation failed, proceeding with available knowledge")
+else:
+  # Use result.content as reference documentation during debugging
+  systemDocumentation = result.content
+```
 
-5. **Confirm the test passes**
-   - Run the reproduction test on fixed code
-   - Verify it passes consistently
-   - Document the fix in bug file
+### Step 7: Identify Root Cause from Evidence
 
-6. **Remove the fix and confirm it fails again** (when safe)
-   - Revert fix to unmodified code
-   - Re-run reproduction test
-   - Verify it fails as before (confirms fix actually addresses the issue, not coincidence)
-   - Re-apply fix
+- Examine code paths involved in failure
+- Review logs and stack traces from step 3
+- Reference system documentation from step 6
+- Form hypothesis about root cause
+- Validate hypothesis against all evidence
 
-### Step 6: Record Root Cause and Verification
+### Step 8: Fix the Root Problem
+
+- Apply minimal fix targeting identified root cause
+- Do not apply workarounds or papering over symptoms
+- Do not change unrelated code
+
+### Step 9: Confirm the Test Passes
+
+- Run the reproduction test on fixed code
+- Verify it passes consistently
+- Document the fix in bug file
+
+### Step 10: Verify Fix is Necessary (when safe)
+
+- Revert fix to unmodified code
+- Re-run reproduction test
+- Verify it fails as before (confirms fix actually addresses the issue, not coincidence)
+- Re-apply fix
+
+### Step 11: Record Root Cause and Verification
 
 Update bug file with:
 - **Root Cause**: Explanation of why the bug occurred (reference code locations)
@@ -98,14 +114,17 @@ Update bug file with:
 
 ## Brain Patch Output
 
-After all bug files are written and debugging checklist is complete:
+After all bug files are written and debugging checklist is complete (step 11):
 
-Resolves WORK_DIR (see rule 7) and writes `$WORK_DIR/brain-patch.json`:
+Resolves WORK_DIR (see rule 8) and writes `$WORK_DIR/brain-patch.json`:
 ```json
 {
   "bugFiles": [
     "/absolute/path/to/bug-file-1.md",
     "/absolute/path/to/bug-file-2.md"
+  ],
+  "notes": [
+    "debugger-agent: root cause was <summary>, fixed in <key files>"
   ]
 }
 ```
@@ -115,11 +134,12 @@ Resolves WORK_DIR (see rule 7) and writes `$WORK_DIR/brain-patch.json`:
 1. **Follow the checklist in strict order** — Do not skip steps; each step validates the previous one
 2. **Read all evidence before coding** — Understand the bug completely before touching code
 3. **Write tests before fixing** — Test-first ensures the fix is actually necessary
-4. **Verify fix is necessary** — Remove fix and confirm test fails again (except when unsafe)
-5. **Do NOT read brain.json** — Context is already injected by pre-hook
-6. **Do NOT write brain.json directly** — Only write brain-patch.json
-7. **Resolve WORK_DIR via pointer file fallback** — Use `$DARK_FACTORY_WORK_DIR` if set; else read contents of `/tmp/dark-factory-work-dir`; skip brain-patch silently if both are empty
-8. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
+4. **Understand system in context of failure** — Invoke investigation-agent after a reproducible test is written and confirmed failing, not in the abstract (Step 6). This ensures system understanding is grounded in a concrete, reproducible failure.
+5. **Verify fix is necessary** — Remove fix and confirm test fails again (except when unsafe)
+6. **Do NOT read brain.json** — Context is already injected by pre-hook
+7. **Do NOT write brain.json directly** — Only write brain-patch.json
+8. **Resolve WORK_DIR via pointer file fallback** — Use `$DARK_FACTORY_WORK_DIR` if set; else read contents of `/tmp/dark-factory-work-dir`; skip brain-patch silently if both are empty
+9. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
 
 ## Dependencies
 

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -21,24 +21,20 @@ Follow this skill every time debugging is required and the issue is not simple o
    - Read all relevant stack traces, runtime logs, and debugger logs for the failing path.
    - Compare current logs with prior bug logs to find similar known failures and reuse validated guidance when applicable.
 4. Fill the bug file from `templates/bug-audit-log-template.md`. Do not invent alternate section order.
-5. Run the debugging checklist in order:
-   - Stop thinking - make an audit log.
-   - Read the bug.
-   - Make it fail by writing an automated reproduction test first (unit test preferred; integration/e2e when unit is not feasible), and record exact steps.
-   - Understand the system boundary and flow.
-   - Run the reproduction test to confirm it fails before the fix.
-   - Identify the cause of failure from evidence.
-   - Fix the root problem (never just symptoms).
-   - Re-run the reproduction test and failure steps to confirm the issue is resolved.
-   - Remove the fix and confirm the bug fails again (when safe) to prove causality.
-6. Verify and finalize:
-   - Keep the repro test as a regression guard when appropriate.
-   - Record final root cause, fix summary, and verification evidence in the bug file.
-   - Ensure one saved audit log per unique solved root cause; merge duplicates into the existing bug file.
-7. Run a final code review gate by invoking `.agent/skills/code-review/SKILL.md`:
-   - Validate the fix diff against plan contracts.
-   - Validate plan-flow test harness coverage for the fix paths.
-   - Validate DRY/YAGNI and maintainability before closing the bug.
+5. Make it fail by writing an automated reproduction test first (unit test preferred; integration/e2e when unit is not feasible), and record exact steps. Run the reproduction test to confirm it fails before any fix.
+6. Understand the system boundary and flow. Invoke investigation-agent to understand the system context in the context of your known, reproducible failure.
+7. Identify the cause of failure from evidence.
+8. Fix the root problem (never just symptoms).
+9. Re-run the reproduction test and failure steps to confirm the issue is resolved.
+10. Remove the fix and confirm the bug fails again (when safe) to prove causality.
+11. Verify and finalize:
+    - Keep the repro test as a regression guard when appropriate.
+    - Record final root cause, fix summary, and verification evidence in the bug file.
+    - Ensure one saved audit log per unique solved root cause; merge duplicates into the existing bug file.
+12. Run a final code review gate by invoking `.agent/skills/code-review/SKILL.md`:
+    - Validate the fix diff against plan contracts.
+    - Validate plan-flow test harness coverage for the fix paths.
+    - Validate DRY/YAGNI and maintainability before closing the bug.
 
 ## Resources
 - Related skill: `.agent/skills/code-review/SKILL.md` for end-of-fix quality gate.


### PR DESCRIPTION
## Summary

Restructures the debugger-agent workflow to align with "The Art of Debugging" methodology. Moves investigation-agent invocation from step 0 (abstract understanding) to step 6 (after reproducible failure is confirmed), ensuring system understanding is grounded in concrete, reproducible failure context rather than abstract analysis.

## Changes

- Expands debugging workflow from 6 to 11 explicit steps
- Step 5: Write Failing Reproduction Test
- Step 6: Understand System Context (investigation-agent call now happens here)
- Steps 7-11: Root cause identification, fix, verification, and documentation
- Updated rule 4 to emphasize understanding system in context of failure, not in the abstract

## Rationale

System understanding is most valuable when grounded in a known, reproducible failure. This prevents premature abstraction and ensures investigation is targeted at the actual problem.

## Test Plan

- [x] Documentation follows the improved debugging methodology
- [x] Steps are now in strict order as per "The Art of Debugging" principles
