### PR TITLE
chore: remove duplicate investigate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Feature work uses a structured plan template before a single line of code is wri
 | `/dark-factory:execute` | Path to an approved plan file | Implements an approved plan — runs the full execution pipeline, code review, and opens a PR |
 | `/dark-factory:debug` | Bug description | Diagnoses and fixes a non-obvious bug — fills out a bug audit log, applies the fix, runs code review, and opens a PR |
 | `/dark-factory:repair` | Change description | Applies a small targeted change — no plan required, runs tests in a loop until green, opens a PR |
-| `/dark-factory:investigate` | System name or topic | Investigates a system and writes authoritative documentation to `docs/docs/` |
+| `/dark-factory:investigation` | System name or topic | Investigates a system and writes authoritative documentation to `docs/docs/` |
 | `/dark-factory:gotoworktree` | PR number, task name, or description | Finds or creates the matching git worktree and pulls main/master — use this before running any other command |
 | `/dark-factory:build-factory` | Optional terminal name | Opens a new gnome-terminal running `claude /remote-control` for parallel factory sessions |
 | `/dark-factory:install` | None | Install or reinstall the plugin (run from repo root after `git pull`) |

--- a/commands/investigate.md
+++ b/commands/investigate.md
@@ -1,5 +1,0 @@
----
-description: "Generates system documentation using investigation-agent, validates all claims via claim-validator-agent loops, commits verified doc via SubagentStop hook."
----
-
-Follow the instructions in `agents/commands/investigation-orchestrator.md` exactly.

--- a/docs/docs/dark-factory-commands.md
+++ b/docs/docs/dark-factory-commands.md
@@ -18,7 +18,7 @@ flowchart TD
     DEBUG["/dark-factory:debug"]
     REPAIR["/dark-factory:repair"]
     GOTOWORKTREE["/dark-factory:gotoworktree"]
-    INVESTIGATE["/dark-factory:investigate (or investigation)"]
+    INVESTIGATE["/dark-factory:investigation"]
     BUILD["/dark-factory:build-factory"]
     DESTROY["/dark-factory:destroy-factory"]
     INSTALL["/dark-factory:install"]
@@ -259,9 +259,9 @@ flowchart TD
 
 ---
 
-### Flow: `investigate` / `investigation`
+### Flow: `investigation`
 
-**Command file**: `commands/investigate.md` and `commands/investigation.md` (identical)  
+**Command file**: `commands/investigation.md`  
 **Entry agent**: `agents/commands/investigation-orchestrator.md`  
 **User-invocable**: yes
 

--- a/docs/docs/manufacture.md
+++ b/docs/docs/manufacture.md
@@ -6,7 +6,7 @@
 
 ## System Intent
 
-- What this is: The `/dark-factory:manufacture` command is the legacy top-level entry point for the dark-factory autonomous coding pipeline. **This command is deprecated.** Use the focused standalone commands instead: `/dark-factory:plan`, `/dark-factory:execute`, `/dark-factory:debug`, `/dark-factory:repair`, or `/dark-factory:investigate`. The command continues to work for backward compatibility but will be removed in a future version.
+- What this is: The `/dark-factory:manufacture` command is the legacy top-level entry point for the dark-factory autonomous coding pipeline. **This command is deprecated.** Use the focused standalone commands instead: `/dark-factory:plan`, `/dark-factory:execute`, `/dark-factory:debug`, `/dark-factory:repair`, or `/dark-factory:investigation`. The command continues to work for backward compatibility but will be removed in a future version.
 
 ## Mermaid Diagram
 

--- a/docs/plans/remove-duplicate-investigate-command.md
+++ b/docs/plans/remove-duplicate-investigate-command.md
@@ -1,0 +1,21 @@
+# Remove Duplicate /dark-factory:investigate Command
+
+## System Intent
+
+- **What is being built:** Remove the deprecated `/dark-factory:investigate` command (duplicate of `/dark-factory:investigation`) and update all references throughout the codebase to use the correct `investigation` command instead.
+- **Primary consumer(s):** End users of the dark-factory Claude Code plugin.
+- **Boundary:** This is a cleanup task that removes duplicate command files and updates documentation and help references.
+
+## Changes
+
+1. Delete `/commands/investigate.md` (duplicate command file)
+2. Update `README.md` to reference `/dark-factory:investigation` instead of `/dark-factory:investigate`
+3. Update `docs/docs/dark-factory-commands.md` to reflect the correct command name in diagrams and flows
+4. Update `docs/docs/manufacture.md` to reference the correct command in deprecated references
+
+## Acceptance Criteria
+
+- All references to the deprecated `/dark-factory:investigate` command are updated to `/dark-factory:investigation`
+- No broken links or references remain
+- Documentation is consistent across all files
+- The duplicate `commands/investigate.md` file is deleted


### PR DESCRIPTION
## Summary

Remove the duplicate `/dark-factory:investigate` command file and update all documentation and references to use the single `/dark-factory:investigation` command consistently throughout the codebase.

- Deleted duplicate `commands/investigate.md`
- Updated `README.md` to reference `/dark-factory:investigation`
- Updated `docs/docs/dark-factory-commands.md` to remove alias reference
- Updated `docs/docs/manufacture.md` to reference correct command

## Test plan

- Manual verification that all documentation references are consistent
- No automated tests required (documentation and config changes only)

🤖 Generated with Claude Code
