### PR TITLE
docs: update README command links and simplify command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Feature work uses a structured plan template before a single line of code is wri
 
 | Command | Input | Description |
 |---|---|---|
-| `/dark-factory:plan` | Task description | Plans a feature end-to-end — walks through system intent, architecture diagram, and per-flow approval gates, then opens a PR with the approved plan |
-| `/dark-factory:execute` | Path to an approved plan file | Implements an approved plan — runs the full execution pipeline, code review, and opens a PR |
-| `/dark-factory:debug` | Bug description | Diagnoses and fixes a non-obvious bug — fills out a bug audit log, applies the fix, runs code review, and opens a PR |
-| `/dark-factory:repair` | Change description | Applies a small targeted change — no plan required, runs tests in a loop until green, opens a PR |
-| `/dark-factory:investigation` | System name or topic | Investigates a system and writes authoritative documentation to `docs/docs/` |
-| `/dark-factory:save` | Optional task description | Commits current changes and opens or updates a PR — lightweight shortcut that skips code review and docs pipeline |
-| `/dark-factory:goto` | PR number, task name, or description | Finds or creates the matching git worktree and pulls main/master — use this before running any other command |
-| `/dark-factory:build-factory` | Optional terminal name | Opens a new gnome-terminal running `claude /remote-control` for parallel factory sessions |
-| `/dark-factory:destroy-factory` | Optional terminal name | Terminates all other running Claude/dark-factory terminal sessions and spawns one fresh factory terminal |
-| `/dark-factory:gen-hooks` | None | Scans YAML frontmatter of skill/agent/command files for hook declarations and writes them to `.claude/settings.json` |
-| `/dark-factory:install` | None | Install or reinstall the plugin (run from repo root after `git pull`) |
+| [/dark-factory:plan](docs/docs/plan-command-agent.md) | Task description | Plans a feature end-to-end — walks through system intent, architecture diagram, and per-flow approval gates, then saves the approved plan |
+| [/dark-factory:execute](docs/docs/execute-command-agent.md) | Path to an approved plan file | Implements an approved plan — runs the full execution pipeline, code review, and opens a PR |
+| [/dark-factory:debug](docs/docs/debug-command-agent.md) | Bug description | Diagnoses and fixes a non-obvious bug — fills out a bug audit log, applies the fix, runs code review, and opens a PR |
+| [/dark-factory:repair](docs/docs/repair-command-agent.md) | Change description | Applies a small targeted change — no plan required, runs tests in a loop until green, opens a PR |
+| [/dark-factory:investigation](docs/docs/investigation-command.md) | System name or topic | Investigates a system and writes authoritative documentation to `docs/docs/` |
+| [/dark-factory:save](docs/docs/save-command.md) | Optional task description | Commits current changes and opens or updates a PR — lightweight shortcut that skips code review and docs pipeline |
+| [/dark-factory:goto](docs/docs/gotoworktree-command-agent.md) | PR number, task name, or description | Finds or creates the matching git worktree and pulls main/master — use this before running any other command |
+| [/dark-factory:build-factory](docs/docs/build-factory.md) | Optional terminal name | Opens a new gnome-terminal running `claude /remote-control` for parallel factory sessions |
+| [/dark-factory:destroy-factory](docs/docs/destroy-factory.md) | Optional terminal name | Terminates all other running Claude/dark-factory terminal sessions and spawns one fresh factory terminal |
+| [/dark-factory:gen-hooks](docs/docs/gen-hooks.md) | None | Scans YAML frontmatter of skill/agent/command files for hook declarations and writes them to `.claude/settings.json` |
+| [/dark-factory:install](docs/docs/install.md) | None | Install or reinstall the plugin (run from repo root after `git pull`) |

--- a/docs/docs/build-factory.md
+++ b/docs/docs/build-factory.md
@@ -1,84 +1,20 @@
-# build-factory
+# /dark-factory:build-factory
 
-## Metadata
+Opens a new terminal window running `claude /remote-control` for parallel factory sessions.
 
-- System type: `command`
-
-## System Intent
-
-- What this is: A Claude Code slash command that spawns a new terminal window running `claude /remote-control`, leaving the calling session completely untouched.
-
-## Mermaid Diagram
+## Flow
 
 ```mermaid
 flowchart TD
-  User[User] -->|runs /dark-factory:build-factory| Command[commands/build-factory.md]
-  Command -->|bash scripts/build-factory.sh NAME| Script[scripts/build-factory.sh]
-  Script -->|detects available terminal emulator| Detect{Terminal emulator?}
-  Detect -->|gnome-terminal| GnomeTerminal[gnome-terminal --working-directory]
-  Detect -->|x-terminal-emulator| XTE[x-terminal-emulator -e bash]
-  Detect -->|xterm| Xterm[xterm -e bash]
-  Detect -->|konsole| Konsole[konsole --workdir]
-  GnomeTerminal --> RC[claude '/remote-control NAME']
-  XTE --> RC
-  Xterm --> RC
-  Konsole --> RC
-  RC --> FactorySession[New factory session running in parallel]
+  User["User: /dark-factory:build-factory<br/>name (optional)"] --> Cmd["commands/build-factory.md"]
+  Cmd -->|"bash scripts/build-factory.sh"| Script["scripts/build-factory.sh"]
+  Script --> Detect{"Terminal emulator?"}
+  Detect -->|"gnome-terminal"| Terminal["gnome-terminal"]
+  Detect -->|"xterm / konsole"| Terminal
+  Terminal -->|"claude /remote-control NAME"| Done["Done: new terminal running"]
 ```
 
-## Flows
+## See also
 
