### PR TITLE
refactor(repair-command-agent): remove significantChange fast-path

### DIFF
--- a/agents/dark-factory/agents/repair-command-agent.md
+++ b/agents/dark-factory/agents/repair-command-agent.md
@@ -10,7 +10,7 @@ model: sonnet
 You are the repair-command-agent. Your job is to orchestrate targeted repairs by:
 1. Deriving a task name from the change description
 2. Running repair-agent to apply targeted changes
-3. Conditionally running the post-execution pipeline (code review → docs → skills → PR → cleanup)
+3. Running the post-execution pipeline (code review → docs → skills → PR → cleanup)
 
 The agent assumes it is already running in the correct working directory (worktree). Worktree creation is handled by gotoworktree-command-agent.
 
@@ -37,25 +37,20 @@ repair-command-agent(taskDescription, taskName):
     report error: "Repair failed after 5 iterations: " + result.error.message
     STOP
 
-  # Step 3 — if repair was insignificant, skip code review and PR (fast path)
-  if result.significantChange == false:
-    Report: "Repair applied (insignificant change — no PR opened)."
-    STOP
-
-  # Step 4 — code review
+  # Step 3 — code review
   invoke code-review-orchestrator-agent({
     planFilePath: "Task: " + taskDescription,
     codePath: PROJECT_DIR
   })
 
-  # Step 5 — update docs (non-fatal)
+  # Step 4 — update docs (non-fatal)
   invoke update-documentation-agent({ planFilePath: null, workDir: PROJECT_DIR })
 
-  # Step 6 — skill update (non-fatal)
+  # Step 5 — skill update (non-fatal)
   try: invoke skill-update-agent({ planFilePath: null, workDir: PROJECT_DIR, taskSummary: taskDescription })
   catch: warn and continue
 
-  # Step 7 — determine WORK_DIR (worktree root) and open PR
+  # Step 6 — determine WORK_DIR (worktree root) and open PR
   WORK_DIR = bash("git rev-parse --show-toplevel")
   prResult = invoke pr-agent({ planFilePath: taskDescription, workDir: WORK_DIR })
   prUrl = prResult.prUrl
@@ -66,7 +61,7 @@ repair-command-agent(taskDescription, taskName):
 
 ## Rules
 
-- Check repair-agent's `significantChange` flag to determine if a PR should be opened (fast path for insignificant repairs).
-- Never skip code review, docs, or PR steps for significant changes.
+- Always run code review, docs, and PR steps after a successful repair.
+- pr-agent handles both new PR creation and reuse of existing PRs on the branch (via `gh pr view`).
 - Gracefully handle repair-agent errors (report and stop).
 - This agent runs in-place; worktree setup is handled by gotoworktree-command-agent.

--- a/agents/repair/agents/repair-agent.md
+++ b/agents/repair/agents/repair-agent.md
@@ -37,16 +37,11 @@ You will be invoked with:
 
 3. **Apply** — Make the targeted change. Keep modifications minimal and focused.
 
-4. **Assess significance** — Set `significantChange = true` if any modified file is:
-   - An agent instruction file (`*.md` inside `agents/`)
-   - A skill definition (`SKILL.md`)
-   - A user-facing command (inside `commands/`)
-   - A public API or interface boundary
-   Otherwise `significantChange = false`.
+4. **Assess significance** — Note which files were modified, but do not check for significance (the caller will determine whether a PR is needed based on git diff).
 
-5. **Fix failures** — Run the test suite again. If tests fail, check which failures are new (not present in the pre-existing baseline from step 2). For new failures, diagnose and apply a targeted fix, then re-run. Repeat up to **5 times**. If new test failures are still present after 5 attempts, return `{ success: false, significantChange, error: { message: "<summary of last failure>" } }`. Note any pre-existing failures in the output but do not count them as failures caused by the repair.
+5. **Fix failures** — Run the test suite again. If tests fail, check which failures are new (not present in the pre-existing baseline from step 2). For new failures, diagnose and apply a targeted fix, then re-run. Repeat up to **5 times**. If new test failures are still present after 5 attempts, return `{ success: false, error: { message: "<summary of last failure>" } }`. Note any pre-existing failures in the output but do not count them as failures caused by the repair.
 
-6. **Return** — `{ success: true, significantChange }`.
+6. **Return** — `{ success: true }`.
 
 ## Rules
 

