### PR TITLE
fix(pr-agent): enforce dark factory footer attribution verbatim

### DIFF
--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -33,9 +33,12 @@ pr-agent(planFilePath or taskDescription, workDir):
   # (if no existing PR, pr_url will be set in Step 2 below)
 
   # Step 1 — Build PR body
-  Read agents/pr/templates/pr-template.md for structure.
+  Read agents/pr/templates/pr-template.md — use it as the exact scaffold.
   Populate Description from planFilePath (or taskDescription string).
   Run tests if a test suite exists; include output in Test Plan, or omit section if none.
+  The footer line MUST be copied verbatim from the template:
+    🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
+  Never substitute any other attribution (e.g. "Generated with [Claude Code](...)" is WRONG).
   Write body to /tmp/pr-body.md.
 
   # Step 2 — Open PR (delegate to create-pr skill) if no existing PR
@@ -72,6 +75,7 @@ pr-agent(planFilePath or taskDescription, workDir):
 - Fix is already applied to the working tree — do not re-apply.
 - Always use `git -C "$workDir"` for all git operations (workDir is passed as input parameter).
 - Always write PR body to /tmp/pr-body.md and open with `gh pr create --body-file /tmp/pr-body.md`.
+- The PR body footer MUST always be exactly: `🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)` — never "Generated with [Claude Code]" or any other attribution.
 - For existing PR checks, cd into workDir before running gh commands: `cd "$workDir" && gh ...`.
 - Delegate CI watching to ci-watch-runner — do not implement watch loop inline.
 - Delegate comment resolution to comment-resolution-runner — do not implement comment loop inline.

--- a/docs/bugs/2026-05-27-pr-body-footer-wrong-attribution.md
+++ b/docs/bugs/2026-05-27-pr-body-footer-wrong-attribution.md
@@ -1,0 +1,36 @@
+# Bug: PR body footer shows wrong attribution
+
+**Date:** 2026-05-27
+**Status:** Fixed
+
+## Symptom
+
+PRs opened by pr-agent never include "Generated with dark factory" in the footer. Instead the body sometimes shows "Generated with [Claude Code](https://claude.com/claude-code)" — the default Claude Code commit attribution — rather than the correct dark factory attribution from the template.
+
+## Root Cause
+
+The pr-agent instructions for Step 1 said:
+
+> Read agents/pr/templates/pr-template.md for structure.
+
+The phrase "for structure" signaled to the Haiku model that the template is a structural reference, not a verbatim scaffold. When writing the PR body from scratch, the Haiku model fell back on its training-data knowledge of the standard Claude Code attribution footer instead of copying the footer from the template.
+
+The template (`agents/pr/templates/pr-template.md`) has the correct footer:
+
+```
+🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
+```
+
+But since the instruction didn't mandate verbatim copying of that line, the model substituted its own version.
+
+## Fix
+
+Updated `agents/pr/agents/pr-agent.md` in two places:
+
+1. **Step 1 orchestration block** — changed "Read template for structure" to explicitly embed the required footer and state it must be copied verbatim. Added a negative example ("Generated with [Claude Code](...)" is WRONG) to make the constraint unambiguous.
+
+2. **Rules section** — added a dedicated rule: "The PR body footer MUST always be exactly: `🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)` — never `Generated with [Claude Code]` or any other attribution."
+
+## Files Changed
+
+- `/home/lewibs/github/dark_factory/dark_factory/agents/pr/agents/pr-agent.md`


### PR DESCRIPTION
## Description

**Bug:** PRs opened by pr-agent showed the wrong footer attribution — sometimes "Generated with [Claude Code](https://claude.com/claude-code)" instead of "Generated with [dark factory](https://github.com/lewibs/dark-factory)".

**Root cause:** The pr-agent Step 1 instruction said "Read agents/pr/templates/pr-template.md for structure." The phrase "for structure" signaled to the Haiku model to use the template as a layout guide rather than a verbatim scaffold. When writing the PR body from scratch, Haiku fell back on its training-data knowledge of the standard Claude Code attribution footer instead of copying the footer from the template.

**Fix:** Updated `agents/pr/agents/pr-agent.md` in two places:
1. Step 1 orchestration block — changed the template instruction to mandate verbatim footer copying and added an explicit negative example ("Generated with [Claude Code](...)" is WRONG).
2. Rules section — added a dedicated rule that the footer must always be exactly `🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)`.

**Files changed:**
- `agents/pr/agents/pr-agent.md` — enforce verbatim dark factory footer
- `docs/bugs/2026-05-27-pr-body-footer-wrong-attribution.md` — bug audit log

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