-### Flow: `build-factory`
-
-- Core files: `commands/build-factory.md`, `scripts/build-factory.sh`
-- Test files: `tests/test_build_factory_no_destroy.py`
-
-#### Types
-
-```txt
-Input {
-  name: string (optional, default: "dark factory") — label passed to /remote-control
-}
-
-Output {
-  side-effect: new terminal window opened, running claude /remote-control <name>
-}
-```
-
-#### Paths
-
-| path | input | output | path-type | notes |
-| --- | --- | --- | --- | --- |
-| `build-factory.success` | `name` | new terminal window running remote-control | `happy path` | calling session is left untouched |
-| `build-factory.no-terminal` | `name` | error to stderr, exit 1 | `error` | no supported terminal emulator found |
-
-#### Pseudocode
-
-```
-NAME = args[1] or "dark factory"
-cmd  = "claude '/remote-control NAME'"
-cwd  = pwd
-
-try gnome-terminal --working-directory=cwd -- bash -c cmd
-else try x-terminal-emulator -e bash -c cmd  (cd cwd first)
-else try xterm -e bash -c cmd                 (cd cwd first)
-else try konsole --workdir cwd -e bash -c cmd
-else error "No terminal emulator found"
-```
-
-## Logs
-
-| Source | Location |
-|--------|----------|
-| terminal open failure | stderr of the calling claude session |
-
-## Deployment
-
-- Mechanism: `local only`
-- Deploy command:
-  ```bash
-  # No deployment needed; the command and script ship with the plugin.
-  # Install via:
-  /dark-factory:install
-  ```
-- Notes: `scripts/build-factory.sh` is an open-only script. It has no self-close behavior. The "reopen" pattern (open new + close self) lives in `scripts/reopen-remote-control.sh` and must not be reused here — see `docs/bugs/2026-04-28-build-factory-destroys-existing-terminals.md`.
+- scripts/build-factory.sh — terminal spawn implementation
+- [/dark-factory:destroy-factory](destroy-factory.md) — clean up all other terminals

--- a/docs/docs/debug-command-agent.md
+++ b/docs/docs/debug-command-agent.md
@@ -1,109 +1,27 @@
-# debug-command-agent
+# /dark-factory:debug
 
-## Metadata
+Diagnoses and fixes a non-obvious bug — fills out a bug audit log, applies the fix, and opens a PR.
 
-- System type: `flow`
-
-## System Intent
-
-- What this is: The `debug-command-agent` backs the `/dark-factory:debug` slash command. It runs in-place in whatever working directory (worktree) it is invoked from — worktree setup is handled by `gotoworktree-command-agent` separately. It delegates to `debugger-agent` to identify and fix the bug (including writing a bug audit log), then runs the full post-execution pipeline (code review → docs → skills → PR). No plan file is generated; `taskDescription` is passed as fallback to downstream agents. State is passed directly between steps as local variables — no `brain.json` is created.
-
-## Mermaid Diagram
+## Flow
 
 ```mermaid
 flowchart TD
-  User["User: /dark-factory:debug\ntaskDescription, taskName"] --> DCA
+  User["User: /dark-factory:debug<br/>taskDescription, taskName"] --> DCA
 
-  DCA["debug-command-agent\n(runs in-place)"]
+  DCA["debug-command-agent<br/>(runs in-place)"]
 
-  DCA --> DA["debugger-agent\n(taskDescription)"]
+  DCA --> DA["debugger-agent<br/>(taskDescription)"]
 
-  DA -->|"error"| ERR["STOP: error"]
   DA -->|"success"| CRO["code-review-orchestrator-agent"]
 
   CRO --> UDA["update-documentation-agent"]
-  UDA --> SUA["skill-update-agent\n(non-fatal)"]
+  UDA --> SUA["skill-update-agent<br/>(non-fatal)"]
   SUA --> PRA["pr-agent"]
   PRA -->|"prUrl"| Done["Done: PR URL"]
 ```
 
-## Flows
+## See also
 
-### Flow: `debugCommand`
-
-- Test files: `N/A`
-- Core files: `commands/debug.md`, `agents/dark-factory/agents/debug-command-agent.md`, `agents/debugger/agents/debugger-agent.md`
-
-#### Types
-
-```txt
-DebugCommandInput {
-  taskDescription: string (required — description of the bug)
-  taskName:        string (optional — derived if absent)
-}
-
-DebugCommandOutput {
-  prUrl:    string
-  bugFiles: string[]  (paths to bug audit log files written)
-}
-
-StandardError {
-  message: string (human-readable description of what went wrong)
-}
-```
-
-#### Paths
-
-| path | input | output | path-type | notes |
-| --- | --- | --- | --- | --- |
-| `debugCommand.success` | `DebugCommandInput` | `DebugCommandOutput` | happy path | bug fixed, docs updated, PR opened |
-| `debugCommand.worker-error` | `DebugCommandInput` | `StandardError` | error | debugger-agent returned error |
-
-#### Pseudocode
-
-```
-debug-command-agent(taskDescription, taskName):
-
-  # Step 1 — derive taskName slug
-  if taskName is empty:
-    taskName = "debug-" + slugify(taskDescription)
-
-  PROJECT_DIR = bash("git rev-parse --show-toplevel")
-
-  # Step 2 — invoke debugger-agent (no brain.json created)
-  result = invoke debugger-agent({ taskDescription })
-
-  if result is error:
-    report error: result.message
-    STOP
-
-  planFilePath = null  # no plan file for debugger route
-
-  # Steps 3-6 — post-execution pipeline
-  invoke code-review-orchestrator-agent({
-    planFilePath: planFilePath ?? "Task: " + taskDescription,
-    codePath: PROJECT_DIR
-  })
-  invoke update-documentation-agent({ planFilePath, workDir: PROJECT_DIR })
-  try: invoke skill-update-agent({ planFilePath, workDir: PROJECT_DIR, taskSummary: taskDescription })
-  prResult = invoke pr-agent({ planFilePath: planFilePath ?? taskDescription, workDir: PROJECT_DIR })
-
-  Report: "Debug complete. PR: " + prResult.prUrl
-  STOP
-```
-
-## Logs
-
-| Source | Location |
-|--------|----------|
-| command agent stdout | PR URL reported directly on completion |
-| bug audit logs | `docs/bugs/<date>-<slug>.md` (written by debugger-agent, persisted) |
-
-## Deployment
-
-- Mechanism: `local only`
-- Deploy command:
-  ```bash
-  /dark-factory:debug
-  ```
-- Notes: Invoked as a Claude Code slash command. Requires the dark-factory plugin installed. The agent runs in-place in the current directory — use `/dark-factory:goto` first to land in the correct worktree. No plan file is generated — `taskDescription` is passed as fallback to code-review and pr-agent.
+- [debugger-agent](debugger-agent.md) — investigates and fixes bugs
+- bug-audit-log-template.md — structured bug documentation
+- [code-review-orchestrator-agent](code-review-orchestrator-agent.md) — reviews code changes