--- a/docs/docs/dark-factory-commands.md
+++ b/docs/docs/dark-factory-commands.md
@@ -203,23 +203,23 @@ flowchart TD
    - Read relevant files; identify minimal change set.
    - Run baseline test suite; record pre-existing failures.
    - Apply the targeted change.
-   - Assess `significantChange` flag (true if agent/skill/command files or public API are modified).
    - Run tests again; iterate up to 5 times fixing new failures only.
-   - Return `{ success: true|false, significantChange }`.
+   - Return `{ success: true|false, error? }`.
 4. If `result.success == false`: report error and stop.
-5. If `result.significantChange == false`: report "Repair applied (insignificant change — no PR opened)" and stop.
-6. Invoke `code-review-orchestrator-agent` with `"Task: " + taskDescription` and `codePath`.
-7. Invoke `update-documentation-agent` with `planFilePath=null` and `workDir`.
-8. Invoke `skill-update-agent` (non-fatal).
-9. Invoke `pr-agent` with `taskDescription`.
-10. Report: "Repair complete. PR: `<prUrl>`".
+5. Invoke `code-review-orchestrator-agent` with `"Task: " + taskDescription` and `codePath`.
+6. Invoke `update-documentation-agent` with `planFilePath=null` and `workDir`.
+7. Invoke `skill-update-agent` (non-fatal).
+8. Invoke `pr-agent` with `taskDescription`.
+   - pr-agent checks for existing PR on current branch via `gh pr view`.
+   - If PR exists: commits and pushes to it.
+   - If no PR: creates a new one.
+9. Report: "Repair complete. PR: `<prUrl>`".
 
 #### Paths
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `repair.success-significant` | taskDescription | prUrl | happy path | Significant change applied, code-reviewed, PR open |
-| `repair.success-insignificant` | taskDescription | status message | fast path | Insignificant change applied, no PR opened |
+| `repair.success` | taskDescription | prUrl | happy path | Change applied, code-reviewed, PR open (new or existing) |
 | `repair.failed` | taskDescription | error message | error | repair-agent returned success=false after 5 iterations |
 
 ---

--- a/docs/docs/repair-agent.md
+++ b/docs/docs/repair-agent.md
@@ -46,21 +46,9 @@ Unlike the debugging agent, repair-agent does not use a systematic debug methodo
 3. Keeps changes tight and focused (no refactoring)
 4. Does not introduce new abstractions, helpers, or patterns outside the task scope
 
-### Step 4: Assess Significance
+### Step 4: Complete Repair
 
-Sets `significantChange` flag based on whether any modified file is:
-
-**Significant if changed**:
-- Agent instruction file (`*.md` inside `agents/`)
-- Skill definition (`SKILL.md`)
-- User-facing command (inside `commands/`)
-- Public API or interface boundary
-
-**Not significant otherwise**:
-- Data files
-- Configuration files
-- Comments-only changes
-- Internal implementation details
+The repair is applied and all changes are committed. The caller (repair-command-agent) will determine whether a PR is needed based on the current branch state (existing PR or new PR).
 
 ### Step 5: Fix Failures
 
@@ -75,7 +63,7 @@ Sets `significantChange` flag based on whether any modified file is:
    - If no new failures: proceed to Step 6
 
 4. **After 5 attempts**: if new test failures still exist:
-   - Returns `{ success: false, significantChange, error: { message: "<last failure summary>" } }`
+   - Returns `{ success: false, error: { message: "<last failure summary>" } }`
    - Notes pre-existing failures but doesn't count them
 
 ### Step 6: Return Result
@@ -83,8 +71,7 @@ Sets `significantChange` flag based on whether any modified file is:
 **Success**:
 ```json
 {
-  "success": true,
-  "significantChange": true|false
+  "success": true
 }
 ```
 
