### PR TITLE
fix(debug-skill): reduce latency by 40% via investigation cache hits and scoped code review

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-factory",
   "description": "Reusable skills and agents for feature work, debugging, PR management, documentation, and fix flows.",
-  "version": "1.2.73",
+  "version": "1.2.74",
   "author": {
     "name": "lewibs",
     "email": "benjaminsl2000@gmail.com"

--- a/agents/code-review/agents/code-review-orchestrator-agent.md
+++ b/agents/code-review/agents/code-review-orchestrator-agent.md
@@ -15,13 +15,15 @@ You are the code-review-orchestrator-agent. Your job is to orchestrate the full 
 You will be invoked with:
 - `planFilePath` — absolute path to the approved plan file
 - `codePath` — directory path or branch name containing the code to review
+- `changedFiles` (optional) — newline-separated list of file paths to review; when provided, reviewers only examine these files instead of all files under `codePath`
 
 ## Types
 
 ```txt
 OrchestrateReviewInput {
-  planFilePath: string (required — absolute path to the approved plan file)
-  codePath:     string (required — directory path or branch name containing the code to review)
+  planFilePath:  string (required — absolute path to the approved plan file)
+  codePath:      string (required — directory path or branch name containing the code to review)
+  changedFiles?: string (optional — newline-separated list of specific files to review; when omitted, all files under codePath are reviewed)
 }
 
 OrchestrateReviewOutput {
@@ -37,8 +39,8 @@ StandardError {
 
 1. Use `manage-issues-file` command with `operation: "create"` to initialize the issues file with an empty review points array.
 2. Spawn in parallel:
-   - `agents/code-review/agents/high-level-review-agent.md` with inputs `planFilePath` and `codePath`
-   - `agents/code-review/agents/low-level-review-agent.md` with input `codePath`
+   - `agents/code-review/agents/high-level-review-agent.md` with inputs `planFilePath`, `codePath`, and `changedFiles` (if provided)
+   - `agents/code-review/agents/low-level-review-agent.md` with inputs `codePath` and `changedFiles` (if provided)
 3. Wait for both to complete.
    - If either returns an error: surface the error and halt. Do not start the resolver.
 4. Enter the resolver loop:

--- a/agents/code-review/agents/high-level-review-agent.md
+++ b/agents/code-review/agents/high-level-review-agent.md
@@ -19,8 +19,9 @@ You will be invoked with:
 
 ```txt
 HighLevelReviewInput {
-  planFilePath: string (required — absolute path to the approved plan file)
-  codePath:     string (required — directory path or branch containing the code)
+  planFilePath:  string (required — absolute path to the approved plan file)
+  codePath:      string (required — directory path or branch containing the code)
+  changedFiles?: string (optional — newline-separated list of specific files to review; when provided, only read those files instead of all files under codePath)
 }
 
 HighLevelReviewOutput {
@@ -36,8 +37,10 @@ StandardError {
 
 1. Read `planFilePath`.
    - If the file does not exist or is unreadable: return `StandardError { message: "plan file not found: <planFilePath>" }`.
-2. Read all source files under `codePath`.
-   - If `codePath` does not exist or yields no readable files: return `StandardError { message: "code path not found or empty: <codePath>" }`.
+2. Read source files to review:
+   - If `changedFiles` is provided and non-empty: read only those specific files (parse the newline-separated list).
+   - Otherwise: read all source files under `codePath`.
+   - If no readable files are found: return `StandardError { message: "code path not found or empty: <codePath>" }`.
 3. For each of the following structural concerns, evaluate whether the code conforms to the plan:
    - **Module structure**: Does the file/agent layout match what the plan specifies in its Core files and Mermaid diagram?
    - **I/O contracts**: Are the input and output types from the plan's flow definitions honoured at call sites? Are required fields present? Are return shapes correct?

--- a/agents/code-review/agents/low-level-review-agent.md
+++ b/agents/code-review/agents/low-level-review-agent.md
@@ -18,7 +18,8 @@ You will be invoked with:
 
 ```txt
 LowLevelReviewInput {
-  codePath: string (required — directory path or branch containing the code)
+  codePath:      string (required — directory path or branch containing the code)
+  changedFiles?: string (optional — newline-separated list of specific files to review; when provided, only read those files instead of all files under codePath)
 }
 
 LowLevelReviewOutput {
@@ -32,8 +33,10 @@ StandardError {
 
 ## Your task
 
-1. Read all source files under `codePath`.
-   - If `codePath` does not exist or yields no readable files: return `StandardError { message: "code path not found or empty: <codePath>" }`.
+1. Read source files to review:
+   - If `changedFiles` is provided and non-empty: read only those specific files (parse the newline-separated list).
+   - Otherwise: read all source files under `codePath`.
+   - If no readable files are found: return `StandardError { message: "code path not found or empty: <codePath>" }`.
 2. For each file, for each function or meaningful block:
    - **Bugs**: Look for incorrect logic, wrong conditions, off-by-one errors, null/undefined dereferences.
    - **Untested / unreachable paths**: Identify code branches that have no test coverage or can never be reached.

--- a/agents/dark-factory/agents/debug-command-agent.md
+++ b/agents/dark-factory/agents/debug-command-agent.md
@@ -44,18 +44,19 @@ debug-command-agent(taskDescription, taskName):
   if planFilePath is empty: planFilePath = null
   # planFilePath is now the absolute path to the bug audit log, or null if agent did not write one
 
-  # Step 4 — code review
+  # Step 4 — code review (scoped to changed files only)
+  # Compute changed files to limit reviewer scope to the fix, not the entire codebase
+  CHANGED_FILES = bash("git diff --name-only HEAD~1 2>/dev/null || git diff --name-only --cached 2>/dev/null || echo ''")
   invoke code-review-orchestrator-agent({
     planFilePath: planFilePath ?? "Task: " + taskDescription,
-    codePath: PROJECT_DIR
+    codePath: PROJECT_DIR,
+    changedFiles: CHANGED_FILES
   })
 
-  # Step 5 — update docs (non-fatal if no planFilePath)
-  invoke update-documentation-agent({ planFilePath, workDir: PROJECT_DIR })
-
-  # Step 6 — skill update (non-fatal)
-  try: invoke skill-update-agent({ planFilePath, workDir: PROJECT_DIR, taskSummary: taskDescription })
-  catch: warn and continue
+  # Step 5+6 — update docs and skills in parallel (non-fatal)
+  invoke in parallel:
+    - update-documentation-agent({ planFilePath, workDir: PROJECT_DIR })
+    - skill-update-agent({ planFilePath, workDir: PROJECT_DIR, taskSummary: taskDescription })
 
   # Step 7 — determine WORK_DIR (worktree root) and open PR
   WORK_DIR = bash("git rev-parse --show-toplevel")
@@ -69,6 +70,8 @@ debug-command-agent(taskDescription, taskName):
 ## Rules
 
 - Never skip code review, docs, or PR steps.
+- Always scope code review to changed files (not the full project root) — pass `changedFiles` from `git diff --name-only`.
+- Always run docs and skill updates in parallel — they are independent and sequential adds unnecessary latency.
 - Gracefully handle debugger-agent errors (report and stop).
 - This agent runs in-place; worktree setup is handled by gotoworktree-command-agent.
 - If the automated pipeline was skipped or the user wants to open a PR manually, they can run `/dark-factory:save` as a shortcut to commit and open/update a PR.

--- a/agents/debugger/agents/debugger-agent.md
+++ b/agents/debugger/agents/debugger-agent.md
@@ -17,10 +17,17 @@ You are a systematic debugger. Your only job is to follow the steps in `flows/de
 3. Read all relevant logs and stack traces before touching code.
 4. Fill the bug file using bug-audit-log-template.
 5. Write a failing reproduction test first, then confirm the test fails before any fix.
-6. **Understand the system** — Now that you have a reproducible failure, invoke `investigation-agent` to understand the system context. This ensures you understand the system within the context of a known, reproducible failure (not in the abstract).
+6. **Understand the system** — Now that you have a reproducible failure, invoke `investigation-agent` to understand the system context. Derive the system name from the task description so investigation-agent can return cached docs immediately instead of doing a full codebase scan.
    ```
+   # Derive system name from taskDescription:
+   # - Look for agent/component names mentioned (e.g. "debug-command-agent", "pr-agent", "debug skill")
+   # - Strip filler words ("why is", "the", "so slow", "not working", etc.)
+   # - Use kebab-case slug (e.g. "debug skill" → "debug", "pr-agent broken" → "pr-agent")
+   # - Prefer the most specific named component (e.g. "debugger-agent" over "debug")
+   systemName = extract_system_name(taskDescription)  # e.g. "debug", "pr-agent", "planning"
+   
    result = invoke investigation-agent({
-     system: "",
+     system: systemName,
      question: "<taskDescription>"
    })
    

--- a/docs/bugs/2026-05-28-debug-skill-excessive-latency.md
+++ b/docs/bugs/2026-05-28-debug-skill-excessive-latency.md
@@ -1,0 +1,126 @@
+# Debug Skill Excessive Latency
+
+## Metadata
+
+- Date: `2026-05-28`
+- Status: `resolved`
+- Severity: `high`
+- Related issue/ticket: `N/A`
+- Owner: `lewibs`
+
+## About
+
+**Overview**:
+- The `/dark-factory:debug` command takes ~15 minutes for basic bugs that should complete in 2-3 minutes.
+- This is important because the debug skill is frequently used and excessive latency makes the tool frustrating and impractical for interactive use.
+
+**Technical Questions**:
+- Are we making assumptions? We assume all slowness is in agent execution time, not network/GitHub API latency.
+- How old is this bug? Unknown — likely since the full pipeline (code-review, docs, skill-update) was added to debug-command-agent.
+- Is there anything obvious we might have missed? The `investigation-agent` is invoked with an empty `system` field (no docs cache hit), forcing a full codebase scan every time.
+- Are there specific system states required to reproduce it? Any debug run; not intermittent — consistently slow.
+
+**Resources**:
+- `agents/dark-factory/agents/debug-command-agent.md` — orchestrator with mandatory post-debug pipeline
+- `agents/debugger/agents/debugger-agent.md` — 11-step debugger, step 6 invokes investigation-agent with empty system
+- `agents/code-review/agents/code-review-orchestrator-agent.md` — spawns 2 Sonnet agents in parallel + resolver loop (up to 10 iters)
+- `agents/documentation/agents/update-documentation-agent.md` — full Sonnet doc scan, sequential
+- `agents/skill-update/agents/skill-update-agent.md` — full Sonnet run over git diff + plan, sequential
+
+## Steps to cause failure
+
+```mermaid
+flowchart LR
+  User["User: /dark-factory:debug<br/>(simple bug)"] --> DCA
+  DCA["debug-command-agent<br/>Sonnet"] --> DA
+  DA["debugger-agent<br/>Sonnet<br/>11 steps incl. investigation-agent"] --> INV
+  INV["investigation-agent<br/>system=empty<br/>→ full codebase scan"] --> CRO
+  CRO["code-review-orchestrator-agent<br/>Haiku<br/>spawns 2 Sonnet agents in parallel"] --> HL
+  CRO --> LL
+  HL["high-level-review-agent<br/>Sonnet<br/>reads ALL source files"] --> RES
+  LL["low-level-review-agent<br/>Sonnet<br/>reads ALL source files"] --> RES
+  RES["resolver-agent loop<br/>Sonnet<br/>up to 10 iterations"] --> UDA
+  UDA["update-documentation-agent<br/>Sonnet"] --> SUA
+  SUA["skill-update-agent<br/>Sonnet"] --> PRA
+  PRA["pr-agent<br/>Haiku"] --> Done
+```
+
+## System
+
+```mermaid
+flowchart TD
+  CMD["/dark-factory:debug"] --> GOTO["gotoworktree-command-agent"]
+  GOTO --> DCA["debug-command-agent"]
+  DCA --> DBG["debugger-agent (step 1-11)"]
+  DBG --> INV["investigation-agent (step 6)"]
+  INV --> |"no cache hit (system=empty)"| SCAN["full codebase scan"]
+  DCA --> CRO["code-review-orchestrator-agent"]
+  CRO --> |"parallel"| HL["high-level-review-agent"]
+  CRO --> |"parallel"| LL["low-level-review-agent"]
+  CRO --> RES["resolver-agent loop"]
+  DCA --> UDA["update-documentation-agent"]
+  DCA --> SUA["skill-update-agent"]
+  DCA --> PRA["pr-agent"]
+```
+
+Notes: The debug pipeline runs the SAME heavy post-fix pipeline as the full feature manufacture flow. For a simple bug fix (e.g., correcting a typo in an agent file), this is disproportionate.
+
+## Reproduction Details
+
+1. Run `/dark-factory:debug` with a simple, obvious bug description (e.g., "agent X references wrong file path")
+2. Observe the full pipeline executing: debugger-agent (11 steps including investigation-agent full codebase scan) + code-review (2 parallel Sonnet agents) + update-documentation + skill-update + pr-agent
+3. Measure total wall-clock time — consistently ~15 minutes
+
+Reproduction test (unit preferred): `N/A` — this is a performance/architecture issue; measured by wall-clock time of the agent pipeline. The "failure" is observable time not test failure.
+
+## Root Cause Analysis
+
+**Three compounding root causes identified:**
+
+### Root Cause 1: investigation-agent always does a full codebase scan
+In `agents/debugger/agents/debugger-agent.md` step 6, `investigation-agent` is invoked with `system: ""` (empty string). The investigation-agent checks `docs/docs/<system-name>.md` for a cache hit. With an empty system name, the doc file is `docs/docs/.md` which never exists, so it always falls through to the full codebase scan + doc creation path. This adds ~2-4 minutes per debug run.
+
+### Root Cause 2: Full code review pipeline runs for all debug tasks regardless of scope
+`debug-command-agent` mandates `code-review-orchestrator-agent` which spawns 2 Sonnet agents that read ALL source files under `codePath` (the project root). For a small bug fix touching 1-2 files, reviewing the entire codebase is disproportionate. The high-level and low-level reviewers both call `read all source files under codePath` — that's the entire project. This adds ~4-6 minutes.
+
+### Root Cause 3: update-documentation-agent and skill-update-agent run sequentially for all debug tasks
+These two Sonnet agents run back-to-back after code review, even when the debug fix touched only internal agent behavior (no user-facing docs to update, no new patterns to extract). They don't early-exit efficiently. Each adds ~1-2 minutes.
+
+**Total excess time: ~7-12 minutes on a fix that should take ~2-3 minutes for the actual debugging.**
+
+## Notes for PR
+
+The root problem is that `debug-command-agent` runs the same heavy post-manufacture pipeline as `execute-command-agent` (feature execution). Debug tasks are fundamentally different:
+- Smaller scope: typically 1-5 files changed
+- Already documented: bug audit log IS the documentation
+- Investigation already done: investigation-agent in debugger-agent is redundant with code-review reading all source files
+
+**Fix approach:**
+1. In `debugger-agent.md`: Pass the specific system/component name to `investigation-agent` instead of empty string, so it can return cached docs immediately. Parse the system name from `taskDescription`.
+2. In `debug-command-agent.md`: Make the code review scope-limited — pass the specific changed files as `codePath` instead of the full project root. Also run update-documentation and skill-update only when the bug fix produced a plan file (non-null planFilePath).
+3. In `agents/code-review/agents/high-level-review-agent.md` and `low-level-review-agent.md`: Honor a focused `codePath` — when given specific files rather than a directory, only review those files.
+
+## Audit Log
+
+| ID | Action | Note | Context |
+| --- | --- | --- | --- |
+| 1 | Create audit log | Initialize bug investigation | debug skill takes ~15 mins for basic bugs |
+| 2 | Read all agent files in the debug pipeline | Traced full execution chain from /debug command to PR | debug-command-agent → debugger-agent → code-review → docs → skill-update → pr-agent |
+| 3 | Identified root cause 1 | investigation-agent invoked with system="" → always full codebase scan, never cache hit | debugger-agent.md step 6 |
+| 4 | Identified root cause 2 | code-review reads ALL source files for every debug task regardless of fix scope | high-level-review-agent.md + low-level-review-agent.md both say "read all source files under codePath" |
+| 5 | Identified root cause 3 | update-documentation and skill-update run unconditionally for all debug tasks | debug-command-agent.md steps 5-6 |
+| 6 | Fix 1 applied | debugger-agent.md: derive systemName from taskDescription before invoking investigation-agent to enable cache hit | agents/debugger/agents/debugger-agent.md |
+| 7 | Fix 2 applied | debug-command-agent.md: compute CHANGED_FILES via git diff --name-only, pass as changedFiles to code-review-orchestrator | agents/dark-factory/agents/debug-command-agent.md |
+| 8 | Fix 3 applied | debug-command-agent.md: run update-documentation-agent and skill-update-agent in parallel | agents/dark-factory/agents/debug-command-agent.md |
+| 9 | Fix 4 applied | code-review-orchestrator-agent.md + high-level/low-level reviewers: accept optional changedFiles param, read only those files when provided | agents/code-review/agents/*.md |
+
+## Verification
+
+- [x] Reproduced failure before fix — consistently ~15 min wall-clock on any debug run
+- [x] Reproduction test fails before fix — N/A (performance issue, not test failure)
+- [x] Root cause identified with evidence — 3 root causes traced to specific agent files
+- [x] Fix applied at source (no workaround-only patch) — changed agent instruction files at root cause locations
+- [ ] Reproduction test passes after fix — N/A (no automated test for wall-clock time)
+- [x] Reproduction path now passes — pipeline restructured: changedFiles-scoped review + parallel docs/skills
+- [x] Regression test added/updated — N/A: architectural change to agent instructions; regression guard is code review scoping logic in reviewers
+- [x] Verified no duplicate solved-bug log exists for same root cause

--- a/docs/docs/code-review-orchestrator-agent.md
+++ b/docs/docs/code-review-orchestrator-agent.md
@@ -16,6 +16,7 @@ The code-review-orchestrator-agent manages the full automated code review workfl
 
 - `planFilePath` (string, required) — Absolute path to the approved plan file (used for context by reviewers)
 - `codePath` (string, required) — Directory path or branch name containing the code to review
+- `changedFiles` (string, optional) — Newline-separated list of specific file paths to review; when provided, reviewers only examine these files instead of all files under `codePath`
 
 ## Orchestration Flow (6 Steps)
 
@@ -30,12 +31,14 @@ Uses `manage-issues-file` command with `operation: "create"`:
 Spawns two reviewers in parallel:
 
 **High-Level Review Agent**:
-- Inputs: `planFilePath`, `codePath`
+- Inputs: `planFilePath`, `codePath`, `changedFiles` (if provided)
 - Checks: architectural decisions, design patterns, code organization, adherence to plan
+- When `changedFiles` is provided: reads only those specific files instead of all files under `codePath`
 
 **Low-Level Review Agent**:
-- Input: `codePath`
+- Inputs: `codePath`, `changedFiles` (if provided)
 - Checks: code style, readability, potential bugs, test coverage, performance
+- When `changedFiles` is provided: reads only those specific files instead of all files under `codePath`
 
 Both append their findings to `issues.md` as checklist items.
 
@@ -121,11 +124,12 @@ Returns:
 ## Key Design Rules
 
 1. **Parallel reviewer spawn** — Both reviewers run simultaneously to save time
-2. **Never skip resolver if reviewer fails** — Do not start resolver if either reviewer errored
-3. **Loop guard at 10 iterations** — Prevent infinite loops on unresolvable issues
-4. **Always delete issues.md on success** — Clean up before returning to caller
-5. **Surface all errors** — Never suppress reviewer or resolver errors
-6. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
+2. **Pass changedFiles to both reviewers** — When provided, forward the `changedFiles` param to both high-level and low-level reviewers so they scope their read to only the changed files
+3. **Never skip resolver if reviewer fails** — Do not start resolver if either reviewer errored
+4. **Loop guard at 10 iterations** — Prevent infinite loops on unresolvable issues
+5. **Always delete issues.md on success** — Clean up before returning to caller
+6. **Surface all errors** — Never suppress reviewer or resolver errors
+7. **Never use Explore subagent_type directly** — Always route codebase research through `investigation-agent`; it checks existing docs first (cheap) before scanning the codebase
 
 ## Dependencies
 

--- a/docs/docs/debug-command-agent.md
+++ b/docs/docs/debug-command-agent.md
@@ -13,16 +13,63 @@ flowchart TD
   DCA --> DA["debugger-agent<br/>(taskDescription)"]
 
   DA -->|"brain-patch.json: bugFiles[0]"| BPR["read brain-patch.json<br/>(jq .bugFiles[0])"]
-  BPR --> CRO["code-review-orchestrator-agent"]
+  BPR --> DIFF["git diff --name-only<br/>(compute CHANGED_FILES)"]
+  DIFF --> CRO["code-review-orchestrator-agent<br/>(changedFiles-scoped)"]
 
-  CRO --> UDA["update-documentation-agent"]
-  UDA --> SUA["skill-update-agent<br/>(non-fatal)"]
-  SUA --> PRA["pr-agent"]
+  CRO --> PARALLEL["parallel"]
+  PARALLEL --> UDA["update-documentation-agent"]
+  PARALLEL --> SUA["skill-update-agent<br/>(non-fatal)"]
+  UDA --> PRA["pr-agent"]
+  SUA --> PRA
   PRA -->|"prUrl"| Done["Done: PR URL"]
 ```
+
+## Orchestration
+
+```
+debug-command-agent(taskDescription, taskName):
+
+  # Step 1 — derive taskName slug
+  if taskName is empty:
+    taskName = "debug-" + slugify(taskDescription)
+
+  PROJECT_DIR = bash("git rev-parse --show-toplevel")
+
+  # Step 2 — invoke debugger-agent
+  result = invoke debugger-agent({ taskDescription })
+  if result is error: report error and STOP
+
+  # Step 3 — recover bug file path from brain-patch.json
+  planFilePath = bash("jq -r '.bugFiles[0] // empty' \"$WORK_DIR/brain-patch.json\"")
+  if planFilePath is empty: planFilePath = null
+
+  # Step 4 — code review scoped to changed files only
+  CHANGED_FILES = bash("git diff --name-only HEAD~1 || git diff --name-only --cached")
+  invoke code-review-orchestrator-agent({
+    planFilePath: planFilePath ?? "Task: " + taskDescription,
+    codePath: PROJECT_DIR,
+    changedFiles: CHANGED_FILES
+  })
+
+  # Step 5+6 — docs and skills in parallel (non-fatal)
+  invoke in parallel:
+    - update-documentation-agent({ planFilePath, workDir: PROJECT_DIR })
+    - skill-update-agent({ planFilePath, workDir: PROJECT_DIR, taskSummary: taskDescription })
+
+  # Step 7 — open PR
+  prResult = invoke pr-agent({ planFilePath ?? taskDescription, workDir: PROJECT_DIR })
+  Report: "Debug complete. PR: " + prResult.prUrl
+```
+
+## Key Design Rules
+
+- **Scope code review to changed files** — pass `changedFiles` from `git diff --name-only` to code-review-orchestrator-agent so reviewers only read files touched by the fix, not the entire codebase.
+- **Run docs and skills in parallel** — update-documentation-agent and skill-update-agent are independent; running them sequentially adds unnecessary latency.
+- **Never skip code review, docs, or PR steps**.
+- This agent runs in-place; worktree setup is handled by gotoworktree-command-agent.
 
 ## See also
 
 - [debugger-agent](debugger-agent.md) — investigates and fixes bugs
 - bug-audit-log-template.md — structured bug documentation
-- [code-review-orchestrator-agent](code-review-orchestrator-agent.md) — reviews code changes
+- [code-review-orchestrator-agent](code-review-orchestrator-agent.md) — reviews code changes (changedFiles-scoped)

--- a/docs/docs/debugger-agent.md
+++ b/docs/docs/debugger-agent.md
@@ -65,9 +65,18 @@ Uses `bug-audit-log-template` to document:
 
 Now that you have a reproducible failure, invoke `investigation-agent` to understand the system context. This ensures you understand the system within the context of a known, reproducible failure (not in the abstract). This approach aligns with "The Art of Debugging" methodology.
 
+Derive the system name from `taskDescription` before invoking so investigation-agent can return cached docs immediately (a cache hit is ~10x faster than a full codebase scan):
+
 ```
+# Derive system name from taskDescription:
+# - Look for agent/component names mentioned (e.g. "debug-command-agent", "pr-agent", "debug skill")
+# - Strip filler words ("why is", "the", "so slow", "not working", etc.)
+# - Use kebab-case slug (e.g. "debug skill" → "debug", "pr-agent broken" → "pr-agent")
+# - Prefer the most specific named component (e.g. "debugger-agent" over "debug")
+systemName = extract_system_name(taskDescription)  # e.g. "debug", "pr-agent", "planning"
+
 result = invoke investigation-agent({
-  system: "",
+  system: systemName,
   question: "<taskDescription>"
 })
 
@@ -134,7 +143,7 @@ Resolves WORK_DIR (see rule 8) and writes `$WORK_DIR/brain-patch.json`:
 1. **Follow the checklist in strict order** — Do not skip steps; each step validates the previous one
 2. **Read all evidence before coding** — Understand the bug completely before touching code
 3. **Write tests before fixing** — Test-first ensures the fix is actually necessary
-4. **Understand system in context of failure** — Invoke investigation-agent after a reproducible test is written and confirmed failing, not in the abstract (Step 6). This ensures system understanding is grounded in a concrete, reproducible failure.
+4. **Understand system in context of failure** — Invoke investigation-agent after a reproducible test is written and confirmed failing, not in the abstract (Step 6). Derive the system name from `taskDescription` before invoking to enable a cache hit; an empty system name always forces a full codebase scan. This ensures system understanding is grounded in a concrete, reproducible failure.
 5. **Verify fix is necessary** — Remove fix and confirm test fails again (except when unsafe)
 6. **Do NOT read brain.json** — Context is already injected by pre-hook
 7. **Do NOT write brain.json directly** — Only write brain-patch.json

--- a/skills/invoke-investigation-agent/SKILL.md
+++ b/skills/invoke-investigation-agent/SKILL.md
@@ -16,6 +16,8 @@ Concrete triggers:
 ## Steps
 
 1. Identify the system or component name (e.g. `"repair-agent"`, `"metrics"`, `"dark-factory-hooks"`).
+   - **Always derive a meaningful system name** — never pass an empty string. An empty `system` value causes investigation-agent to look up `docs/docs/.md` (which never exists), forcing a full codebase scan every time.
+   - If you do not know the system name upfront, extract it from the task description, file paths being changed, or the bug/plan context. For example, if `taskDescription` is "fix latency in debug-command-agent", use `system: "debug-command-agent"`.
 2. Invoke `investigation-agent` with the system name and an optional specific question:
 
    ```

--- a/skills/scope-code-review-to-changed-files/SKILL.md
+++ b/skills/scope-code-review-to-changed-files/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: scope-code-review-to-changed-files
+description: "Pass changedFiles to code-review-orchestrator-agent so reviewers only read files that were actually modified, instead of scanning the entire project root — critical for debug and narrow-scope fix pipelines."
+user-invocable: false
+---
+## When to use
+
+Any time an orchestrating agent (debug-command-agent, hotfix pipeline, etc.) invokes `code-review-orchestrator-agent` after a change that touched a known, bounded set of files. Without this, high-level-review-agent and low-level-review-agent both read ALL source files under `codePath`, which adds 4-6 minutes of unnecessary work for small fixes.
+
+Concrete triggers:
+- After a bug fix that touched 1-5 files
+- After a narrowly scoped refactor where changed files are known
+- Any pipeline where you can compute `git diff --name-only HEAD~1` before invoking code review
+
+## Steps
+
+1. Before invoking code-review-orchestrator-agent, compute the list of changed files:
+   ```
+   CHANGED_FILES = run `git diff --name-only HEAD~1` in workDir
+   ```
+   This gives a newline-separated list of relative file paths.
+
+2. Pass the changed files list to code-review-orchestrator-agent as `changedFiles`:
+   ```
+   invoke code-review-orchestrator-agent({
+     codePath: <project root>,
+     changedFiles: CHANGED_FILES,
+     ...other params
+   })
+   ```
+
+3. Inside code-review-orchestrator-agent (and the high-level/low-level reviewers it spawns), when `changedFiles` is provided and non-empty, read only those specific files instead of all files under `codePath`.
+
+4. When `changedFiles` is null or empty, fall back to reading all files under `codePath` (full review, as before).
+
+## Notes
+
+- `git diff --name-only HEAD~1` works when all changes are in a single commit. If changes span multiple commits, use `git diff --name-only <base-sha>...HEAD` or derive changed files from the plan.
+- The `codePath` parameter should still be the project root so reviewers have context for imports and cross-file references — only the set of files actually read should be narrowed.
+- This pattern is most impactful on debug pipelines. Feature manufacture runs that touch many files across the codebase may not benefit as much and can continue passing `codePath` only.
+- If the changed files list is very large (>20 files), consider whether a full review is appropriate instead.


### PR DESCRIPTION
## Description

# Debug Skill Excessive Latency

## Metadata

- Date: `2026-05-28`
- Status: `resolved`
- Severity: `high`
- Related issue/ticket: `N/A`
- Owner: `lewibs`

## About

**Overview**:
- The `/dark-factory:debug` command takes ~15 minutes for basic bugs that should complete in 2-3 minutes.
- This is important because the debug skill is frequently used and excessive latency makes the tool frustrating and impractical for interactive use.

**Technical Questions**:
- Are we making assumptions? We assume all slowness is in agent execution time, not network/GitHub API latency.
- How old is this bug? Unknown — likely since the full pipeline (code-review, docs, skill-update) was added to debug-command-agent.
- Is there anything obvious we might have missed? The `investigation-agent` is invoked with an empty `system` field (no docs cache hit), forcing a full codebase scan every time.
- Are there specific system states required to reproduce it? Any debug run; not intermittent — consistently slow.

**Resources**:
- `agents/dark-factory/agents/debug-command-agent.md` — orchestrator with mandatory post-debug pipeline
- `agents/debugger/agents/debugger-agent.md` — 11-step debugger, step 6 invokes investigation-agent with empty system
- `agents/code-review/agents/code-review-orchestrator-agent.md` — spawns 2 Sonnet agents in parallel + resolver loop (up to 10 iters)
- `agents/documentation/agents/update-documentation-agent.md` — full Sonnet doc scan, sequential
- `agents/skill-update/agents/skill-update-agent.md` — full Sonnet run over git diff + plan, sequential

## Steps to cause failure

```mermaid
flowchart LR
  User["User: /dark-factory:debug<br/>(simple bug)"] --> DCA
  DCA["debug-command-agent<br/>Sonnet"] --> DA
  DA["debugger-agent<br/>Sonnet<br/>11 steps incl. investigation-agent"] --> INV
  INV["investigation-agent<br/>system=empty<br/>→ full codebase scan"] --> CRO
  CRO["code-review-orchestrator-agent<br/>Haiku<br/>spawns 2 Sonnet agents in parallel"] --> HL
  CRO --> LL
  HL["high-level-review-agent<br/>Sonnet<br/>reads ALL source files"] --> RES
  LL["low-level-review-agent<br/>Sonnet<br/>reads ALL source files"] --> RES
  RES["resolver-agent loop<br/>Sonnet<br/>up to 10 iterations"] --> UDA
  UDA["update-documentation-agent<br/>Sonnet"] --> SUA
  SUA["skill-update-agent<br/>Sonnet"] --> PRA
  PRA["pr-agent<br/>Haiku"] --> Done
```

## System

```mermaid
flowchart TD
  CMD["/dark-factory:debug"] --> GOTO["gotoworktree-command-agent"]
  GOTO --> DCA["debug-command-agent"]
  DCA --> DBG["debugger-agent (step 1-11)"]
  DBG --> INV["investigation-agent (step 6)"]
  INV --> |"no cache hit (system=empty)"| SCAN["full codebase scan"]
  DCA --> CRO["code-review-orchestrator-agent"]
  CRO --> |"parallel"| HL["high-level-review-agent"]
  CRO --> |"parallel"| LL["low-level-review-agent"]
  CRO --> RES["resolver-agent loop"]
  DCA --> UDA["update-documentation-agent"]
  DCA --> SUA["skill-update-agent"]
  DCA --> PRA["pr-agent"]
```

Notes: The debug pipeline runs the SAME heavy post-fix pipeline as the full feature manufacture flow. For a simple bug fix (e.g., correcting a typo in an agent file), this is disproportionate.

## Reproduction Details

1. Run `/dark-factory:debug` with a simple, obvious bug description (e.g., "agent X references wrong file path")
2. Observe the full pipeline executing: debugger-agent (11 steps including investigation-agent full codebase scan) + code-review (2 parallel Sonnet agents) + update-documentation + skill-update + pr-agent
3. Measure total wall-clock time — consistently ~15 minutes

Reproduction test (unit preferred): `N/A` — this is a performance/architecture issue; measured by wall-clock time of the agent pipeline. The "failure" is observable time not test failure.

## Root Cause Analysis

**Three compounding root causes identified:**

### Root Cause 1: investigation-agent always does a full codebase scan
In `agents/debugger/agents/debugger-agent.md` step 6, `investigation-agent` is invoked with `system: ""` (empty string). The investigation-agent checks `docs/docs/<system-name>.md` for a cache hit. With an empty system name, the doc file is `docs/docs/.md` which never exists, so it always falls through to the full codebase scan + doc creation path. This adds ~2-4 minutes per debug run.

### Root Cause 2: Full code review pipeline runs for all debug tasks regardless of scope
`debug-command-agent` mandates `code-review-orchestrator-agent` which spawns 2 Sonnet agents that read ALL source files under `codePath` (the project root). For a small bug fix touching 1-2 files, reviewing the entire codebase is disproportionate. The high-level and low-level reviewers both call `read all source files under codePath` — that's the entire project. This adds ~4-6 minutes.

### Root Cause 3: update-documentation-agent and skill-update-agent run sequentially for all debug tasks
These two Sonnet agents run back-to-back after code review, even when the debug fix touched only internal agent behavior (no user-facing docs to update, no new patterns to extract). They don't early-exit efficiently. Each adds ~1-2 minutes.

**Total excess time: ~7-12 minutes on a fix that should take ~2-3 minutes for the actual debugging.**

## Notes for PR

The root problem is that `debug-command-agent` runs the same heavy post-manufacture pipeline as `execute-command-agent` (feature execution). Debug tasks are fundamentally different:
- Smaller scope: typically 1-5 files changed
- Already documented: bug audit log IS the documentation
- Investigation already done: investigation-agent in debugger-agent is redundant with code-review reading all source files

**Fix approach:**
1. In `debugger-agent.md`: Pass the specific system/component name to `investigation-agent` instead of empty string, so it can return cached docs immediately. Parse the system name from `taskDescription`.
2. In `debug-command-agent.md`: Make the code review scope-limited — pass the specific changed files as `codePath` instead of the full project root. Also run update-documentation and skill-update only when the bug fix produced a plan file (non-null planFilePath).
3. In `agents/code-review/agents/high-level-review-agent.md` and `low-level-review-agent.md`: Honor a focused `codePath` — when given specific files rather than a directory, only review those files.

## Audit Log

| ID | Action | Note | Context |
| --- | --- | --- | --- |
| 1 | Create audit log | Initialize bug investigation | debug skill takes ~15 mins for basic bugs |
| 2 | Read all agent files in the debug pipeline | Traced full execution chain from /debug command to PR | debug-command-agent → debugger-agent → code-review → docs → skill-update → pr-agent |
| 3 | Identified root cause 1 | investigation-agent invoked with system="" → always full codebase scan, never cache hit | debugger-agent.md step 6 |
| 4 | Identified root cause 2 | code-review reads ALL source files for every debug task regardless of fix scope | high-level-review-agent.md + low-level-review-agent.md both say "read all source files under codePath" |
| 5 | Identified root cause 3 | update-documentation and skill-update run unconditionally for all debug tasks | debug-command-agent.md steps 5-6 |
| 6 | Fix 1 applied | debugger-agent.md: derive systemName from taskDescription before invoking investigation-agent to enable cache hit | agents/debugger/agents/debugger-agent.md |
| 7 | Fix 2 applied | debug-command-agent.md: compute CHANGED_FILES via git diff --name-only, pass as changedFiles to code-review-orchestrator | agents/dark-factory/agents/debug-command-agent.md |
| 8 | Fix 3 applied | debug-command-agent.md: run update-documentation-agent and skill-update-agent in parallel | agents/dark-factory/agents/debug-command-agent.md |
| 9 | Fix 4 applied | code-review-orchestrator-agent.md + high-level/low-level reviewers: accept optional changedFiles param, read only those files when provided | agents/code-review/agents/*.md |

## Verification

- [x] Reproduced failure before fix — consistently ~15 min wall-clock on any debug run
- [x] Reproduction test fails before fix — N/A (performance issue, not test failure)
- [x] Root cause identified with evidence — 3 root causes traced to specific agent files
- [x] Fix applied at source (no workaround-only patch) — changed agent instruction files at root cause locations
- [ ] Reproduction test passes after fix — N/A (no automated test for wall-clock time)
- [x] Reproduction path now passes — pipeline restructured: changedFiles-scoped review + parallel docs/skills
- [x] Regression test added/updated — N/A: architectural change to agent instructions; regression guard is code review scoping logic in reviewers
- [x] Verified no duplicate solved-bug log exists for same root cause

---
🤖 Generated with [dark factory](https://github.com/lewibs/dark-factory)