--- a/docs/docs/destroy-factory.md
+++ b/docs/docs/destroy-factory.md
@@ -1,0 +1,20 @@
+# /dark-factory:destroy-factory
+
+Terminates all other running Claude/dark-factory terminal sessions and spawns one fresh factory terminal.
+
+## Flow
+
+```mermaid
+flowchart TD
+  User["User: /dark-factory:destroy-factory<br/>name (optional)"] --> Cmd["commands/destroy-factory.md"]
+  Cmd -->|"bash scripts/destroy-factory.sh"| Script["scripts/destroy-factory.sh"]
+  Script --> Scan["Scan running terminals<br/>for claude descendants"]
+  Scan --> Kill["Kill all found<br/>(except caller)"]
+  Kill --> Open["gnome-terminal / xterm / konsole<br/>running claude /remote-control"]
+  Open --> Done["Done: fresh terminal"]
+```
+
+## See also
+
+- scripts/destroy-factory.sh — terminal detection and cleanup
+- [/dark-factory:build-factory](build-factory.md) — opens one additional terminal without cleanup

--- a/docs/docs/execute-command-agent.md
+++ b/docs/docs/execute-command-agent.md
@@ -1,109 +1,27 @@
-# execute-command-agent
+# /dark-factory:execute
 
-## Metadata
+Implements an approved plan — runs the full execution pipeline (code, tests, review) and opens a PR.
 
-- System type: `flow`
-
-## System Intent
-
-- What this is: The `execute-command-agent` backs the `/dark-factory:execute` slash command. It runs in-place in whatever working directory (worktree) it is invoked from — worktree setup is handled by `gotoworktree-command-agent` separately. It takes an approved plan file, runs `execution-agent` to implement all flows from the plan, then runs the full post-execution pipeline (code review → docs → skills → PR). State is passed directly between steps as local variables — no `brain.json` is created.
-
-## Mermaid Diagram
+## Flow
 
 ```mermaid
 flowchart TD
-  User["User: /dark-factory:execute\nplanPath, taskName"] --> ECA
+  User["User: /dark-factory:execute<br/>planPath, taskName"] --> ECA
 
-  ECA["execute-command-agent\n(runs in-place)"]
+  ECA["execute-command-agent<br/>(runs in-place)"]
 
-  ECA -->|"validate planPath"| CHECK{"Plan\nexists?"}
-  CHECK -->|"no"| ERR["STOP: error"]
-  CHECK -->|"yes"| EA["execution-agent\n(planPath)"]
+  ECA --> EA["execution-agent<br/>(planPath)"]
 
-  EA -->|"hardStop: true"| ABORT["STOP: aborted"]
   EA -->|"success"| CRO["code-review-orchestrator-agent"]
 
   CRO --> UDA["update-documentation-agent"]
-  UDA --> SUA["skill-update-agent\n(non-fatal)"]
+  UDA --> SUA["skill-update-agent<br/>(non-fatal)"]
   SUA --> PRA["pr-agent"]
   PRA -->|"prUrl"| Done["Done: PR URL"]
 ```
 
-## Flows
+## See also
 
-### Flow: `executeCommand`
-
-- Test files: `N/A`
-- Core files: `commands/execute.md`, `agents/dark-factory/agents/execute-command-agent.md`, `agents/featurework/execution/agents/execution-agent.md`
-
-#### Types
-
-```txt
-ExecuteCommandInput {
-  planPath: string (required — absolute path to approved plan file)
-  taskName: string (optional — derived from plan file name if absent)
-}
-
-ExecuteCommandOutput {
-  prUrl: string
-}
-
-StandardError {
-  message: string (human-readable description of what went wrong)
-}
-```
-
-#### Paths
-
-| path | input | output | path-type | notes |
-| --- | --- | --- | --- | --- |
-| `executeCommand.success` | `ExecuteCommandInput` | `ExecuteCommandOutput` | happy path | all flows implemented, PR opened |
-| `executeCommand.plan-not-found` | `ExecuteCommandInput` | `StandardError` | error | planPath does not exist |
-| `executeCommand.hard-stop` | `ExecuteCommandInput` | `StandardError` | error | execution-agent hard-stop that user chose Abort for |
-
-#### Pseudocode
-
-```
-execute-command-agent(planPath, taskName):
-
-  # Step 1 — validate plan file exists
-  if planPath not found: report error and STOP
-
-  # Step 2 — derive taskName from plan file name if not provided
-  if taskName is empty:
-    taskName = basename(planPath) without .md extension and date prefix
-    # e.g. "2026-05-27-add-oauth.md" → "add-oauth"
-
-  PROJECT_DIR = bash("git rev-parse --show-toplevel")
-
-  # Step 3 — invoke execution-agent
-  invoke execution-agent({ planPath })
-
-  if execution-agent returns hardStop: true:
-    report "Execution aborted by user."
-    STOP
-
-  # Steps 4-7 — post-execution pipeline
-  invoke code-review-orchestrator-agent({ planFilePath: planPath, codePath: PROJECT_DIR })
-  invoke update-documentation-agent({ planFilePath: planPath, workDir: PROJECT_DIR })
-  try: invoke skill-update-agent({ planFilePath: planPath, workDir: PROJECT_DIR, taskSummary: "Execute: " + planPath })
-  prResult = invoke pr-agent({ planFilePath: planPath, workDir: PROJECT_DIR })
-
-  Report: "Execution complete. PR: " + prResult.prUrl
-  STOP
-```
-
-## Logs
-
-| Source | Location |
-|--------|----------|
-| command agent stdout | PR URL reported directly on completion |
-
-## Deployment
-
-- Mechanism: `local only`
-- Deploy command:
-  ```bash
-  /dark-factory:execute
-  ```
-- Notes: Invoked as a Claude Code slash command. Requires the dark-factory plugin installed. The agent runs in-place in the current directory — use `/dark-factory:goto` first to land in the correct worktree. The plan file must already exist (created by `/dark-factory:plan` or manually).
+- execution-agent — implements flows from plan
+- [code-review-orchestrator-agent](code-review-orchestrator-agent.md) — reviews code changes
+- pr-agent — opens/updates PR