@@ -92,7 +79,6 @@ Sets `significantChange` flag based on whether any modified file is:
 ```json
 {
   "success": false,
-  "significantChange": true|false,
   "error": {
     "message": "<summary of last test failure>"
   }
@@ -107,7 +93,8 @@ Sets `significantChange` flag based on whether any modified file is:
 4. **Pre-existing failures are noted, not counted** — Only new failures caused by the change block success
 5. **5-attempt limit** — Stop iterating after 5 tries; return failure
 6. **No plan file required** — This is the lightweight alternative to feature-agent
-7. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
+7. **No significance assessment** — repair-command-agent always runs the full post-pipeline (code review, docs, PR); pr-agent handles both new PR creation and existing PR reuse
+8. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
 
 ## Dependencies
 
@@ -127,9 +114,9 @@ Sets `significantChange` flag based on whether any modified file is:
 
 ## Lifecycle in repair-command-agent
 
-1. Invoked by repair-command-agent as non-fatal step
-2. If returns `success: false`: logged but repair-command-agent continues to code review and PR
-3. If returns `success: true`: continues to code review
+1. Invoked by repair-command-agent as first step
+2. If returns `success: false`: repair-command-agent logs error and stops
+3. If returns `success: true`: repair-command-agent always continues to code review, docs, and PR (pr-agent handles both new PR creation and reuse of existing PRs)
 4. No brain-patch.json written (repair-agent produces no artifacts for downstream use)
 
 ## Use Cases

--- a/docs/docs/repair-command-agent.md
+++ b/docs/docs/repair-command-agent.md
@@ -6,7 +6,7 @@
 
 ## System Intent
 
-- What this is: The `repair-command-agent` backs the `/dark-factory:repair` slash command. It runs in-place in whatever working directory (worktree) it is invoked from — worktree setup is handled by `gotoworktree-command-agent` separately. It delegates to `repair-agent` to apply targeted changes, then conditionally runs the post-execution pipeline depending on whether the repair was significant. Insignificant repairs skip code review and PR entirely. State is passed directly between steps as local variables — no `brain.json` is created.
+- What this is: The `repair-command-agent` backs the `/dark-factory:repair` slash command. It runs in-place in whatever working directory (worktree) it is invoked from — worktree setup is handled by `gotoworktree-command-agent` separately. It delegates to `repair-agent` to apply targeted changes, then always runs the post-execution pipeline (code review → docs → skills → PR). The pr-agent naturally handles both new PR creation and reuse of existing PRs on the branch. State is passed directly between steps as local variables — no `brain.json` is created.
 
 ## Mermaid Diagram
 
@@ -19,12 +19,11 @@ flowchart TD
   RCA --> RA["repair-agent\n(taskDescription)"]
 
   RA -->|"success: false"| ERR["STOP: error"]
-  RA -->|"significantChange: false"| FAST["STOP: insignificant\n(no PR)"]
-  RA -->|"significantChange: true"| CRO["code-review-orchestrator-agent"]
+  RA -->|"success: true"| CRO["code-review-orchestrator-agent"]
 
   CRO --> UDA["update-documentation-agent"]
   UDA --> SUA["skill-update-agent\n(non-fatal)"]
-  SUA --> PRA["pr-agent"]
+  SUA --> PRA["pr-agent\n(new or existing)"]
   PRA -->|"prUrl"| Done["Done: PR URL"]
 ```
 
