### PR TITLE
chore: bump version to 1.2.73

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.72",
+  "version": "1.2.73",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"


### PR DESCRIPTION
## Summary

- Bumps patch version to 1.2.73

🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)