--- a/docs/docs/gen-hooks.md
+++ b/docs/docs/gen-hooks.md
@@ -1,0 +1,19 @@
+# /dark-factory:gen-hooks
+
+Scans YAML frontmatter of skill/agent/command files for hook declarations and writes them to `.claude/settings.json` additively.
+
+## Flow
+
+```mermaid
+flowchart TD
+  User["User: /dark-factory:gen-hooks"] --> Cmd["commands/gen-hooks.md"]
+  Cmd -->|"python scripts/gen_hooks.py"| Scan["Scan all .md files<br/>for YAML frontmatter"]
+  Scan --> Extract["Extract hook declarations<br/>(PreToolUse, PostToolUse, etc)"]
+  Extract --> Merge["Merge into .claude/settings.json<br/>additively"]
+  Merge --> Done["Done: hooks registered"]
+```
+
+## See also
+
+- scripts/gen_hooks.py — hook discovery and settings.json update
+- [hooks documentation](hooks.md) — hook types and usage

--- a/docs/docs/gotoworktree-command-agent.md
+++ b/docs/docs/gotoworktree-command-agent.md
@@ -1,144 +1,28 @@
-# gotoworktree-command-agent
+# /dark-factory:goto
 
-## Metadata
+Finds or creates a git worktree for a PR, branch, or new task — pulls main/master and reports the path.
 
-- System type: `flow`
-
-## System Intent
-
-- What this is: The `gotoworktree-command-agent` backs the `/dark-factory:goto` slash command. It finds or creates a git worktree for a PR, branch, or new task, pulls main/master into the worktree, and reports the path. It is the single place where worktree setup lives — all command agents (plan, execute, debug, repair) delegate worktree creation to this agent or expect the user to call it first.
-
-## Mermaid Diagram
+## Flow
 
 ```mermaid
 flowchart TD
-  User["User: /dark-factory:goto\nprNumber, taskName, or description"] --> GW
+  User["User: /dark-factory:goto<br/>prNumber, taskName, or description"] --> GW
 
   GW["gotoworktree-command-agent"]
 
-  GW -->|"validate input"| CHK{"at least one\narg provided?"}
-  CHK -->|"no"| ERR["STOP: StandardError"]
-  CHK -->|"yes"| SLUG["derive taskName slug"]
-
-  SLUG --> LOCAL{"Local worktree\nexists?"}
+  GW --> LOCAL{"Local worktree<br/>exists?"}
   LOCAL -->|"yes"| PULL["git pull origin main/master"]
-  PULL --> DONE["Report: Worktree ready at: WORK_DIR"]
+  PULL --> DONE["Report: Worktree ready"]
 
-  LOCAL -->|"no"| PR_CHK{"Open PR\nfound?"}
-  PR_CHK -->|"yes, by prNumber"| GH_PR["gh pr view → EXISTING_BRANCH"]
-  PR_CHK -->|"yes, by description"| FIND_PR["find-related-pr.sh → EXISTING_BRANCH"]
-  GH_PR & FIND_PR --> WT_ADD["git worktree add EXISTING_BRANCH"]
-  WT_ADD --> PULL
+  LOCAL -->|"no"| PR_CHK{"Open PR<br/>found?"}
+  PR_CHK -->|"yes"| CREATE["git worktree add"]
+  CREATE --> PULL
 
-  PR_CHK -->|"no"| PREP["prep-feature-dir.sh taskName"]
-  PREP -->|"fail"| ERR2["STOP: StandardError"]
-  PREP -->|"success"| DONE
+  PR_CHK -->|"no"| PREP["prep-feature-dir.sh"]
+  PREP --> PULL
 ```
 
-## Flows
+## See also
 
-### Flow: `gotoworktreeCommand`
-
-- Test files: `N/A`
-- Core files: `commands/goto.md`, `agents/dark-factory/agents/gotoworktree-command-agent.md`
-
-#### Types
-
-```txt
-GotoWorktreeInput {
-  prNumber:    string (optional — PR number to find branch for)
-  taskName:    string (optional — explicit slug)
-  description: string (optional — used to derive slug or search for related PR)
-}
-
-GotoWorktreeOutput {
-  message: string  ("Worktree ready at: <path>")
-}
-
-StandardError {
-  message: string
-}
-```
-
-#### Paths
-
-| path | input | output | path-type | notes |
-| --- | --- | --- | --- | --- |
-| `gotoworktreeCommand.reuse-local` | any input | `GotoWorktreeOutput` | happy path | matching local worktree already exists; pulls and reports path |
-| `gotoworktreeCommand.reuse-pr` | prNumber or description | `GotoWorktreeOutput` | happy path | open PR branch found; creates worktree if absent, pulls, reports path |
-| `gotoworktreeCommand.create-new` | taskName or description | `GotoWorktreeOutput` | happy path | no existing worktree/PR; creates fresh via prep-feature-dir.sh |
-| `gotoworktreeCommand.no-input` | all null | `StandardError` | error | no input provided |
-| `gotoworktreeCommand.prep-failure` | any | `StandardError` | error | prep-feature-dir.sh failed |
-
-#### Pseudocode
-
-```
-gotoworktree-command-agent(prNumber, taskName, description):
-
-  # Step 1 — validate input
-  if prNumber is empty AND taskName is empty AND description is empty:
-    report error: StandardError { message: "Must provide prNumber, taskName, or description" }
-    STOP
-
-  PROJECT_DIR = bash("git rev-parse --show-toplevel")
-  PROJECT_NAME = basename(PROJECT_DIR)
-
-  # Step 2 — derive taskName if not yet provided
-  if taskName is empty:
-    if prNumber is not empty:
-      branchName = bash("gh pr view \"$prNumber\" --json headRefName --jq .headRefName")
-      taskName = branchName after stripping leading "<prefix>/" (e.g. "feature/add-oauth" → "add-oauth")
-    elif description is not empty:
-      taskName = slugify(description)   # lowercase, hyphens, ≤30 chars
-
-  # Step 3 — search for existing local worktree by taskName
-  WORKTREE_NAME = PROJECT_NAME + "-" + taskName
-  WORK_DIR = PROJECT_DIR + "/../" + WORKTREE_NAME
-  if WORK_DIR exists and is a git worktree:
-    bash("git -C \"$WORK_DIR\" fetch origin")
-    bash("git -C \"$WORK_DIR\" pull origin main 2>/dev/null || git -C \"$WORK_DIR\" pull origin master || true")
-    Report: "Worktree ready at: " + WORK_DIR
-    STOP
-
-  # Step 4 — search for open PR (by prNumber or description)
-  if prNumber is not empty:
-    prJson = bash("gh pr view \"$prNumber\" --json headRefName,url --jq '[.headRefName,.url]|@tsv'")
-    EXISTING_BRANCH = first field of prJson
-  else:
-    relatedPrOutput = bash("bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/find-related-pr.sh\" \"$description\"") || ""
-    EXISTING_BRANCH = extract BRANCH= from relatedPrOutput
-
-  if EXISTING_BRANCH is not empty:
-    existingTaskName = EXISTING_BRANCH after stripping leading "<prefix>/" prefix
-    WORK_DIR = PROJECT_DIR + "/../" + PROJECT_NAME + "-" + existingTaskName
-    if WORK_DIR does not exist:
-      bash("git -C \"$PROJECT_DIR\" pull origin main || true")
-      bash("git -C \"$PROJECT_DIR\" worktree add \"$WORK_DIR\" \"$EXISTING_BRANCH\"")
-    bash("git -C \"$WORK_DIR\" pull origin main 2>/dev/null || git -C \"$WORK_DIR\" pull origin master || true")
-    Report: "Worktree ready at: " + WORK_DIR
-    STOP
-
-  # Step 5 — create new worktree via prep-feature-dir.sh
-  prepOutput = bash("bash \"${CLAUDE_PLUGIN_ROOT}/agents/dark-factory/scripts/prep-feature-dir.sh\" \"$taskName\"")
-  if script fails:
-    report error: StandardError { message: "Failed to create worktree: " + prepOutput }
-    STOP
-  WORK_DIR = extract WORK_DIR=<value> from prepOutput
-  Report: "Worktree ready at: " + WORK_DIR
-  STOP
-```
-
-## Logs
-
-| Source | Location |
-|--------|----------|
-| command agent stdout | Worktree path reported directly on completion |
-
-## Deployment
-
-- Mechanism: `local only`
-- Deploy command:
-  ```bash
-  /dark-factory:goto
-  ```
-- Notes: Invoked as a Claude Code slash command. Requires the dark-factory plugin installed. Reuses `prep-feature-dir.sh` and `find-related-pr.sh` scripts. Does not delegate to other agents — stops after reporting the worktree path. All four command agents (plan, execute, debug, repair) assume the user has already run this command to enter the correct worktree before invoking them.
+- [find-related-pr](find-related-pr.md) — searches for matching open PRs
+- prep-feature-dir.sh — creates new worktree

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -1,89 +1,23 @@
-# install
+# /dark-factory:install
 