@@ -44,8 +43,7 @@ RepairCommandInput {
 }
 
 RepairCommandOutput {
-  prUrl:             string
-  significantChange: boolean
+  prUrl: string
 }
 
 StandardError {
@@ -57,8 +55,7 @@ StandardError {
 
 | path | input | output | path-type | notes |
 | --- | --- | --- | --- | --- |
-| `repairCommand.success` | `RepairCommandInput` | `RepairCommandOutput` | happy path | repair applied, tests passing, PR opened (for significant changes) |
-| `repairCommand.insignificant` | `RepairCommandInput` | `{ significantChange: false }` | happy path | repair applied but no PR opened (fast path) |
+| `repairCommand.success` | `RepairCommandInput` | `RepairCommandOutput` | happy path | repair applied, tests passing, PR opened (new or existing) |
 | `repairCommand.test-failure` | `RepairCommandInput` | `StandardError` | error | repair-agent could not fix new test failures within 5 iterations |
 
 #### Pseudocode
@@ -79,12 +76,7 @@ repair-command-agent(taskDescription, taskName):
     report error: "Repair failed after 5 iterations: " + result.error.message
     STOP
 
-  # Step 3 — fast path for insignificant changes
-  if result.significantChange == false:
-    Report: "Repair applied (insignificant change — no PR opened)."
-    STOP
-
-  # Steps 4-7 — post-execution pipeline
+  # Steps 3-6 — post-execution pipeline
   invoke code-review-orchestrator-agent({
     planFilePath: "Task: " + taskDescription,
     codePath: PROJECT_DIR
@@ -110,4 +102,4 @@ repair-command-agent(taskDescription, taskName):
   ```bash
   /dark-factory:repair
   ```
-- Notes: Invoked as a Claude Code slash command. Requires the dark-factory plugin installed. The agent runs in-place in the current directory — use `/dark-factory:gotoworktree` first to land in the correct worktree. Insignificant repairs (as determined by repair-agent's `significantChange` flag) skip code review and PR opening entirely.
+- Notes: Invoked as a Claude Code slash command. Requires the dark-factory plugin installed. The agent runs in-place in the current directory — use `/dark-factory:gotoworktree` first to land in the correct worktree. All repairs go through the full post-execution pipeline (code review, docs, skills, PR). The pr-agent handles both new PR creation and reuse of existing PRs on the branch via `gh pr view`.

--- a/skills/stateless-command-agent-orchestrator/SKILL.md
+++ b/skills/stateless-command-agent-orchestrator/SKILL.md
@@ -47,7 +47,8 @@ This is the architecture used by the six standalone commands: plan, execute, deb
      invoke code-review-orchestrator-agent({ planFilePath, codePath: PROJECT_DIR })
      invoke update-documentation-agent({ planFilePath, workDir: PROJECT_DIR })
      try: invoke skill-update-agent({ planFilePath, workDir: PROJECT_DIR, taskSummary: taskDescription })
-     prResult = invoke pr-agent({ planFilePath })
+     WORK_DIR = bash("git rev-parse --show-toplevel")  # must be passed explicitly for pr-agent reuse
+     prResult = invoke pr-agent({ planFilePath, workDir: WORK_DIR })
      prUrl = prResult.prUrl
 
      Report: "Done. PR: " + prUrl
@@ -89,6 +90,8 @@ This is the architecture used by the six standalone commands: plan, execute, deb
 
 - `planFilePath` may be `null` for debug and repair routes (no plan file generated). When null, pass a human-readable string like `"Task: " + taskDescription` to code-review-orchestrator-agent and pr-agent so they have context.
 - **Do not add the post-execution pipeline to plan-only commands.** The pipeline (code-review → docs → skills → PR) only makes sense when code has actually changed. A plan-only command produces a single markdown file; adding the pipeline causes phantom code reviews, spurious PRs, and skill extractions against no real code change. The canonical division: `plan` command = feature-agent with planOnly:true, no pipeline. `execute` command = execution-agent + full pipeline.
+- **Never gate the post-execution pipeline on a worker flag.** A worker agent must never return a `significantChange` (or similar boolean) that the command-agent uses to skip code review or PR steps. The pipeline always runs after a successful worker result — pr-agent internally decides whether to open a new PR or reuse an existing one on the current branch (via `gh pr view`). Adding a significance gate breaks PR reuse: re-runs on an existing branch will skip pr-agent and the existing PR will never be updated.
+- **Always pass `workDir` explicitly to pr-agent.** pr-agent uses `gh pr view` on the current branch to detect existing PRs and decide between creation and reuse. Without `workDir`, `gh` may resolve to the wrong repo context. Always resolve `WORK_DIR = bash("git rev-parse --show-toplevel")` immediately before the pr-agent invocation and pass it as the `workDir` argument.
 - Command agents no longer call `prep-feature-dir.sh`, `find-related-pr.sh`, `AskUserQuestion` for PR reuse, or `cleanup-worktree.sh`. All of that is handled by `gotoworktree-command-agent` when the user explicitly needs a worktree.
 - `codePath` and `workDir` passed to post-execution agents are `PROJECT_DIR` (the live cwd), not a separate `WORK_DIR`. If the user is already inside a worktree, `PROJECT_DIR` will resolve to the worktree root correctly.
 - Do not add the command to an agent allowlist or PHASE_MAP in any hook — this pattern uses no hooks.


### PR DESCRIPTION
## Summary

Removes the `significantChange` fast-path from repair-command-agent. The repair pipeline now always runs the full post-execution sequence (code-review → docs → skills → pr-agent), aligning with execute and debug patterns.

Key changes:
- pr-agent now handles both creation of new PRs and reuse of existing PRs on the current branch via `gh pr view`
- repair-command-agent no longer gates pr-agent invocation on a `significantChange` flag
- Documentation updated to clarify that post-execution pipeline always runs and pr-agent decides reuse internally
- Reinforces requirement to always pass `workDir` explicitly to pr-agent for correct gh repo context

This ensures that re-runs on an existing branch will properly update the existing PR instead of skipping the pr-agent step.

## Test Plan

- [x] Documentation updates reviewed
- [x] Changes committed and pushed
