### PR TITLE
fix(feature-agent): include mermaid diagram URL in approval question

### DIFF
--- a/agents/featurework/agents/feature-agent.md
+++ b/agents/featurework/agents/feature-agent.md
@@ -60,9 +60,11 @@ feature-agent(taskDescription, answer, planPath, planOnly=false):
 
     rendered = invoke render-plan-section({ planPath, sectionName: "## Mermaid Diagram" })
 
+    diagramLink = if url then "\n\nRendered diagram: " + url else "\n\n(Diagram rendering unavailable — review the source below.)"
+
     RETURN {
       status: "question",
-      question: "Mermaid diagram:\n\n" + rendered.content + "\n\nHow would you like to proceed?",
+      question: "Mermaid diagram:" + diagramLink + "\n\n" + rendered.content + "\n\nHow would you like to proceed?",
       options: ["Approve — continue to flows", "Request Changes"],
       planPath: planPath,
       phase: "mermaid"

--- a/docs/bugs/2026-05-27-mermaid-diagram-url-missing-from-question.md
+++ b/docs/bugs/2026-05-27-mermaid-diagram-url-missing-from-question.md
@@ -1,0 +1,54 @@
+# Mermaid Diagram URL Missing From Approval Question
+
+## Metadata
+
+- Date: `2026-05-27`
+- Status: `fixed`
+- Severity: `medium`
+- Related issue/ticket: `N/A`
+- Owner: `N/A`
+
+## About
+
+**Overview**:
+- When the planning flow reaches the Mermaid diagram approval phase, the agent presents a question to the developer asking them to approve or request changes. However, the mermaid.ink URL (rendered diagram link) is only sent via `PushNotification` — it is never included in the question text shown to the developer. The developer sees only the raw Mermaid source code and has no way to view the rendered diagram unless they click the push notification. If the notification is missed or the developer is in a different context, they must approve a diagram they cannot see.
+
+**Technical Questions**:
+- This is a deterministic bug, not intermittent. Every time the mermaid phase runs, the URL is generated and stored in the `url` variable, but the `question` string only contains `rendered.content` (the raw Mermaid source). The `url` is passed only to `PushNotification` and discarded before the question is returned.
+- The `iterative-plan-approval-gate` skill (step 2c) documents the correct behavior: "If `url` is non-null, note it in the question text." The `feature-agent` implementation was not following this guidance.
+
+**Resources**:
+- `/home/lewibs/github/dark_factory/dark_factory/agents/featurework/agents/feature-agent.md` — Phase 2 mermaid question construction
+- `/home/lewibs/github/dark_factory/dark_factory/skills/iterative-plan-approval-gate/SKILL.md` — Step 2c documents the expected behavior
+
+## Steps to cause failure
+
+```mermaid
+flowchart LR
+    A[Planning: mermaid phase] --> B[sub-planning-agent generates url]
+    B --> C[feature-agent receives url]
+    C --> D[PushNotification sent with url]
+    C --> E[Question returned WITHOUT url]
+    E --> F[Developer sees raw Mermaid source only]
+    F --> G[Cannot view rendered diagram before approving]
+```
+
+## Root Cause
+
+In `agents/featurework/agents/feature-agent.md`, Phase 2 (Mermaid Diagram), the `url` variable was available but not embedded in the `question` string returned to the caller. The question only contained `rendered.content` (raw Mermaid markdown), while the URL was dispatched only via `PushNotification`.
+
+## Fix Summary
+
+Added `diagramLink` construction in Phase 2 of `feature-agent.md`:
+
+```
+diagramLink = if url then "\n\nRendered diagram: " + url else "\n\n(Diagram rendering unavailable — review the source below.)"
+
+question: "Mermaid diagram:" + diagramLink + "\n\n" + rendered.content + "\n\nHow would you like to proceed?"
+```
+
+This ensures the rendered diagram URL is always visible in the question text, even if the push notification was missed. When rendering fails, a fallback note is shown so the developer knows to review the raw source.
+
+## Verification
+
+The fix is in the agent instruction file (not in executable code), so automated test coverage is not directly applicable. Manual verification: run the planning flow, observe that the AskUserQuestion prompt for the mermaid phase now includes a clickable mermaid.ink URL before the raw diagram source.


### PR DESCRIPTION
## Summary

Fixed the feature-agent mermaid phase to include the rendered diagram URL in the approval question text. Previously, the mermaid.ink URL was only sent via push notification and users could not view the rendered diagram in the approval prompt itself—they only saw the raw Mermaid source code.

The fix adds a `diagramLink` variable that either includes the mermaid.ink URL (when available) or a fallback note explaining that the diagram is unavailable and to review the raw source instead.

## Changes

- **agents/featurework/agents/feature-agent.md** — Updated Phase 2 (Mermaid Diagram) to include the rendered diagram URL in the question text
- **docs/bugs/2026-05-27-mermaid-diagram-url-missing-from-question.md** — Added bug documentation with root cause analysis and verification steps

## Test Plan

This is a documentation-only fix (agent instructions, not executable code). Manual verification:
1. Run the feature-agent planning flow
2. Reach the mermaid diagram approval phase
3. Confirm the AskUserQuestion prompt now includes a clickable mermaid.ink URL above the raw Mermaid source
4. Verify fallback text appears when diagram rendering is unavailable

## Related

Addresses guidance from `skills/iterative-plan-approval-gate/SKILL.md` step 2c: "If `url` is non-null, note it in the question text."