-## Metadata
+Installs or reinstalls the dark-factory plugin — registers with the plugin marketplace, installs the plugin, syncs agents and scripts to the local cache, and reopens the terminal.
 
-- System type: `flow`
-
-## System Intent
-
-- What this is: The `/dark-factory:install` command installs or reinstalls the dark-factory plugin into a local Claude Code environment. It registers the plugin with the marketplace, reinstalls it, syncs local agent/script files, and reopens the remote-control terminal.
-
-## Mermaid Diagram
+## Flow
 
 ```mermaid
 flowchart TD
-  A[User runs /dark-factory:install] --> B[git pull]
-  B --> C[claude plugin marketplace add]
-  C --> D{First install or update?}
-  D -->|First install| E[claude plugin install dark-factory]
-  D -->|Update| F[claude plugin marketplace update dark-factory]
-  F --> G[claude plugin uninstall dark-factory]
-  G --> E
-  E --> H[Copy scripts and agents to ~/.dark-factory/]
-  H --> I[bash scripts/reopen-remote-control.sh]
-  I --> J[Verify: claude plugin list]
+  User["User: /dark-factory:install<br/>from repo root"] --> GitPull["git pull"]
+  GitPull --> Marketplace["claude plugin marketplace add"]
+  Marketplace --> Check{"First install<br/>or update?"}
+  Check -->|"first time"| Install["claude plugin install"]
+  Check -->|"update"| Update["marketplace update +<br/>uninstall + reinstall"]
+  Install --> Copy["Copy scripts/agents<br/>to ~/.dark-factory/"]
+  Update --> Copy
+  Copy --> Terminal["bash scripts/reopen-remote-control.sh"]
+  Terminal --> Done["Done: plugin ready"]
 ```
 
-## Flows
+## See also
 
-### Flow: `install`
-- Core files: `commands/install.md`, `skills/install/SKILL.md`
-
-#### Types
-
-```txt
-No typed input/output — this is a shell command flow.
-```
-
-#### Paths
-
-| path | input | output | path-type | notes |
-| --- | --- | --- | --- | --- |
-| `install.first-time` | repo root on disk | plugin registered + terminal open | `happy path` | clone repo, add to marketplace, install, copy files, reopen terminal |
-| `install.update` | existing install | updated plugin + terminal open | `happy path` | pull, marketplace add+update, uninstall, reinstall, copy files, reopen terminal |
-
-#### Steps (install)
-
-```
-1. git pull                                           — sync latest code
-2. claude plugin marketplace add "$(pwd)"             — register local repo as plugin source
-3. claude plugin install dark-factory                 — install plugin into Claude Code
-4. rm -rf ~/.dark-factory && mkdir -p ~/.dark-factory — reset local agent/script cache
-5. cp -r scripts agents ~/.dark-factory/              — sync current files
-6. bash scripts/reopen-remote-control.sh "dark factory" — open remote-control terminal
-7. claude plugin list                                 — verify install
-```
-
-#### Steps (update / reinstall)
-
-```
-1. git pull
-2. claude plugin marketplace add "$(pwd)"
-3. claude plugin marketplace update dark-factory
-4. claude plugin uninstall dark-factory
-5. claude plugin install dark-factory
-6. rm -rf ~/.dark-factory && mkdir -p ~/.dark-factory
-7. cp -r scripts agents ~/.dark-factory/
-8. bash scripts/reopen-remote-control.sh "dark factory"
-```
-
-## Logs
-
-| Source | Location |
-|--------|----------|
-| Plugin list | stdout of `claude plugin list` |
-
-## Deployment
-
-- Mechanism: `local only`
-- Deploy command:
-  ```bash
-  # From repo root — first install
-  git clone https://github.com/lewibs/dark-factory
-  cd dark-factory
-  claude plugin marketplace add "$(pwd)"
-  claude plugin install dark-factory
-  rm -rf ~/.dark-factory && mkdir -p ~/.dark-factory && cp -r "$(pwd)/scripts" ~/.dark-factory/ && cp -r "$(pwd)/agents" ~/.dark-factory/
-  bash scripts/reopen-remote-control.sh "dark factory"
-  ```
-- Notes: The `reopen-remote-control.sh` script opens a new GNOME terminal tab running Claude in remote-control mode. The `~/.dark-factory/` directory caches agents and scripts so they are accessible to Claude Code hooks regardless of working directory.
+- scripts/reopen-remote-control.sh — opens new terminal
+- Plugin docs

