### PR TITLE
fix(pr-agent,debug-command-agent): ground PR body in plan/bug file when available

### DIFF
--- a/agents/dark-factory/agents/debug-command-agent.md
+++ b/agents/dark-factory/agents/debug-command-agent.md
@@ -37,8 +37,12 @@ debug-command-agent(taskDescription, taskName):
     report error: result.message
     STOP
 
-  # Step 3 — planFilePath is null for debugger route (no plan file generated)
-  planFilePath = null
+  # Step 3 — recover bug file path from brain-patch.json written by debugger-agent
+  # debugger-agent writes: { "bugFiles": ["<absolute path>"], "notes": [...] }
+  WORK_DIR = bash("git rev-parse --show-toplevel")
+  planFilePath = bash("jq -r '.bugFiles[0] // empty' \"$WORK_DIR/brain-patch.json\" 2>/dev/null || echo ''")
+  if planFilePath is empty: planFilePath = null
+  # planFilePath is now the absolute path to the bug audit log, or null if agent did not write one
 
   # Step 4 — code review
   invoke code-review-orchestrator-agent({

--- a/agents/pr/agents/pr-agent.md
+++ b/agents/pr/agents/pr-agent.md
@@ -34,7 +34,9 @@ pr-agent(planFilePath or taskDescription, workDir):
 
   # Step 1 — Build PR body
   Read agents/pr/templates/pr-template.md — use it as the exact scaffold.
-  Populate Description from planFilePath (or taskDescription string).
+  Populate Description:
+    - If planFilePath is a valid file path: READ the file and paste its full contents verbatim into the Description section. Do not summarise or paraphrase. The comment in the template says "Do not summarise" — honour it.
+    - If planFilePath is a plain string (not a file path) or null: use the string (or taskDescription) as the description text.
   Run tests if a test suite exists; include output in Test Plan, or omit section if none.
   The footer line MUST be copied verbatim from the template:
     🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)

--- a/docs/docs/debug-command-agent.md
+++ b/docs/docs/debug-command-agent.md
@@ -12,7 +12,8 @@ flowchart TD
 
   DCA --> DA["debugger-agent<br/>(taskDescription)"]
 
-  DA -->|"success"| CRO["code-review-orchestrator-agent"]
+  DA -->|"brain-patch.json: bugFiles[0]"| BPR["read brain-patch.json<br/>(jq .bugFiles[0])"]
+  BPR --> CRO["code-review-orchestrator-agent"]
 
   CRO --> UDA["update-documentation-agent"]
   UDA --> SUA["skill-update-agent<br/>(non-fatal)"]

--- a/docs/docs/pr-agent.md
+++ b/docs/docs/pr-agent.md
@@ -34,8 +34,8 @@ The PR lifecycle is fully automated except for the final merge decision, enablin
 
 1. **Reads PR template** from `agents/pr/templates/pr-template.md` for structure
 2. **Populates Description section**:
-   - If planFilePath provided: extracts summary from plan
-   - If taskDescription provided: uses description directly
+   - If planFilePath is a valid file path: reads the file and pastes its full contents verbatim — no summarisation
+   - If planFilePath is a plain string or null: uses the string (or taskDescription) directly as description text
    - If neither: builds from git diff
 3. **Runs tests** (if test suite exists):
    - Detects test runner (pytest, npm test, go test, etc.)


### PR DESCRIPTION
## Summary

- `debug-command-agent`: read `brain-patch.json` after `debugger-agent` completes to extract the bug audit log path into `planFilePath` (was hardcoded `null`)
- `pr-agent`: explicit instruction to READ the file at `planFilePath` and paste its contents verbatim when a valid path is passed, rather than summarising from the task description string

## Root cause

Two compounding bugs caused pr-agent to always generate generic PR descriptions:

1. `debug-command-agent` hardcoded `planFilePath = null` — the bug audit log path written by `debugger-agent` into `brain-patch.json` was never read back
2. `pr-agent` instructions were ambiguous about whether to read and embed the file vs. use it as a summary hint

🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)