--- a/docs/docs/investigation-command.md
+++ b/docs/docs/investigation-command.md
@@ -1,112 +1,21 @@
-# investigation-command
+# /dark-factory:investigation
 
-## Metadata
+Investigates a system and writes authoritative documentation to `docs/docs/` — validates every claim against source code and commits the verified doc.
 
-- System type: `flow`
-
-## System Intent
-
-- What this is: A standalone dark-factory command (`/dark-factory:investigation`) that generates system documentation for any named system, validates every factual claim in the generated doc against actual source code through an iterative correction loop, and commits the verified documentation via a SubagentStop hook. It is self-contained and does not open a PR or interact with the manufacture pipeline.
-
-## Mermaid Diagram
+## Flow
 
 ```mermaid
 flowchart TD
-  CMD["investigation command\ncommands/investigation.md"]:::entry -->|"system, question"| ORC["investigation-orchestrator\nagents/commands/investigation-orchestrator.md"]
-  ORC -->|"system, question"| IA["investigation-agent\nagents/documentation/agents/investigation-agent.md"]
-  IA -->|"writes docs/docs/<system>.md"| DOC["docs/docs/<system>.md"]
-  ORC -->|"docPath"| CV["claim-validator-agent\nagents/documentation/agents/claim-validator-agent.md"]
-  CV -->|"ClaimValidatorResult"| ORC
-  ORC -->|"corrections (false claims)"| IA
-  ORC -->|"allVerified=true → SubagentStop"| HOOK["commit-investigation-docs.sh\ngit add docs/docs/ && git commit"]
-
-classDef entry fill:#a8e6a3,stroke:#666,stroke-width:1px;
+  User["User: /dark-factory:investigation<br/>system, question"] --> ORC["investigation-orchestrator"]
+  ORC --> IA["investigation-agent"]
+  IA -->|"writes docs"| DOC["docs/docs/<system>.md"]
+  ORC --> CV["claim-validator-agent"]
+  CV -->|"result"| ORC
+  ORC -->|"corrections needed?"| IA
+  ORC -->|"all verified"| HOOK["git commit<br/>SubagentStop"]
 ```
 
-## Flows
+## See also
 
-### Flow: `investigationCommand`
-
-- Test files: `tests/test_investigation_command.py`
-- Core files:
-  - `commands/investigation.md`
-  - `agents/commands/investigation-orchestrator.md`
-  - `agents/documentation/agents/investigation-agent.md`
-  - `agents/documentation/agents/claim-validator-agent.md`
-  - `agents/dark-factory/scripts/commit-investigation-docs.sh`
-
-#### Types
-
-```txt
-InvestigationCommandInput {
-  system: string (required — name of the system to document)
-  question: string | null (optional — specific aspect to focus on)
-}
-
-InvestigationCommandOutput {
-  docPath: string (absolute path to the verified docs/docs/<system>.md)
-  iterations: number (how many validator → investigation-agent cycles ran)
-}
-
-StandardError {
-  message: string (human-readable description of what went wrong)
-}
-```
-
-#### Paths
-
-| path | input | output | path-type | notes |
-| --- | --- | --- | --- | --- |
-| `investigationCommand.success` | `InvestigationCommandInput` | `InvestigationCommandOutput` | `happy path` | all claims verify on first pass; SubagentStop hook commits doc |
-| `investigationCommand.iterative-correction` | `InvestigationCommandInput` | `InvestigationCommandOutput` | `happy path` | one or more false-claim feedback cycles before all claims pass |
-| `investigationCommand.max-iterations-exceeded` | `InvestigationCommandInput` | `StandardError` | `error` | validator cycles hit hard cap (5) without full verification |
-| `investigationCommand.empty-system` | `InvestigationCommandInput` | `StandardError` | `error` | system name is empty |
-| `investigationCommand.doc-not-created` | `InvestigationCommandInput` | `StandardError` | `error` | investigation-agent did not produce a documentation file |
-
-#### Pseudocode
-
-```
-investigationCommand(system, question):
-  maxIterations = 5
-  iterations = 0
-
-  # Step 1: investigation-orchestrator calls investigation-agent
-  docPath = invoke investigation-agent(system, question)
-  if error: RETURN StandardError
-
-  loop:
-    iterations += 1
-    if iterations > maxIterations:
-      RETURN StandardError("Max validation iterations exceeded for system: " + system)
-
-    # Step 2: Validate all claims in the generated doc
-    result = invoke claim-validator-agent(docPath)  # returns ClaimValidatorResult
-
-    # Step 3: If all verified, commit and finish
-    if result.allVerified:
-      trigger SubagentStop  # commit-investigation-docs.sh runs: git add docs/docs/ && git commit
-      RETURN InvestigationCommandOutput(docPath, iterations)
-
-    # Step 4: Feed false claims back to investigation-agent for correction
-    corrections = format result.falseClaims as bullet list with evidence
-    docPath = invoke investigation-agent(system, question, corrections=corrections)
-```
-
-## Logs
-
-| Source | Location |
-|--------|----------|
-| investigation-agent iterations | written to calling agent's stdout (no persistent log) |
-| false claims per cycle | included inline in the correction prompt fed back to investigation-agent |
-| commit result | written to stderr by commit-investigation-docs.sh |
-
-## Deployment
-
-- Mechanism: `local only`
-- Deploy command:
-  ```bash
-  # No separate deploy step — command files are loaded by agents at invocation time.
-  # Run gen-hooks to register the SubagentStop hook declared in the command YAML frontmatter:
-  /dark-factory:install
-  ```
-- Notes: The SubagentStop hook (`commit-investigation-docs.sh`) is declared in the YAML frontmatter of `agents/commands/investigation-orchestrator.md`. It fires when investigation-orchestrator finishes and commits any new or updated files in `docs/docs/`. The hook resolves the working directory from `DARK_FACTORY_WORK_DIR` or falls back to `/tmp/dark-factory-work-dir`.
+- [investigation-agent](investigation-agent.md) — generates system documentation
+- [claim-validator-agent](claim-validator-agent.md) — validates factual claims

--- a/docs/docs/plan-command-agent.md
+++ b/docs/docs/plan-command-agent.md
@@ -1,108 +1,26 @@
-# plan-command-agent
+# /dark-factory:plan
 
-## Metadata
+Plans a feature end-to-end — walks through system intent, architecture diagram, and per-flow approval gates, then saves the approved plan (no code yet).
 
-- System type: `flow`
-
-## System Intent
-
-- What this is: The `plan-command-agent` backs the `/dark-factory:plan` slash command. It runs in-place in whatever working directory (worktree) it is invoked from — worktree setup is handled by `gotoworktree-command-agent` separately. It drives `feature-agent` through all planning phases (draft → mermaid → flows → final approval) with `planOnly: true` to skip execution and returns the approved plan path. State is passed directly between steps as local variables — no `brain.json` is created.
-
-## Mermaid Diagram
+## Flow
 
 ```mermaid
 flowchart TD
-  User["User: /dark-factory:plan\ntaskDescription, taskName"] --> PCA
+  User["User: /dark-factory:plan<br/>taskDescription, taskName"] --> PCA
 
-  PCA["plan-command-agent\n(runs in-place)"]
+  PCA["plan-command-agent<br/>(runs in-place)"]
 
-  PCA --> FA["feature-agent\n(planOnly: true)"]
+  PCA --> FA["feature-agent<br/>(planOnly: true)"]
 
   FA -->|"status: question"| PCA
   PCA -->|"AskUserQuestion"| User
   User -->|"answer"| PCA
   PCA -->|"re-invoke"| FA
 
-  FA -->|"status: aborted"| ABORT["STOP: aborted"]
-  FA -->|"status: hard-stop"| HSTOP["STOP: hard-stop"]
-  FA -->|"status: done\nplanPath"| Done["Done: planPath"]
+  FA -->|"status: done"| Done["Done: planPath"]
 ```
 
-## Flows
+## See also
 
-### Flow: `planCommand`
-
-- Test files: `N/A`
-- Core files: `commands/plan.md`, `agents/dark-factory/agents/plan-command-agent.md`, `agents/featurework/agents/feature-agent.md`
-
-#### Types
-
-```txt
-PlanCommandInput {
-  taskDescription: string (required)
-  taskName:        string (optional — derived from taskDescription if absent)
-}
-
-PlanCommandOutput {
-  planPath: string (absolute path to approved plan file)
-}
-
-StandardError {
-  message: string (human-readable description of what went wrong)
-}
-```
-
-#### Paths
-
-| path | input | output | path-type | notes |
-| --- | --- | --- | --- | --- |
-| `planCommand.success` | `PlanCommandInput` | `PlanCommandOutput` | happy path | plan fully approved, planPath returned |
-| `planCommand.aborted` | `PlanCommandInput` | `StandardError` | error | user aborted at final approval gate |
-| `planCommand.hard-stop` | `PlanCommandInput` | `StandardError` | error | feature-agent returned hard-stop |
-
-#### Pseudocode
-
-```
-plan-command-agent(taskDescription, taskName):
-
-  # Step 1 — derive taskName slug if not provided
-  if taskName is empty:
-    taskName = slugify(taskDescription)   # lowercase, hyphens, ≤30 chars
-
-  PROJECT_DIR = bash("git rev-parse --show-toplevel")
-
-  # Step 2 — drive feature-agent through planning phases ONLY (planOnly: true)
-  result = invoke feature-agent({ taskDescription, answer: null, planPath: null, planOnly: true })
-  LOOP until result.status == "done":
-    if result.status == "aborted":
-      report "Aborted: " + result.reason
-      STOP
-    if result.status == "hard-stop":
-      report "Hard stop: " + result.reason
-      STOP
-    if result.status == "question":
-      PushNotification("Question", result.question)
-      answer = AskUserQuestion(header: result.phase, question: result.question, options: result.options)
-      result = invoke feature-agent({ answer, planPath: result.planPath, taskDescription: null, planOnly: true })
-
-  planFilePath = result.planPath
-
-  Report: "Plan approved. File: " + planFilePath
-  STOP
-```
-
-## Logs
-
-| Source | Location |
-|--------|----------|
-| command agent stdout | Plan path reported directly on completion |
-| bug audit logs | N/A (planning only — no code executed) |
-
-## Deployment
-
-- Mechanism: `local only`
-- Deploy command:
-  ```bash
-  /dark-factory:plan
-  ```
-- Notes: Invoked as a Claude Code slash command. Requires the dark-factory plugin installed. The agent runs in-place in the current directory — use `/dark-factory:goto` first to land in the correct worktree. Passes `planOnly: true` to `feature-agent` so execution-agent is never called.
+- feature-agent — executes planning phases
+- plan-template.md — plan structure and approval gates

--- a/docs/docs/repair-command-agent.md
+++ b/docs/docs/repair-command-agent.md
@@ -1,105 +1,27 @@
-# repair-command-agent
+# /dark-factory:repair
 
-## Metadata
+Applies a small targeted change — no plan required, runs tests in a loop until green, opens a PR.
 
-- System type: `flow`
-
-## System Intent
-
-- What this is: The `repair-command-agent` backs the `/dark-factory:repair` slash command. It runs in-place in whatever working directory (worktree) it is invoked from — worktree setup is handled by `gotoworktree-command-agent` separately. It delegates to `repair-agent` to apply targeted changes, then always runs the post-execution pipeline (code review → docs → skills → PR). The pr-agent naturally handles both new PR creation and reuse of existing PRs on the branch. State is passed directly between steps as local variables — no `brain.json` is created.
-
-## Mermaid Diagram
+## Flow
 
 ```mermaid
 flowchart TD
-  User["User: /dark-factory:repair\ntaskDescription, taskName"] --> RCA
+  User["User: /dark-factory:repair<br/>taskDescription, taskName"] --> RCA
 
-  RCA["repair-command-agent\n(runs in-place)"]
+  RCA["repair-command-agent<br/>(runs in-place)"]
 
-  RCA --> RA["repair-agent\n(taskDescription)"]
+  RCA --> RA["repair-agent<br/>(taskDescription)"]
 
-  RA -->|"success: false"| ERR["STOP: error"]
   RA -->|"success: true"| CRO["code-review-orchestrator-agent"]
 
   CRO --> UDA["update-documentation-agent"]
-  UDA --> SUA["skill-update-agent\n(non-fatal)"]
-  SUA --> PRA["pr-agent\n(new or existing)"]
+  UDA --> SUA["skill-update-agent<br/>(non-fatal)"]
+  SUA --> PRA["pr-agent<br/>(new or existing)"]
   PRA -->|"prUrl"| Done["Done: PR URL"]
 ```
 
-## Flows
+## See also
 
-### Flow: `repairCommand`
-
-- Test files: `N/A`
-- Core files: `commands/repair.md`, `agents/dark-factory/agents/repair-command-agent.md`, `agents/repair/agents/repair-agent.md`
-
-#### Types
-
-```txt
-RepairCommandInput {
-  taskDescription: string (required — description of targeted change)
-  taskName:        string (optional — derived if absent)
-}
-
-RepairCommandOutput {
-  prUrl: string
-}
-
-StandardError {
-  message: string (human-readable description of what went wrong)
-}
-```
-
-#### Paths
-
-| path | input | output | path-type | notes |
-| --- | --- | --- | --- | --- |
-| `repairCommand.success` | `RepairCommandInput` | `RepairCommandOutput` | happy path | repair applied, tests passing, PR opened (new or existing) |
-| `repairCommand.test-failure` | `RepairCommandInput` | `StandardError` | error | repair-agent could not fix new test failures within 5 iterations |
-
-#### Pseudocode
-
-```
-repair-command-agent(taskDescription, taskName):
-
-  # Step 1 — derive taskName slug
-  if taskName is empty:
-    taskName = "repair-" + slugify(taskDescription)
-
-  PROJECT_DIR = bash("git rev-parse --show-toplevel")
-
-  # Step 2 — invoke repair-agent (no brain.json created)
-  result = invoke repair-agent({ taskDescription })
-
-  if result.success == false:
-    report error: "Repair failed after 5 iterations: " + result.error.message
-    STOP
-
-  # Steps 3-6 — post-execution pipeline
-  invoke code-review-orchestrator-agent({
-    planFilePath: "Task: " + taskDescription,
-    codePath: PROJECT_DIR
-  })
-  invoke update-documentation-agent({ planFilePath: null, workDir: PROJECT_DIR })
-  try: invoke skill-update-agent({ planFilePath: null, workDir: PROJECT_DIR, taskSummary: taskDescription })
-  prResult = invoke pr-agent({ planFilePath: taskDescription, workDir: PROJECT_DIR })
-
-  Report: "Repair complete. PR: " + prResult.prUrl
-  STOP
-```
-
-## Logs
-
-| Source | Location |
-|--------|----------|
-| command agent stdout | PR URL reported directly on completion (or "insignificant change" notice) |
-
-## Deployment
-
-- Mechanism: `local only`
-- Deploy command:
-  ```bash
-  /dark-factory:repair
-  ```
-- Notes: Invoked as a Claude Code slash command. Requires the dark-factory plugin installed. The agent runs in-place in the current directory — use `/dark-factory:goto` first to land in the correct worktree. All repairs go through the full post-execution pipeline (code review, docs, skills, PR). The pr-agent handles both new PR creation and reuse of existing PRs on the branch via `gh pr view`.
+- [repair-agent](repair-agent.md) — applies targeted fixes with iterative testing
+- [code-review-orchestrator-agent](code-review-orchestrator-agent.md) — reviews code changes
+- pr-agent — opens/updates PR

--- a/docs/docs/save-command.md
+++ b/docs/docs/save-command.md
@@ -1,0 +1,19 @@
+# /dark-factory:save
+
+Commits current changes and opens (or updates) a PR — lightweight shortcut that skips code review, docs, and skills pipeline.
+
+## Flow
+
+```mermaid
+flowchart TD
+  User["User: /dark-factory:save<br/>taskDescription (optional)"] --> SCA["save-command-agent"]
+
+  SCA --> PR["pr-agent<br/>(commit + push + PR)"]
+
+  PR -->|"prUrl"| Done["Done: PR URL"]
+```
+
+## See also
+
+- pr-agent — commits, pushes, and opens/updates PR
+- [/dark-factory:repair](repair-command-agent.md) — for targeted changes that need review and testing


### PR DESCRIPTION
## Summary

- Updated README command table: each command name now links to its documentation file
- Simplified 8 existing command docs to short format (one-sentence description + Mermaid flow diagram + see-also links)
- Created 3 new command docs: `save-command.md`, `destroy-factory.md`, `gen-hooks.md`

## Changes

### README.md
- Each command name in the table now links to its corresponding `docs/docs/<command>.md` file
- Improved discoverability: users can click a command name to read its documentation directly

### Simplified Documentation (11 files)
Converted all command documentation to consistent short format:
- **plan-command-agent.md** — One-sentence summary + Flow diagram + See also
- **execute-command-agent.md** — One-sentence summary + Flow diagram + See also
- **debug-command-agent.md** — One-sentence summary + Flow diagram + See also
- **repair-command-agent.md** — One-sentence summary + Flow diagram + See also
- **investigation-command.md** — One-sentence summary + Flow diagram + See also
- **save-command.md** — One-sentence summary + Flow diagram + See also (NEW)
- **gotoworktree-command-agent.md** — One-sentence summary + Flow diagram + See also
- **build-factory.md** — One-sentence summary + Flow diagram + See also
- **destroy-factory.md** — One-sentence summary + Flow diagram + See also (NEW)
- **gen-hooks.md** — One-sentence summary + Flow diagram + See also (NEW)
- **install.md** — One-sentence summary + Flow diagram + See also

Each doc now provides:
- **Title with command name** — what the command is called
- **One-sentence description** — what it does
- **Flow diagram (Mermaid)** — visual flow showing command orchestration
- **See also links** — related systems and alternative commands

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
